### PR TITLE
TFP-1507 unngå henlagte behandlinger i klage/anke

### DIFF
--- a/packages/behandling-klage/src/panelDefinisjoner/prosessStegPaneler/FormKravFamOgPensjonProsessStegPanelDef.tsx
+++ b/packages/behandling-klage/src/panelDefinisjoner/prosessStegPaneler/FormKravFamOgPensjonProsessStegPanelDef.tsx
@@ -5,6 +5,7 @@ import FormkravProsessIndex from '@fpsak-frontend/prosess-formkrav';
 import { prosessStegCodes } from '@fpsak-frontend/konstanter';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { ProsessStegDef, ProsessStegPanelDef } from '@fpsak-frontend/behandling-felles';
+import behandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 
 class PanelDef extends ProsessStegPanelDef {
   getKomponent = (props) => <FormkravProsessIndex {...props} />
@@ -16,7 +17,8 @@ class PanelDef extends ProsessStegPanelDef {
   getOverstyrVisningAvKomponent = () => true
 
   getData = ({ alleBehandlinger, klageVurdering }) => ({
-    avsluttedeBehandlinger: alleBehandlinger.filter((b) => b.status.kode === behandlingStatus.AVSLUTTET),
+    avsluttedeBehandlinger: alleBehandlinger.filter((b) => b.status.kode === behandlingStatus.AVSLUTTET)
+      .filter((b) => !b.behandlingHenlagt).filter((b) => b.type.kode !== behandlingType.KLAGE && b.type.kode !== behandlingType.ANKE),
     klageVurdering,
   })
 }

--- a/packages/behandling-klage/src/panelDefinisjoner/prosessStegPaneler/FormKravKlageInstansProsessStegPanelDef.tsx
+++ b/packages/behandling-klage/src/panelDefinisjoner/prosessStegPaneler/FormKravKlageInstansProsessStegPanelDef.tsx
@@ -5,6 +5,7 @@ import FormkravProsessIndex from '@fpsak-frontend/prosess-formkrav';
 import { prosessStegCodes } from '@fpsak-frontend/konstanter';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { ProsessStegDef, ProsessStegPanelDef } from '@fpsak-frontend/behandling-felles';
+import behandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 
 class PanelDef extends ProsessStegPanelDef {
   getKomponent = (props) => <FormkravProsessIndex {...props} />
@@ -16,7 +17,8 @@ class PanelDef extends ProsessStegPanelDef {
   getOverstyrVisningAvKomponent = () => true
 
   getData = ({ alleBehandlinger, klageVurdering }) => ({
-    avsluttedeBehandlinger: alleBehandlinger.filter((b) => b.status.kode === behandlingStatus.AVSLUTTET),
+    avsluttedeBehandlinger: alleBehandlinger.filter((b) => b.status.kode === behandlingStatus.AVSLUTTET)
+      .filter((b) => !b.behandlingHenlagt).filter((b) => b.type.kode !== behandlingType.KLAGE && b.type.kode !== behandlingType.ANKE),
     klageVurdering,
   })
 }

--- a/packages/prosess-anke/src/components/BehandleAnkeForm.jsx
+++ b/packages/prosess-anke/src/components/BehandleAnkeForm.jsx
@@ -110,7 +110,7 @@ const SKAL_REALITETSBEHANDLES = {
   NEI: false,
 };
 
-const filtrerKlage = (behandlinger = []) => behandlinger.filter((b) => b.type.kode === behandlingType.KLAGE);
+const filtrerKlage = (behandlinger = []) => behandlinger.filter((b) => b.type.kode === behandlingType.KLAGE).filter((b) => !b.behandlingHenlagt);
 
 /**
  * Presentasjonskomponent. Setter opp aksjonspunktet for behandling.

--- a/packages/sak-app/src/behandling/BehandlingIndex.tsx
+++ b/packages/sak-app/src/behandling/BehandlingIndex.tsx
@@ -171,6 +171,7 @@ const BehandlingIndex: FunctionComponent<OwnProps> = ({
       status: b.status,
       opprettet: b.opprettet,
       avsluttet: b.avsluttet,
+      behandlingHenlagt: b.behandlingHenlagt,
     }));
 
   if (behandlingTypeKode === BehandlingType.KLAGE) {


### PR DESCRIPTION
Unngå henlagte behandinger / klager i nedtrekksmenyene i Klage/Formkrav og i Anke.
@tor-nav  jeg lurer på om det ikke er like greit å filtrere vekk henlagte i BehandlingIndex.tsx i stedet for å utvide fagsakBehandlingerInfo hva tror du?
Rett og slett en filter !behandlingHenlagt før map ettersom fagsakBehandlingerInfo brukes i klage, anke og tbk .