### PR TITLE
NOJIRA feil i overstyr fakta uttak

### DIFF
--- a/packages/fakta-uttak/src/components/UttakNyPeriode.tsx
+++ b/packages/fakta-uttak/src/components/UttakNyPeriode.tsx
@@ -427,9 +427,9 @@ const transformValues = (
 
   const arbeidsgiver = arbeidsForhold && (arbeidsForhold[0] !== '-' || arbeidsForhold[2] !== '-')
     ? {
-      identifikator: arbeidsForhold[0] !== '-' ? arbeidsForhold[0] : undefined,
+      identifikator: arbeidsForhold[0] !== '-' && arbeidsForhold[3] !== '-' ? arbeidsForhold[0] : undefined,
       navn: arbeidsForhold[1] ? arbeidsForhold[1] : undefined,
-      aktørId: arbeidsForhold[2] !== '-' ? arbeidsForhold[2] : undefined,
+      aktørId: arbeidsForhold[2] !== '-' && arbeidsForhold[3] === '-' ? arbeidsForhold[2] : undefined,
       virksomhet: arbeidsForhold[3] !== '-',
       arbeidType: arbeidsForhold[4],
     }


### PR DESCRIPTION
Overstyring av fakta uttak har gitt JsonMappingFeil i loggene . ArbeidsgiverLagreDto tar "identifikator" og "aktørId" og orgnr er satt i aktørid (tilsvarende vil skje for private). Sjekker på om er virksomhet i transform ...

```
Cannot construct instance of `no.nav.foreldrepenger.domene.typer.AktørId`, problem: Ugyldig aktørId '973149229', tillatt pattern: ^\d{13}$  
>no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.OverstyringFaktaUttakDto$OverstyrerFaktaUttakDto["bekreftedePerioder"]->java.util.ArrayList[1]->no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.BekreftetOppgittPeriodeDto["bekreftetPeriode"]->no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.KontrollerFaktaPeriodeLagreDto["arbeidsgiver"]->no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.ArbeidsgiverLagreDto["aktørId"])
```
Burde kanskje ha gått opp const mapArbeidsforhold ?
