### PR TITLE
TFP-4917 fjerne manglende beregningsregler som henleggelsesårsak

### DIFF
--- a/packages/sak-meny-henlegg/i18n/nb_NO.json
+++ b/packages/sak-meny-henlegg/i18n/nb_NO.json
@@ -24,6 +24,5 @@
   "HENLAGT_FEILOPPRETTET_UTEN_BREV": "Feilaktig opprettet - uten henleggelsesbrev",
   "HENLAGT_KLAGE_TRUKKET": "Klagen er trukket",
   "HENLAGT_INNSYN_TRUKKET": "Innsynskrav er trukket",
-  "HENLAGT_SØKNAD_MANGLER": "Søknad mangler",
-  "MANGLER_BEREGNINGSREGLER": "Mangler beregningsregler (1. jan 2019)"
+  "HENLAGT_SØKNAD_MANGLER": "Søknad mangler"
 }

--- a/packages/sak-meny-henlegg/src/MenyHenleggIndex.spec.tsx
+++ b/packages/sak-meny-henlegg/src/MenyHenleggIndex.spec.tsx
@@ -22,9 +22,7 @@ describe('<MenyHenleggIndex>', () => {
     expect(screen.getByText('Søknaden er trukket')).toBeInTheDocument();
     expect(screen.getByText('Behandlingen er feilaktig opprettet')).toBeInTheDocument();
     expect(screen.getByText('Søknad mangler')).toBeInTheDocument();
-    expect(screen.getByText('Mangler beregningsregler (1. jan 2019)')).toBeInTheDocument();
     expect(screen.queryByText('Henlagt feilopprettet')).not.toBeInTheDocument();
-    expect(screen.queryByText('Mangler beregningsregler')).not.toBeInTheDocument();
     expect(screen.queryByText('Klagen er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Innsynskrav er trukket')).not.toBeInTheDocument();
 
@@ -63,7 +61,6 @@ describe('<MenyHenleggIndex>', () => {
     expect(screen.queryByText('Henlagt soknad trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt feilopprettet')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt soknad mangler')).not.toBeInTheDocument();
-    expect(screen.queryByText('Mangler beregningsregler')).not.toBeInTheDocument();
     expect(screen.queryByText('Innsynskrav er trukket')).not.toBeInTheDocument();
     expect(screen.getByText('Klagen er trukket')).toBeInTheDocument();
     expect(screen.getByText('Behandlingen er feilaktig opprettet')).toBeInTheDocument();
@@ -76,7 +73,6 @@ describe('<MenyHenleggIndex>', () => {
     expect(screen.queryByText('Henlagt soknad trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt feilopprettet')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt soknad mangler')).not.toBeInTheDocument();
-    expect(screen.queryByText('Mangler beregningsregler')).not.toBeInTheDocument();
     expect(screen.queryByText('Klagen er trukket')).not.toBeInTheDocument();
     expect(screen.getByText('Innsynskrav er trukket')).toBeInTheDocument();
     expect(screen.getByText('Behandlingen er feilaktig opprettet')).toBeInTheDocument();
@@ -89,7 +85,6 @@ describe('<MenyHenleggIndex>', () => {
     expect(screen.queryByText('Henlagt soknad trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt feilopprettet')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt soknad mangler')).not.toBeInTheDocument();
-    expect(screen.queryByText('Mangler beregningsregler')).not.toBeInTheDocument();
     expect(screen.queryByText('Klagen er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Innsynskrav er trukket')).not.toBeInTheDocument();
     expect(screen.getByText('Behandlingen er feilaktig opprettet')).toBeInTheDocument();
@@ -102,7 +97,6 @@ describe('<MenyHenleggIndex>', () => {
     expect(screen.queryByText('Henlagt soknad trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt feilopprettet')).not.toBeInTheDocument();
     expect(screen.queryByText('Henlagt soknad mangler')).not.toBeInTheDocument();
-    expect(screen.queryByText('Mangler beregningsregler')).not.toBeInTheDocument();
     expect(screen.queryByText('Klagen er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Innsynskrav er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Behandlingen er feilaktig opprettet')).not.toBeInTheDocument();
@@ -118,7 +112,6 @@ describe('<MenyHenleggIndex>', () => {
     expect(screen.getByText('Søknad mangler')).toBeInTheDocument();
     expect(screen.getByText('Behandlingen er feilaktig opprettet')).toBeInTheDocument();
     expect(screen.queryByText('Henlagt feilopprettet')).not.toBeInTheDocument();
-    expect(screen.queryByText('Mangler beregningsregler')).not.toBeInTheDocument();
     expect(screen.queryByText('Klagen er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Innsynskrav er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Feilaktig opprettet - med henleggelsesbrev')).not.toBeInTheDocument();

--- a/packages/sak-meny-henlegg/src/MenyHenleggIndex.stories.tsx
+++ b/packages/sak-meny-henlegg/src/MenyHenleggIndex.stories.tsx
@@ -63,10 +63,6 @@ const Template: Story<{
       kode: behandlingResultatType.HENLAGT_SOKNAD_MANGLER,
       kodeverk: 'RESULTAT_TYPE',
       navn: 'Henlagt soknad mangler',
-    }, {
-      kode: behandlingResultatType.MANGLER_BEREGNINGSREGLER,
-      kodeverk: 'RESULTAT_TYPE',
-      navn: 'Mangler beregningsregler',
     }]}
     gaaTilSokeside={action('button-click')}
     lukkModal={lukkModal}

--- a/packages/sak-meny-henlegg/src/components/HenleggBehandlingModal.tsx
+++ b/packages/sak-meny-henlegg/src/components/HenleggBehandlingModal.tsx
@@ -80,15 +80,14 @@ const henleggArsakerPerBehandlingType = {
   [BehandlingType.REVURDERING]: [behandlingResultatType.HENLAGT_SOKNAD_TRUKKET, behandlingResultatType.HENLAGT_FEILOPPRETTET,
     behandlingResultatType.HENLAGT_SOKNAD_MANGLER],
   [BehandlingType.FORSTEGANGSSOKNAD]: [behandlingResultatType.HENLAGT_SOKNAD_TRUKKET, behandlingResultatType.HENLAGT_FEILOPPRETTET,
-    behandlingResultatType.HENLAGT_SOKNAD_MANGLER, behandlingResultatType.MANGLER_BEREGNINGSREGLER],
+    behandlingResultatType.HENLAGT_SOKNAD_MANGLER],
 };
 
 export const getHenleggArsaker = (behandlingResultatTyper: KodeverkMedNavn[], behandlingType: string, ytelseType: string): KodeverkMedNavn[] => {
   const typerForBehandlingType = henleggArsakerPerBehandlingType[behandlingType];
   return typerForBehandlingType
-    .filter((type) => ytelseType !== fagsakYtelseType.ENGANGSSTONAD || (ytelseType === fagsakYtelseType.ENGANGSSTONAD
-      && type !== behandlingResultatType.HENLAGT_SOKNAD_MANGLER
-      && type !== behandlingResultatType.MANGLER_BEREGNINGSREGLER))
+    .filter((type) => ytelseType !== fagsakYtelseType.ENGANGSSTONAD
+      || (ytelseType === fagsakYtelseType.ENGANGSSTONAD && type !== behandlingResultatType.HENLAGT_SOKNAD_MANGLER))
     .flatMap((type) => {
       const typer = behandlingResultatTyper.find((brt) => brt.kode === type);
       return typer ? [typer] : [];

--- a/packages/storybook-utils/mocks/alleKodeverk.json
+++ b/packages/storybook-utils/mocks/alleKodeverk.json
@@ -3725,11 +3725,6 @@
       "kodeverk": "BEHANDLING_RESULTAT_TYPE"
     },
     {
-      "kode": "MANGLER_BEREGNINGSREGLER",
-      "navn": "Mangler beregningsregler",
-      "kodeverk": "BEHANDLING_RESULTAT_TYPE"
-    },
-    {
       "kode": "HENLAGT_SØKNAD_MANGLER",
       "navn": "Henlagt søknad mangler",
       "kodeverk": "BEHANDLING_RESULTAT_TYPE"


### PR DESCRIPTION
Fjerner henleggelsesårsaken fra menyen - ettersom det ligger en del backendlogikk for flytting.
Beholder i behandlingsResultatType.ts i tilfelle visningsbehov