### PR TITLE
TFP-2754 sortering og mer filtrering av uttak-årsaker

### DIFF
--- a/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
@@ -217,6 +217,7 @@ const uttaksresultatPerioder = {
   ],
   perioderAnnenpart: [],
   annenForelderHarRett: true,
+  søkerErMor: true,
   aleneomsorg: false,
 };
 

--- a/packages/prosess-uttak/src/components/Uttak.spec.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.spec.tsx
@@ -83,6 +83,7 @@ describe('<Uttak>', () => {
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
     wrapper.setState({ selectedItem: null });
     const rows = wrapper.find(Row);
@@ -135,6 +136,7 @@ describe('<Uttak>', () => {
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
     wrapper.setState({
       selectedItem: {
@@ -193,6 +195,7 @@ describe('<Uttak>', () => {
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor={false}
     />);
     wrapper.setState({
       selectedItem: {
@@ -259,6 +262,7 @@ describe('<Uttak>', () => {
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
     wrapper.setState({
       selectedItem: {
@@ -325,6 +329,7 @@ describe('<Uttak>', () => {
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
     wrapper.setState({
       selectedItem: {

--- a/packages/prosess-uttak/src/components/Uttak.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.tsx
@@ -138,6 +138,7 @@ interface MappedOwnProps {
   hovedsokerKjonnKode?: Kjønnkode;
   isRevurdering: boolean;
   medsokerKjonnKode: Kjønnkode;
+  søkerErMor: boolean;
   soknadDate: string;
   stonadskonto: UttakStonadskontoer;
   uttakPerioder: PeriodeMedClassName[];
@@ -448,6 +449,7 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
       behandlingsresultat,
       arbeidsgiverOpplysningerPerId,
       kreverSammenhengendeUttak,
+      søkerErMor,
     } = this.props;
     const { selectedItem, stonadskonto, isButtonDisabled } = this.state;
 
@@ -526,6 +528,7 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
                         behandlingsresultat={behandlingsresultat}
                         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
                         kreverSammenhengendeUttak={kreverSammenhengendeUttak}
+                        søkerErMor={søkerErMor}
                       />
                     )}
                   {!selectedItem.hovedsoker
@@ -542,6 +545,7 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
                         behandlingsresultat={behandlingsresultat}
                         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
                         kreverSammenhengendeUttak={kreverSammenhengendeUttak}
+                        søkerErMor={søkerErMor}
                       />
                     )}
                 </>
@@ -795,6 +799,7 @@ const mapStateToProps = (state: any, props: PureOwnProps) => {
     // @ts-ignore
     uttaksresultatActivity: lagUttaksresultatActivity(state, props),
     uttakPerioder,
+    søkerErMor: uttaksresultat.søkerErMor,
   };
 };
 

--- a/packages/prosess-uttak/src/components/UttakActivity.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakActivity.spec.tsx
@@ -47,7 +47,7 @@ describe('<UttakActivity>', () => {
       onSubmit={sinon.spy()}
       periodeAarsakKoder={[
         {
-          kode: '4011', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
+          kode: '4011', sortering: '14-10', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
         }]}
       graderingAvslagAarsakKoder={[]}
       harSoktOmFlerbarnsdager={false}
@@ -63,6 +63,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
 
     const fieldArray = wrapper.find('FieldArray');
@@ -94,7 +95,7 @@ describe('<UttakActivity>', () => {
       onSubmit={sinon.spy()}
       periodeAarsakKoder={[
         {
-          kode: '4011', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
+          kode: '4011', sortering: '14-10', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
         }]}
       graderingAvslagAarsakKoder={[]}
       harSoktOmFlerbarnsdager={false}
@@ -110,6 +111,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
 
     const row = wrapper.find('Row');
@@ -135,7 +137,7 @@ describe('<UttakActivity>', () => {
       onSubmit={sinon.spy()}
       periodeAarsakKoder={[
         {
-          kode: '4011', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
+          kode: '4011', sortering: '14-10', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
         }]}
       graderingAvslagAarsakKoder={[]}
       harSoktOmFlerbarnsdager={false}
@@ -151,6 +153,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
 
     const fieldArray = wrapper.find('FieldArray');
@@ -182,7 +185,7 @@ describe('<UttakActivity>', () => {
       onSubmit={sinon.spy()}
       periodeAarsakKoder={[
         {
-          kode: '4011', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
+          kode: '4011', sortering: '14-10', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [], utfallType: 'AVSLÅTT',
         }]}
       graderingAvslagAarsakKoder={[]}
       harSoktOmFlerbarnsdager={false}
@@ -198,6 +201,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
 
     const fieldArray = wrapper.find('FieldArray');
@@ -229,7 +233,7 @@ describe('<UttakActivity>', () => {
       onSubmit={sinon.spy()}
       periodeAarsakKoder={[
         {
-          kode: '4011', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [],
+          kode: '4011', sortering: '14-10', navn: 'mitt navn', kodeverk: 'MITT_KODEVERK', gyldigForLovendringer: [],
         }]}
       graderingAvslagAarsakKoder={[]}
       harSoktOmFlerbarnsdager={false}
@@ -245,6 +249,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      søkerErMor
     />);
 
     const fieldArray = wrapper.find('FieldArray');

--- a/packages/prosess-uttak/src/components/UttakActivity.tsx
+++ b/packages/prosess-uttak/src/components/UttakActivity.tsx
@@ -50,7 +50,13 @@ const uttakActivityForm = 'uttaksresultatActivity';
 const minLength3 = minLength(3);
 const maxLength1500 = maxLength(1500);
 
-function sortAlphabetically(a: KodeverkMedNavn, b: KodeverkMedNavn): number {
+function sortAlphabetically(a: ArsakKodeverk, b: ArsakKodeverk): number {
+  if (a.sortering < b.sortering) {
+    return -1;
+  }
+  if (a.sortering > b.sortering) {
+    return 1;
+  }
   if (a.navn < b.navn) {
     return -1;
   }
@@ -61,16 +67,19 @@ function sortAlphabetically(a: KodeverkMedNavn, b: KodeverkMedNavn): number {
 }
 
 export type ArsakKodeverk = {
+  sortering: string;
   utfallType?: string;
   uttakTyper?: string[];
   valgbarForKonto?: string[];
   gyldigForLovendringer: string[];
+  synligForRolle?: string[];
 } & KodeverkMedNavn;
 
 const mapAarsak = (
   årsakKoder: ArsakKodeverk[],
   utfallType: string,
   kreverSammenhengendeUttak: boolean,
+  søkerErMor: boolean,
   utsettelseType?: string,
   periodeType?: string,
   skalFiltrere?: boolean,
@@ -85,6 +94,14 @@ const mapAarsak = (
       return kreverSammenhengendeUttak
         ? kodeItem.gyldigForLovendringer.includes('KREVER_SAMMENHENGENDE_UTTAK')
         : kodeItem.gyldigForLovendringer.includes('FRITT_UTTAK');
+    })
+    .filter((kodeItem) => {
+      if (kodeItem.synligForRolle === undefined) {
+        return true;
+      }
+      return søkerErMor
+        ? kodeItem.synligForRolle.includes('MOR')
+        : kodeItem.synligForRolle.includes('IKKE_MOR');
     });
 
   if (!skalFiltrere) {
@@ -149,6 +166,7 @@ interface PureOwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   kreverSammenhengendeUttak: boolean;
+  søkerErMor: boolean;
 }
 
 interface MappedOwnProps {
@@ -189,6 +207,7 @@ export const UttakActivity: FunctionComponent<PureOwnProps & MappedOwnProps & In
   currentlySelectedStønadskonto,
   arbeidsgiverOpplysningerPerId,
   kreverSammenhengendeUttak,
+  søkerErMor,
   ...formProps
 }) => (
   <div>
@@ -249,6 +268,7 @@ export const UttakActivity: FunctionComponent<PureOwnProps & MappedOwnProps & In
                                   periodeAarsakKoder,
                                   erOppfylt ? 'INNVILGET' : 'AVSLÅTT',
                                   kreverSammenhengendeUttak,
+                                  søkerErMor,
                                   selectedItemData.utsettelseType,
                                   currentlySelectedStønadskonto || selectedItemData.periodeType,
                                   selectedItemData.aktiviteter.length === 1,

--- a/packages/prosess-uttak/src/components/UttakMedsokerReadOnly.tsx
+++ b/packages/prosess-uttak/src/components/UttakMedsokerReadOnly.tsx
@@ -22,6 +22,7 @@ interface OwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   kreverSammenhengendeUttak: boolean;
+  søkerErMor: boolean;
 }
 
 const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
@@ -36,6 +37,7 @@ const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
   behandlingsresultat,
   arbeidsgiverOpplysningerPerId,
   kreverSammenhengendeUttak,
+  søkerErMor,
 }) => {
   const intl = useIntl();
   return (
@@ -65,6 +67,7 @@ const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
         behandlingsresultat={behandlingsresultat}
         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
         kreverSammenhengendeUttak={kreverSammenhengendeUttak}
+        søkerErMor={!søkerErMor}
       />
     </TimeLineDataContainer>
   );

--- a/packages/prosess-uttak/src/components/UttakTimeLineData.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakTimeLineData.spec.tsx
@@ -133,6 +133,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     wrapper.setState({ showDelPeriodeModal: false });
     const modal = wrapper.find(DelOppPeriodeModal);
@@ -165,6 +166,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     wrapper.setState({ showDelPeriodeModal: true });
     expect(wrapper.state('showDelPeriodeModal')).toBe(true);
@@ -196,6 +198,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     wrapper.setState({ showDelPeriodeModal: false });
     const modal = wrapper.find(DelOppPeriodeModal);
@@ -229,6 +232,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     const buttons = wrapper.find(TimeLineButton);
     expect(buttons).toHaveLength(2);
@@ -259,6 +263,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     const uttakActivity = wrapper.find(UttakActivity);
     expect(uttakActivity).toHaveLength(1);
@@ -290,6 +295,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     const uttak = wrapper.find(AksjonspunktHelpTextTemp);
     expect(uttak).toHaveLength(1);
@@ -321,6 +327,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      søkerErMor
     />, messages);
     const uttak = wrapper.find(AksjonspunktHelpTextTemp);
     expect(uttak).toHaveLength(1);

--- a/packages/prosess-uttak/src/components/UttakTimeLineData.tsx
+++ b/packages/prosess-uttak/src/components/UttakTimeLineData.tsx
@@ -129,6 +129,7 @@ interface OwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   kreverSammenhengendeUttak: boolean;
+  søkerErMor: boolean;
 }
 
 interface OwnState {
@@ -241,6 +242,7 @@ export class UttakTimeLineData extends Component<OwnProps & WrappedComponentProp
       stonadskonto,
       arbeidsgiverOpplysningerPerId,
       kreverSammenhengendeUttak,
+      søkerErMor,
     } = this.props;
     const { showDelPeriodeModal } = this.state;
     const isEdited = !!selectedItemData.begrunnelse && !isApOpen;
@@ -312,6 +314,7 @@ export class UttakTimeLineData extends Component<OwnProps & WrappedComponentProp
           behandlingsresultat={behandlingsresultat}
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
           kreverSammenhengendeUttak={kreverSammenhengendeUttak}
+          søkerErMor={søkerErMor}
         />
       </TimeLineDataContainer>
     );

--- a/packages/types/src/uttaksresultatPeriodeTsType.ts
+++ b/packages/types/src/uttaksresultatPeriodeTsType.ts
@@ -33,6 +33,7 @@ export type PeriodeSoker = Readonly<{
 type UttaksresultatPeriode = Readonly<{
   perioderSøker: PeriodeSoker[];
   perioderAnnenpart: PeriodeSoker[];
+  søkerErMor: boolean;
   annenForelderHarRett: boolean;
   aleneomsorg: boolean;
 }>


### PR DESCRIPTION
Sender opp ett nytt felt i uttak-resultatet "søkerErMor" + to nye felt i ArsakKodeverk - sortering og synligForRolle

Dette vil gi en bedre sortering enn dagens andre, femte, fjerde, første, sjette, sjuende, tredje
Dessuten langt færre årsaker å velge mellom for de fleste tilfellene.

Testet lokalt for både mor og far og ulike konti. Funker bra.

Tor ser kanskje mer elegante måter å gjøre dette på?

Notat: kreverSammenhengedeUttak finnes også i uttak-resultatet. Nå ser det ut som det hentes fra eget endepunkt.