### PR TITLE
TFP-5011 papirsøknad registrere mor uføre og mor fp eøs

### DIFF
--- a/packages/papirsoknad-fp/i18n/nb_NO.json
+++ b/packages/papirsoknad-fp/i18n/nb_NO.json
@@ -70,5 +70,11 @@
   "Registrering.Permisjon.SøkerHarAleneomsorg.No": "Nei",
   "Registrering.Permisjon.HarRettPaForeldrepenger": "Har den andre forelderen rett på foreldrepenger?",
   "Registrering.Permisjon.HarRettPaForeldrepenger.Yes": "Ja",
-  "Registrering.Permisjon.HarRettPaForeldrepenger.No": "Nei"
+  "Registrering.Permisjon.HarRettPaForeldrepenger.No": "Nei",
+  "Registrering.Permisjon.MorUføretrygd": "Bare far rett og mor mottar uføretryd?",
+  "Registrering.Permisjon.MorUføretrygd.Yes": "Ja",
+  "Registrering.Permisjon.MorUføretrygd.No": "Nei",
+  "Registrering.Permisjon.MorForeldrepengerEØS": "Bare far rett og mor har foreldrepenger fra land i EØS?",
+  "Registrering.Permisjon.MorForeldrepengerEØS.Yes": "Ja",
+  "Registrering.Permisjon.MorForeldrepengerEØS.No": "Nei"
 }

--- a/packages/papirsoknad-fp/src/components/ForeldrepengerForm.tsx
+++ b/packages/papirsoknad-fp/src/components/ForeldrepengerForm.tsx
@@ -27,6 +27,7 @@ import RettigheterPapirsoknadIndex, { rettighet } from '@fpsak-frontend/papirsok
 import AnnenForelderPapirsoknadIndex, { AnnenForelderFormValues } from '@fpsak-frontend/papirsoknad-panel-annen-forelder';
 import FodselPapirsoknadIndex from '@fpsak-frontend/papirsoknad-panel-fodsel';
 
+import foreldreType from '@fpsak-frontend/kodeverk/src/foreldreType';
 import PermisjonRettigheterPanel from './permisjon/PermisjonRettigheterPanel';
 import DekningsgradPanel from './dekningsgrad/DekningsgradPanel';
 import PermisjonPanel, { TIDSROM_PERMISJON_FORM_NAME_PREFIX, FormValues as FormValuesPermisjon } from './permisjon/PermisjonPanel';
@@ -55,6 +56,7 @@ interface MappedOwnProps {
   valuesForRegisteredFieldsOnly: FormValues;
   annenForelderInformertRequired: boolean;
   sokerHarAleneomsorg: boolean;
+  denAndreForelderenHarRettPaForeldrepenger?: boolean;
   initialValues: FormValues;
   validate: (formValues: FormValues) => any;
 }
@@ -87,6 +89,7 @@ export class ForeldrepengerForm extends React.Component<PureOwnProps & MappedOwn
       submitFailed,
       annenForelderInformertRequired,
       sokerHarAleneomsorg,
+      denAndreForelderenHarRettPaForeldrepenger,
       alleKodeverk,
     } = this.props;
 
@@ -121,7 +124,14 @@ export class ForeldrepengerForm extends React.Component<PureOwnProps & MappedOwn
             namePrefix={ANNEN_FORELDER_FORM_NAME_PREFIX}
             form={form}
             readOnly={readOnly}
-            permisjonRettigheterPanel={<PermisjonRettigheterPanel readOnly={readOnly} sokerHarAleneomsorg={sokerHarAleneomsorg} />}
+            permisjonRettigheterPanel={(
+              <PermisjonRettigheterPanel
+                readOnly={readOnly}
+                sokerHarAleneomsorg={sokerHarAleneomsorg}
+                denAndreForelderenHarRettPaForeldrepenger={denAndreForelderenHarRettPaForeldrepenger}
+                sokerErMor={soknadData.getForeldreType() === foreldreType.MOR}
+              />
+            )}
             alleKodeverk={alleKodeverk}
           />
         </FormSection>
@@ -212,6 +222,7 @@ const mapStateToPropsFactory = (_initialState: any, ownProps: PureOwnProps) => {
       : {};
     const sokerValue = valuesForRegisteredFieldsOnly.annenForelder;
     const sokerHarAleneomsorg = sokerValue ? sokerValue.sokerHarAleneomsorg : undefined;
+    const denAndreForelderenHarRettPaForeldrepenger = sokerValue ? sokerValue.denAndreForelderenHarRettPaForeldrepenger : undefined;
 
     let annenForelderInformertRequired = true;
     if (sokerValue && (sokerHarAleneomsorg || sokerValue.denAndreForelderenHarRettPaForeldrepenger === false)) {
@@ -222,6 +233,7 @@ const mapStateToPropsFactory = (_initialState: any, ownProps: PureOwnProps) => {
       valuesForRegisteredFieldsOnly,
       annenForelderInformertRequired,
       sokerHarAleneomsorg,
+      denAndreForelderenHarRettPaForeldrepenger,
       validate,
     };
   };

--- a/packages/papirsoknad-fp/src/components/permisjon/PermisjonRettigheterPanel.spec.tsx
+++ b/packages/papirsoknad-fp/src/components/permisjon/PermisjonRettigheterPanel.spec.tsx
@@ -16,6 +16,8 @@ describe('<PermisjonRettigheterPanel>', () => {
       readOnly={readOnly}
       intl={intlMock}
       sokerHarAleneomsorg
+      denAndreForelderenHarRettPaForeldrepenger={false}
+      sokerErMor={false}
     />);
     expect(wrapper.find({ name: 'sokerHarAleneomsorg' })).toHaveLength(1);
     expect(wrapper.find({ name: 'denAndreForelderenHarRettPaForeldrepenger' })).toHaveLength(0);
@@ -26,6 +28,8 @@ describe('<PermisjonRettigheterPanel>', () => {
       readOnly={readOnly}
       intl={intlMock}
       sokerHarAleneomsorg={false}
+      denAndreForelderenHarRettPaForeldrepenger={false}
+      sokerErMor={false}
     />);
     expect(wrapper.find({ name: 'sokerHarAleneomsorg' })).toHaveLength(1);
     expect(wrapper.find({ name: 'denAndreForelderenHarRettPaForeldrepenger' })).toHaveLength(1);

--- a/packages/papirsoknad-fp/src/components/permisjon/PermisjonRettigheterPanel.tsx
+++ b/packages/papirsoknad-fp/src/components/permisjon/PermisjonRettigheterPanel.tsx
@@ -9,6 +9,8 @@ import { VerticalSpacer } from '@navikt/ft-ui-komponenter';
 interface OwnProps {
   readOnly: boolean;
   sokerHarAleneomsorg?: boolean;
+  denAndreForelderenHarRettPaForeldrepenger?: boolean;
+  sokerErMor: boolean;
 }
 
 /**
@@ -20,6 +22,8 @@ export const PermisjonRettigheterPanel: FunctionComponent<OwnProps & WrappedComp
   intl,
   readOnly,
   sokerHarAleneomsorg,
+  denAndreForelderenHarRettPaForeldrepenger,
+  sokerErMor,
 }) => (
   <>
     <Undertekst>
@@ -45,6 +49,30 @@ export const PermisjonRettigheterPanel: FunctionComponent<OwnProps & WrappedComp
         <RadioGroupField name="denAndreForelderenHarRettPaForeldrepenger" validate={[required]} readOnly={readOnly}>
           <RadioOption label={intl.formatMessage({ id: 'Registrering.Permisjon.HarRettPaForeldrepenger.Yes' })} value />
           <RadioOption label={intl.formatMessage({ id: 'Registrering.Permisjon.HarRettPaForeldrepenger.No' })} value={false} />
+        </RadioGroupField>
+      </div>
+    )}
+    {!sokerErMor && sokerHarAleneomsorg === false && denAndreForelderenHarRettPaForeldrepenger === false && (
+      <div>
+        <Undertekst>
+          {intl.formatMessage({ id: 'Registrering.Permisjon.MorUføretrygd' })}
+        </Undertekst>
+        <VerticalSpacer eightPx />
+        <RadioGroupField name="morMottarUføretrygd" validate={[required]} readOnly={readOnly}>
+          <RadioOption label={intl.formatMessage({ id: 'Registrering.Permisjon.MorUføretrygd.Yes' })} value />
+          <RadioOption label={intl.formatMessage({ id: 'Registrering.Permisjon.MorUføretrygd.No' })} value={false} />
+        </RadioGroupField>
+      </div>
+    )}
+    {!sokerErMor && sokerHarAleneomsorg === false && denAndreForelderenHarRettPaForeldrepenger === false && (
+      <div>
+        <Undertekst>
+          {intl.formatMessage({ id: 'Registrering.Permisjon.MorForeldrepengerEØS' })}
+        </Undertekst>
+        <VerticalSpacer eightPx />
+        <RadioGroupField name="morHarForeldrepengerEØS" validate={[required]} readOnly={readOnly}>
+          <RadioOption label={intl.formatMessage({ id: 'Registrering.Permisjon.MorForeldrepengerEØS.Yes' })} value />
+          <RadioOption label={intl.formatMessage({ id: 'Registrering.Permisjon.MorForeldrepengerEØS.No' })} value={false} />
         </RadioGroupField>
       </div>
     )}

--- a/packages/papirsoknad-fp/src/components/permisjon/RenderPermisjonPeriodeFieldArray.tsx
+++ b/packages/papirsoknad-fp/src/components/permisjon/RenderPermisjonPeriodeFieldArray.tsx
@@ -160,7 +160,7 @@ export const RenderPermisjonPeriodeFieldArray: FunctionComponent<PureOwnProps & 
                     <FlexColumn>
                       <SelectField
                         readOnly={readOnly}
-                        disabled={shouldDisableSelect(selectedPeriodeTyper, index)}
+                        disabled={sokerErMor || shouldDisableSelect(selectedPeriodeTyper, index)}
                         bredde="s"
                         name={`${periodeElementFieldId}.morsAktivitet`}
                         label={getLabel(erForsteRad, 'Registrering.Permisjon.Fellesperiode.morsAktivitet')}
@@ -309,22 +309,22 @@ RenderPermisjonPeriodeFieldArray.transformValues = (values: FormValues[]) => val
 });
 
 const mapStateToPropsFactory = (initialState: any, ownProps: PureOwnProps) => {
-  const values = getFormValues(ownProps.meta.form)(initialState);
-  const permisjonValues = values[ownProps.namePrefix];
-  let selectedPeriodeTyper = [''];
-  if (typeof permisjonValues[ownProps.periodePrefix] !== 'undefined') {
-    selectedPeriodeTyper = permisjonValues[ownProps.periodePrefix].map(({
-      periodeType,
-    }: { periodeType: string }) => periodeType);
-  }
   const periodeTyper = ownProps.alleKodeverk[kodeverkTyper.UTTAK_PERIODE_TYPE];
   const morsAktivitetTyper = ownProps.alleKodeverk[kodeverkTyper.MORS_AKTIVITET];
 
-  return (): MappedOwnProps => ({
-    selectedPeriodeTyper,
-    periodeTyper,
-    morsAktivitetTyper,
-  });
+  return (state: any, props: PureOwnProps): MappedOwnProps => {
+    const values = getFormValues(props.meta.form)(state);
+    const permisjonValues = values[props.namePrefix];
+    let selectedPeriodeTyper = [''];
+    if (typeof permisjonValues[props.periodePrefix] !== 'undefined') {
+      selectedPeriodeTyper = permisjonValues[props.periodePrefix].map(({ periodeType }: { periodeType: string }) => periodeType);
+    }
+    return {
+      selectedPeriodeTyper,
+      periodeTyper,
+      morsAktivitetTyper,
+    };
+  };
 };
 
 export default connect(mapStateToPropsFactory)(RenderPermisjonPeriodeFieldArray);

--- a/packages/papirsoknad-panel-annen-forelder/i18n/nb_NO.json
+++ b/packages/papirsoknad-panel-annen-forelder/i18n/nb_NO.json
@@ -13,5 +13,11 @@
   "Registrering.Permisjon.SøkerHarAleneomsorg.No": "Nei",
   "Registrering.Permisjon.HarRettPaForeldrepenger": "Har den andre forelderen rett på foreldrepenger?",
   "Registrering.Permisjon.HarRettPaForeldrepenger.Yes": "Ja",
-  "Registrering.Permisjon.HarRettPaForeldrepenger.No": "Nei"
+  "Registrering.Permisjon.HarRettPaForeldrepenger.No": "Nei",
+  "Registrering.Permisjon.MorUføretrygd": "Bare far rett og mor mottar uføretryd?",
+  "Registrering.Permisjon.MorUføretrygd.Yes": "Ja",
+  "Registrering.Permisjon.MorUføretrygd.No": "Nei",
+  "Registrering.Permisjon.MorForeldrepengerEØS": "Bare far rett og mor har foreldrepenger fra land i EØS?",
+  "Registrering.Permisjon.MorForeldrepengerEØS.Yes": "Ja",
+  "Registrering.Permisjon.MorForeldrepengerEØS.No": "Nei"
 }


### PR DESCRIPTION
Skal kunne registere om mor er uføretrygdet dersom bruker er far og mor ikke har rett.
Legger inn at mor har foreldrepenger EØS i samme slengen - den er ikke aktiv før 2/8-22