### PR TITLE
TFP-4786 NFP Klagevurdering - skal velge hjemmel

### DIFF
--- a/packages/behandling-klage/src/prosessPaneler/VurderingFellesProsessStegInitPanel.spec.tsx
+++ b/packages/behandling-klage/src/prosessPaneler/VurderingFellesProsessStegInitPanel.spec.tsx
@@ -9,7 +9,7 @@ import { alleKodeverk } from '@fpsak-frontend/storybook-utils';
 import RestApiMock from '@fpsak-frontend/utils-test/src/rest/RestApiMock';
 import { ProsessStegCode } from '@fpsak-frontend/konstanter';
 import { ProsessDefaultInitPanel, ProsessDefaultInitPanelProps, ProsessPanelInitProps } from '@fpsak-frontend/behandling-felles';
-import { Aksjonspunkt, Behandling, Fagsak } from '@fpsak-frontend/types';
+import {Aksjonspunkt, Behandling, Fagsak, KlageVurdering} from '@fpsak-frontend/types';
 import * as Felles from '@fpsak-frontend/behandling-felles/src/utils/prosess/useStandardProsessPanelProps';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import aksjonspunktStatus from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
@@ -20,6 +20,7 @@ import dokumentMalType from '@fpsak-frontend/kodeverk/src/dokumentMalType';
 
 import { KlageBehandlingApiKeys, requestKlageApi } from '../data/klageBehandlingApi';
 import VurderingFellesProsessStegInitPanel from './VurderingFellesProsessStegInitPanel';
+import klageVurderingCodes from "@fpsak-frontend/kodeverk/src/klageVurdering";
 
 type INIT_DATA = {
   aksjonspunkter: Aksjonspunkt[];
@@ -180,9 +181,15 @@ describe('<VurderingFellesProsessStegInitPanel>', () => {
   });
 
   it('skal lagre klage', async () => {
+    const kv = {
+      aktuelleHjemler: [{
+        kode: '14-17',
+        kodeverk: 'KLAGE_HJEMMEL',
+      }],
+    } as KlageVurdering;
     const data = [
       { key: KlageBehandlingApiKeys.AKSJONSPUNKTER.name, data: [] },
-      { key: KlageBehandlingApiKeys.KLAGE_VURDERING.name, data: {} },
+      { key: KlageBehandlingApiKeys.KLAGE_VURDERING.name, data: kv },
       { key: KlageBehandlingApiKeys.SAVE_KLAGE_VURDERING.name, data: undefined },
     ];
 
@@ -206,6 +213,8 @@ describe('<VurderingFellesProsessStegInitPanel>', () => {
 
     userEvent.click(screen.getByText('Oppretthold vedtaket'));
 
+    userEvent.selectOptions(utils.getByLabelText('Hjemmel'), '14-17');
+
     const begrunnelseInput = utils.getByLabelText('Begrunnelse');
     userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
@@ -220,6 +229,9 @@ describe('<VurderingFellesProsessStegInitPanel>', () => {
       begrunnelse: 'Dette er en begrunnelse',
       klageVurderingOmgjoer: null,
       fritekstTilBrev: 'Dette er en fritekst',
+      klageHjemmel: {
+        kode: '14-17',
+      },
       klageMedholdArsak: null,
       klageVurdering: {
         kode: klageVurdering.STADFESTE_YTELSESVEDTAK,

--- a/packages/behandling-klage/src/prosessPaneler/VurderingFellesProsessStegInitPanel.spec.tsx
+++ b/packages/behandling-klage/src/prosessPaneler/VurderingFellesProsessStegInitPanel.spec.tsx
@@ -9,7 +9,9 @@ import { alleKodeverk } from '@fpsak-frontend/storybook-utils';
 import RestApiMock from '@fpsak-frontend/utils-test/src/rest/RestApiMock';
 import { ProsessStegCode } from '@fpsak-frontend/konstanter';
 import { ProsessDefaultInitPanel, ProsessDefaultInitPanelProps, ProsessPanelInitProps } from '@fpsak-frontend/behandling-felles';
-import {Aksjonspunkt, Behandling, Fagsak, KlageVurdering} from '@fpsak-frontend/types';
+import {
+  Aksjonspunkt, AlleKodeverk, Behandling, Fagsak, KlageVurdering,
+} from '@fpsak-frontend/types';
 import * as Felles from '@fpsak-frontend/behandling-felles/src/utils/prosess/useStandardProsessPanelProps';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import aksjonspunktStatus from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
@@ -20,7 +22,6 @@ import dokumentMalType from '@fpsak-frontend/kodeverk/src/dokumentMalType';
 
 import { KlageBehandlingApiKeys, requestKlageApi } from '../data/klageBehandlingApi';
 import VurderingFellesProsessStegInitPanel from './VurderingFellesProsessStegInitPanel';
-import klageVurderingCodes from "@fpsak-frontend/kodeverk/src/klageVurdering";
 
 type INIT_DATA = {
   aksjonspunkter: Aksjonspunkt[];

--- a/packages/kodeverk/src/kodeverkTyper.ts
+++ b/packages/kodeverk/src/kodeverkTyper.ts
@@ -6,6 +6,7 @@ enum KodeverkType {
   BEHANDLING_AARSAK = 'BehandlingÅrsakType',
   KLAGE_AVVIST_AARSAK = 'KlageAvvistÅrsak',
   KLAGE_MEDHOLD_ARSAK = 'KlageMedholdÅrsak',
+  KLAGE_HJEMMEL = 'KlageHjemmel',
   OMSORGSOVERTAKELSE_VILKAR_TYPE = 'OmsorgsovertakelseVilkårType',
   MEDLEMSKAP_MANUELL_VURDERING_TYPE = 'MedlemskapManuellVurderingType',
   VERGE_TYPE = 'VergeType',

--- a/packages/prosess-klagevurdering/i18n/nb_NO.json
+++ b/packages/prosess-klagevurdering/i18n/nb_NO.json
@@ -4,6 +4,7 @@
   "Klage.ResolveKlage.KeepVedtakNk": "Stadfest vedtaket",
   "Klage.ResolveKlage.KeepVedtakNfp": "Oppretthold vedtaket",
   "Klage.ResolveKlage.ChangeVedtak": "Omgjør vedtaket",
+  "Klage.ResolveKlage.Hjemmel": "Hjemmel",
   "Klage.Behandle.Omgjort": "Til gunst",
   "Klage.Behandle.DelvisOmgjort": "Delvis omgjør, til gunst",
   "Klage.Behandle.Hjemsendt": "Hjemsend vedtaket",

--- a/packages/prosess-klagevurdering/src/KlagevurderingProsessIndex.spec.tsx
+++ b/packages/prosess-klagevurdering/src/KlagevurderingProsessIndex.spec.tsx
@@ -25,6 +25,8 @@ describe('<KlagevurderingProsessIndex>', () => {
 
     userEvent.click(screen.getByText('Til gunst'));
 
+    userEvent.selectOptions(utils.getByLabelText('Hjemmel'), '14-17');
+
     const vurderingInput = utils.getByLabelText('Begrunnelse');
     userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
@@ -37,6 +39,9 @@ describe('<KlagevurderingProsessIndex>', () => {
     expect(mellomlagre).toHaveBeenNthCalledWith(1, {
       begrunnelse: 'Dette er en begrunnelse',
       fritekstTilBrev: 'Dette er en fritekst',
+      klageHjemmel: {
+        kode: '14-17',
+      },
       klageMedholdArsak: {
         kode: 'ULIK_VURDERING',
       },
@@ -64,6 +69,9 @@ describe('<KlagevurderingProsessIndex>', () => {
     expect(lagre).toHaveBeenNthCalledWith(1, {
       begrunnelse: 'Dette er en begrunnelse',
       fritekstTilBrev: 'Dette er en fritekst',
+      klageHjemmel: {
+        kode: '14-17',
+      },
       klageMedholdArsak: {
         kode: 'ULIK_VURDERING',
       },

--- a/packages/prosess-klagevurdering/src/KlagevurderingProsessIndex.stories.tsx
+++ b/packages/prosess-klagevurdering/src/KlagevurderingProsessIndex.stories.tsx
@@ -57,6 +57,10 @@ const Template: Story<{
           kodeverk: 'KLAGE_AVVIST_AARSAK',
         }],
       },
+      aktuelleHjemler: [{
+        kode: '14-17',
+        kodeverk: 'KLAGE_HJEMMEL',
+      }],
     } as KlageVurdering}
     saveKlage={mellomlagre}
     previewCallback={forhandsvisCallback}

--- a/packages/prosess-klagevurdering/src/KlagevurderingProsessIndex.tsx
+++ b/packages/prosess-klagevurdering/src/KlagevurderingProsessIndex.tsx
@@ -57,6 +57,7 @@ const KlagevurderingProsessIndex: FunctionComponent<OwnProps & StandardProsessPa
         previewCallback={previewCallback}
         readOnlySubmitButton={readOnlySubmitButton}
         alleKodeverk={alleKodeverk}
+        alleAktuelleHjemler={klageVurdering.aktuelleHjemler ? klageVurdering.aktuelleHjemler : []}
         formData={formData}
         setFormData={setFormData}
       />

--- a/packages/prosess-klagevurdering/src/components/felles/TempsaveKlageButton.tsx
+++ b/packages/prosess-klagevurdering/src/components/felles/TempsaveKlageButton.tsx
@@ -11,6 +11,7 @@ type FormValues = {
   fritekstTilBrev?: string;
   klageMedholdArsak?: Kodeverk;
   klageVurderingOmgjoer?: Kodeverk;
+  klageHjemmel?: Kodeverk;
   begrunnelse?: string;
 };
 
@@ -18,6 +19,7 @@ export type TransformedValues = {
   kode: string;
   klageMedholdArsak?: Kodeverk;
   klageVurderingOmgjoer?: Kodeverk;
+  klageHjemmel?: Kodeverk;
   fritekstTilBrev: string;
   begrunnelse: string;
   klageVurdering: Kodeverk;
@@ -31,6 +33,7 @@ const transformValues = (
   klageMedholdArsak: (values.klageVurdering.kode === klageVurderingType.MEDHOLD_I_KLAGE
     || values.klageVurdering.kode === klageVurderingType.OPPHEVE_YTELSESVEDTAK) ? values.klageMedholdArsak : null,
   klageVurderingOmgjoer: values.klageVurdering.kode === klageVurderingType.MEDHOLD_I_KLAGE ? values.klageVurderingOmgjoer : null,
+  klageHjemmel: values.klageHjemmel,
   fritekstTilBrev: values.fritekstTilBrev,
   begrunnelse: values.begrunnelse,
   klageVurdering: values.klageVurdering,

--- a/packages/prosess-klagevurdering/src/components/nfp/BehandleKlageFormNfp.tsx
+++ b/packages/prosess-klagevurdering/src/components/nfp/BehandleKlageFormNfp.tsx
@@ -24,9 +24,9 @@ import TempsaveKlageButton, { TransformedValues } from '../felles/TempsaveKlageB
 import styles from './behandleKlageFormNfp.less';
 
 const transformValues = (values: FormValues): KlageVurderingResultatAp => ({
-  klageMedholdArsak: (values.klageVurdering.kode === klageVurderingType.MEDHOLD_I_KLAGE
-    || values.klageVurdering.kode === klageVurderingType.OPPHEVE_YTELSESVEDTAK) ? values.klageMedholdArsak : null,
+  klageMedholdArsak: values.klageVurdering.kode === klageVurderingType.MEDHOLD_I_KLAGE ? values.klageMedholdArsak : null,
   klageVurderingOmgjoer: values.klageVurdering.kode === klageVurderingType.MEDHOLD_I_KLAGE ? values.klageVurderingOmgjoer : null,
+  klageHjemmel: values.klageHjemmel,
   klageVurdering: values.klageVurdering,
   fritekstTilBrev: values.fritekstTilBrev,
   begrunnelse: values.begrunnelse,
@@ -37,6 +37,7 @@ type FormValues = {
   klageVurdering?: Kodeverk;
   fritekstTilBrev?: string;
   klageMedholdArsak?: Kodeverk;
+  klageHjemmel?: Kodeverk;
   klageVurderingOmgjoer?: Kodeverk;
   begrunnelse?: string;
 };
@@ -44,6 +45,7 @@ type FormValues = {
 const buildInitialValues = (klageVurderingResultat?: KlageVurderingResultat): FormValues => ({
   klageMedholdArsak: klageVurderingResultat ? klageVurderingResultat.klageMedholdArsak : null,
   klageVurderingOmgjoer: klageVurderingResultat ? klageVurderingResultat.klageVurderingOmgjoer : null,
+  klageHjemmel: klageVurderingResultat ? klageVurderingResultat.klageHjemmel : null,
   klageVurdering: klageVurderingResultat ? klageVurderingResultat.klageVurdering : null,
   begrunnelse: klageVurderingResultat ? klageVurderingResultat.begrunnelse : null,
   fritekstTilBrev: klageVurderingResultat ? klageVurderingResultat.fritekstTilBrev : null,
@@ -57,6 +59,7 @@ interface OwnProps {
   sprakkode: Kodeverk;
   alleKodeverk: AlleKodeverk;
   klageVurdering: KlageVurdering;
+  alleAktuelleHjemler: Kodeverk[];
   submitCallback: (data: KlageVurderingResultatAp) => Promise<void>;
   formData?: FormValues;
   setFormData: (data: FormValues) => void;
@@ -74,6 +77,7 @@ export const BehandleKlageFormNfp: FunctionComponent<OwnProps> = ({
   saveKlage,
   readOnlySubmitButton,
   sprakkode,
+  alleAktuelleHjemler,
   alleKodeverk,
   submitCallback,
   formData,
@@ -103,6 +107,8 @@ export const BehandleKlageFormNfp: FunctionComponent<OwnProps> = ({
         readOnly={readOnly}
         klageVurdering={formValues.klageVurdering}
         medholdReasons={alleKodeverk[kodeverkTyper.KLAGE_MEDHOLD_ARSAK]}
+        alleHjemler={alleKodeverk[kodeverkTyper.KLAGE_HJEMMEL]}
+        alleAktuelleHjemler={alleAktuelleHjemler}
       />
       <div className={styles.confirmVilkarForm}>
         <ProsessStegBegrunnelseTextFieldNew

--- a/packages/prosess-klagevurdering/src/components/nfp/KlageVurderingRadioOptionsNfp.tsx
+++ b/packages/prosess-klagevurdering/src/components/nfp/KlageVurderingRadioOptionsNfp.tsx
@@ -13,16 +13,27 @@ import styles from './klageVurderingRadioOptionsNfp.less';
 interface OwnProps {
   readOnly?: boolean;
   medholdReasons: KodeverkMedNavn[];
+  alleHjemler: KodeverkMedNavn[];
+  alleAktuelleHjemler: Kodeverk[];
   klageVurdering?: Kodeverk;
 }
+
+const lagHjemler = (kodeverkNavn: KodeverkMedNavn[], kodeverkVerdier: string[]): KodeverkMedNavn[] => kodeverkNavn
+  .filter(({ kode }) => kodeverkVerdier.includes(kode))
+  .sort((a, b) => a.kode.localeCompare(b.kode));
+const lagHjemmelsKoder = (kodeverkVerdier: Kodeverk[]): string[] => kodeverkVerdier.map(({ kode }) => kode);
 
 export const KlageVurderingRadioOptionsNfp: FunctionComponent<OwnProps> = ({
   readOnly,
   medholdReasons,
+  alleHjemler,
+  alleAktuelleHjemler,
   klageVurdering,
 }) => {
   const intl = useIntl();
   const medholdOptions = medholdReasons.map((mo: KodeverkMedNavn) => <option key={mo.kode} value={mo.kode}>{mo.navn}</option>);
+  const hjemmelOptions = lagHjemler(alleHjemler, lagHjemmelsKoder(alleAktuelleHjemler))
+    .map((mo: KodeverkMedNavn) => <option key={mo.kode} value={mo.kode}>{mo.navn}</option>);
   return (
     <div>
       <RadioGroupField
@@ -60,6 +71,16 @@ export const KlageVurderingRadioOptionsNfp: FunctionComponent<OwnProps> = ({
           </RadioGroupField>
         </ArrowBox>
       )}
+      <SelectField
+        readOnly={readOnly}
+        name="klageHjemmel.kode"
+        selectValues={hjemmelOptions}
+        className={readOnly ? styles.selectReadOnly : null}
+        label={intl.formatMessage({ id: 'Klage.ResolveKlage.Hjemmel' })}
+        validate={[required]}
+        bredde="xl"
+      />
+      <VerticalSpacer sixteenPx />
     </div>
   );
 };

--- a/packages/storybook-utils/mocks/alleKodeverk.json
+++ b/packages/storybook-utils/mocks/alleKodeverk.json
@@ -3662,6 +3662,13 @@
       "kodeverk": "KLAGE_MEDHOLD_AARSAK"
     }
   ],
+  "KlageHjemmel": [
+    {
+      "kode": "14-17",
+      "navn": "Engangsstønad",
+      "kodeverk": "KLAGE_HJEMMEL"
+    }
+  ],
   "Region": [
     {
       "kode": "EOS",

--- a/packages/storybook/stories/mocks/alleKodeverk.json
+++ b/packages/storybook/stories/mocks/alleKodeverk.json
@@ -3662,6 +3662,13 @@
       "kodeverk": "KLAGE_MEDHOLD_AARSAK"
     }
   ],
+  "KlageHjemmel": [
+    {
+      "kode": "14-17",
+      "navn": "Engangsstønad",
+      "kodeverk": "KLAGE_HJEMMEL"
+    }
+  ],
   "Region": [
     {
       "kode": "EOS",

--- a/packages/types-avklar-aksjonspunkter/src/prosess/KlageVurderingResultatAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/KlageVurderingResultatAp.ts
@@ -9,6 +9,7 @@ type KlageVurderingResultatAp = {
   klageAvvistArsak?: Kodeverk | string;
   klageMedholdArsak?: Kodeverk | string;
   klageVurderingOmgjoer?: Kodeverk | string;
+  klageHjemmel?: Kodeverk | string;
   vedtaksdatoPaklagdBehandling?: string;
   erGodkjentAvMedunderskriver?: boolean;
 } & AksjonspunktTilBekreftelse<AksjonspunktKode.BEHANDLE_KLAGE_NFP | AksjonspunktKode.BEHANDLE_KLAGE_NK>;

--- a/packages/types/src/klageVurderingTsType.ts
+++ b/packages/types/src/klageVurderingTsType.ts
@@ -6,6 +6,7 @@ export type KlageVurderingResultat = Readonly<{
   fritekstTilBrev?: string;
   klageMedholdArsak?: Kodeverk;
   klageVurderingOmgjoer?: Kodeverk;
+  klageHjemmel?: Kodeverk;
   godkjentAvMedunderskriver: boolean;
   begrunnelse?: string;
 }>
@@ -33,6 +34,7 @@ type KlageVurdering = Readonly<{
     erKlagefirstOverholdt: boolean;
     erSignert: boolean;
   };
+  aktuelleHjemler?: Kodeverk[];
 }>
 
 export default KlageVurdering;


### PR DESCRIPTION
Opplegg for at klagebehandler i NFP skal velge lovhjemmel som klagen gjelder. KA/NK skal ikke velge hjemmel

TotalDto kommer med list av aktuelle hjemler (gitt av sakstype) og Klagevurderingdto med en valgt hjemmel.

Har testet mellomlagring og bekreft lokalt. Gjerne feedback. Prodsetting 2022 januar

Det er noen mangler i KlageVedtak-panel  (viser ikke årsak til medhold) og for beslutter står det bare aktuell hjemmel uten "Hjemmel:" fulgt av valgt hjemmel. 
