### PR TITLE
Forenkle paramtere til filtrering + legge på utenMinsterett

### DIFF
--- a/packages/behandling-fp/src/data/fpBehandlingApi.ts
+++ b/packages/behandling-fp/src/data/fpBehandlingApi.ts
@@ -39,7 +39,6 @@ export const FpBehandlingApiKeys = {
   INNTEKT_ARBEID_YTELSE: new RestKey<InntektArbeidYtelse, void>('INNTEKT_ARBEID_YTELSE'),
   VERGE: new RestKey<Verge, void>('VERGE'),
   YTELSEFORDELING: new RestKey<Ytelsefordeling, void>('YTELSEFORDELING'),
-  KREVER_SAMMENHENGENDE_UTTAK: new RestKey<{ kreverSammenhengendeUttak: boolean }, void>('KREVER_SAMMENHENGENDE_UTTAK'),
   OPPTJENING: new RestKey<Opptjening, void>('OPPTJENING'),
   FAKTA_ARBEIDSFORHOLD: new RestKey<FaktaArbeidsforhold[], void>('FAKTA_ARBEIDSFORHOLD'),
   UTTAKSRESULTAT_PERIODER: new RestKey<UttaksresultatPeriode, void>('UTTAKSRESULTAT_PERIODER'),
@@ -83,7 +82,6 @@ const endpoints = new RestApiConfigBuilder()
   .withRel('inntekt-arbeid-ytelse', FpBehandlingApiKeys.INNTEKT_ARBEID_YTELSE)
   .withRel('soeker-verge', FpBehandlingApiKeys.VERGE)
   .withRel('ytelsefordeling', FpBehandlingApiKeys.YTELSEFORDELING)
-  .withRel('krever-sammenhengende-uttak', FpBehandlingApiKeys.KREVER_SAMMENHENGENDE_UTTAK)
   .withRel('opptjening', FpBehandlingApiKeys.OPPTJENING)
   .withRel('fakta-arbeidsforhold', FpBehandlingApiKeys.FAKTA_ARBEIDSFORHOLD)
   .withRel('uttaksresultat-perioder', FpBehandlingApiKeys.UTTAKSRESULTAT_PERIODER)

--- a/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.spec.tsx
+++ b/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.spec.tsx
@@ -53,7 +53,6 @@ const uttaksresultatPerioder = {
         {
           stønadskontoType: 'FORELDREPENGER_FØR_FØDSEL',
           prosentArbeid: 0,
-          arbeidsforholdId: null,
           eksternArbeidsforholdId: null,
           arbeidsgiverReferanse: '910909088',
           utbetalingsgrad: 100,
@@ -80,6 +79,11 @@ const uttaksresultatPerioder = {
   perioderAnnenpart: [],
   annenForelderHarRett: true,
   aleneomsorg: false,
+  årsakFilter: {
+    kreverSammenhengendeUttak: false,
+    utenMinsterett: false,
+    søkerErMor: true,
+  },
 } as UttaksresultatPeriode;
 
 const behandling = {
@@ -121,7 +125,6 @@ const lagRestApiMockData = () => [
   },
   { key: FpBehandlingApiKeys.YTELSEFORDELING.name, data: {} },
   { key: FpBehandlingApiKeys.UTTAK_STONADSKONTOER.name, data: { stonadskontoer: stonadskonto } },
-  { key: FpBehandlingApiKeys.KREVER_SAMMENHENGENDE_UTTAK.name, data: { kreverSammenhengendeUttak: false } },
   { key: FpBehandlingApiKeys.STONADSKONTOER_GITT_UTTAKSPERIODER.name, data: undefined },
 ];
 

--- a/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.tsx
+++ b/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.tsx
@@ -64,7 +64,6 @@ const ENDEPUNKTER_PANEL_DATA = [
   FpBehandlingApiKeys.UTTAK_STONADSKONTOER,
   FpBehandlingApiKeys.SOKNAD,
   FpBehandlingApiKeys.YTELSEFORDELING,
-  FpBehandlingApiKeys.KREVER_SAMMENHENGENDE_UTTAK,
 ];
 type EndepunktPanelData = {
   familiehendelse: FamilieHendelseSamling;
@@ -72,7 +71,6 @@ type EndepunktPanelData = {
   uttakStonadskontoer: UttakStonadskontoer;
   soknad: Soknad;
   ytelsefordeling: Ytelsefordeling;
-  kreverSammenhengendeUttak: { kreverSammenhengendeUttak: boolean };
 }
 
 interface OwnProps {

--- a/packages/prosess-uttak/src/UttakProsessIndex.spec.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.spec.tsx
@@ -21,7 +21,6 @@ describe('<UttakProsessIndex>', () => {
           {
             stønadskontoType: 'FORELDREPENGER_FØR_FØDSEL',
             prosentArbeid: 0,
-            arbeidsforholdId: null,
             eksternArbeidsforholdId: null,
             arbeidsgiverReferanse: '910909088',
             utbetalingsgrad: 100,
@@ -96,7 +95,6 @@ describe('<UttakProsessIndex>', () => {
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       alleMerknaderFraBeslutter={{}}
       setFormData={() => undefined}
-      kreverSammenhengendeUttak={{ kreverSammenhengendeUttak: true }}
     />);
     expect(wrapper.find(UttakPanel)).toHaveLength(1);
   });

--- a/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
@@ -219,6 +219,11 @@ const uttaksresultatPerioder = {
   annenForelderHarRett: true,
   søkerErMor: true,
   aleneomsorg: false,
+  årsakFilter: {
+    kreverSammenhengendeUttak: false,
+    utenMinsterett: false,
+    søkerErMor: true,
+  },
 };
 
 const uttakPeriodeGrense = {
@@ -290,6 +295,5 @@ export const visProsessUttak = () => (
     arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
     alleMerknaderFraBeslutter={{}}
     setFormData={() => undefined}
-    kreverSammenhengendeUttak={{ kreverSammenhengendeUttak: true }}
   />
 );

--- a/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
@@ -217,7 +217,6 @@ const uttaksresultatPerioder = {
   ],
   perioderAnnenpart: [],
   annenForelderHarRett: true,
-  søkerErMor: true,
   aleneomsorg: false,
   årsakFilter: {
     kreverSammenhengendeUttak: false,

--- a/packages/prosess-uttak/src/UttakProsessIndex.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.tsx
@@ -27,7 +27,6 @@ interface OwnProps {
     perioder: any;
   }) => Promise<any>;
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  kreverSammenhengendeUttak: { kreverSammenhengendeUttak: boolean };
 }
 
 const UttakProsessIndex: FunctionComponent<OwnProps & StandardProsessPanelProps> = ({
@@ -50,7 +49,6 @@ const UttakProsessIndex: FunctionComponent<OwnProps & StandardProsessPanelProps>
   arbeidsgiverOpplysningerPerId,
   formData,
   setFormData,
-  kreverSammenhengendeUttak,
 }) => (
   <RawIntlProvider value={intl}>
     <ReduxWrapper formName="UttakProsessIndex" formData={formData} setFormData={setFormData}>
@@ -78,7 +76,6 @@ const UttakProsessIndex: FunctionComponent<OwnProps & StandardProsessPanelProps>
         apCodes={aksjonspunkter.map((a) => a.definisjon)}
         isApOpen={isAksjonspunktOpen}
         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-        kreverSammenhengendeUttak={kreverSammenhengendeUttak.kreverSammenhengendeUttak}
       />
     </ReduxWrapper>
   </RawIntlProvider>

--- a/packages/prosess-uttak/src/components/Uttak.spec.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.spec.tsx
@@ -82,8 +82,6 @@ describe('<Uttak>', () => {
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      søkerErMor
     />);
     wrapper.setState({ selectedItem: null });
     const rows = wrapper.find(Row);
@@ -135,8 +133,6 @@ describe('<Uttak>', () => {
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      søkerErMor
     />);
     wrapper.setState({
       selectedItem: {
@@ -194,8 +190,6 @@ describe('<Uttak>', () => {
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      søkerErMor={false}
     />);
     wrapper.setState({
       selectedItem: {
@@ -261,8 +255,6 @@ describe('<Uttak>', () => {
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      søkerErMor
     />);
     wrapper.setState({
       selectedItem: {
@@ -328,8 +320,6 @@ describe('<Uttak>', () => {
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      søkerErMor
     />);
     wrapper.setState({
       selectedItem: {

--- a/packages/prosess-uttak/src/components/Uttak.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.tsx
@@ -125,7 +125,6 @@ interface PureOwnProps {
     behandlingUuid: string;
     perioder: any;
   }) => Promise<any>;
-  kreverSammenhengendeUttak: boolean;
 }
 
 interface MappedOwnProps {
@@ -138,7 +137,6 @@ interface MappedOwnProps {
   hovedsokerKjonnKode?: Kjønnkode;
   isRevurdering: boolean;
   medsokerKjonnKode: Kjønnkode;
-  søkerErMor: boolean;
   soknadDate: string;
   stonadskonto: UttakStonadskontoer;
   uttakPerioder: PeriodeMedClassName[];
@@ -448,8 +446,7 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
       alleKodeverk,
       behandlingsresultat,
       arbeidsgiverOpplysningerPerId,
-      kreverSammenhengendeUttak,
-      søkerErMor,
+      uttaksresultat,
     } = this.props;
     const { selectedItem, stonadskonto, isButtonDisabled } = this.state;
 
@@ -527,8 +524,9 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
                         alleKodeverk={alleKodeverk}
                         behandlingsresultat={behandlingsresultat}
                         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-                        kreverSammenhengendeUttak={kreverSammenhengendeUttak}
-                        søkerErMor={søkerErMor}
+                        kreverSammenhengendeUttak={uttaksresultat.årsakFilter?.kreverSammenhengendeUttak}
+                        utenMinsterett={uttaksresultat.årsakFilter?.utenMinsterett}
+                        søkerErMor={uttaksresultat.årsakFilter?.søkerErMor}
                       />
                     )}
                   {!selectedItem.hovedsoker
@@ -544,8 +542,9 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
                         alleKodeverk={alleKodeverk}
                         behandlingsresultat={behandlingsresultat}
                         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-                        kreverSammenhengendeUttak={kreverSammenhengendeUttak}
-                        søkerErMor={søkerErMor}
+                        kreverSammenhengendeUttak={uttaksresultat.årsakFilter?.kreverSammenhengendeUttak}
+                        utenMinsterett={uttaksresultat.årsakFilter?.utenMinsterett}
+                        søkerErMor={uttaksresultat.årsakFilter?.søkerErMor}
                       />
                     )}
                 </>
@@ -799,7 +798,6 @@ const mapStateToProps = (state: any, props: PureOwnProps) => {
     // @ts-ignore
     uttaksresultatActivity: lagUttaksresultatActivity(state, props),
     uttakPerioder,
-    søkerErMor: uttaksresultat.søkerErMor,
   };
 };
 

--- a/packages/prosess-uttak/src/components/Uttak.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.tsx
@@ -452,6 +452,8 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
 
     const gjeldendeFamiliehendelse = familiehendelse?.gjeldende;
 
+    const aarsakFilter = uttaksresultat.årsakFilter;
+
     const dodeBarn = gjeldendeFamiliehendelse
       && !gjeldendeFamiliehendelse.brukAntallBarnFraTps
       && gjeldendeFamiliehendelse.avklartBarn
@@ -524,9 +526,7 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
                         alleKodeverk={alleKodeverk}
                         behandlingsresultat={behandlingsresultat}
                         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-                        kreverSammenhengendeUttak={uttaksresultat.årsakFilter?.kreverSammenhengendeUttak}
-                        utenMinsterett={uttaksresultat.årsakFilter?.utenMinsterett}
-                        søkerErMor={uttaksresultat.årsakFilter?.søkerErMor}
+                        aarsakFilter={aarsakFilter}
                       />
                     )}
                   {!selectedItem.hovedsoker
@@ -542,9 +542,7 @@ export class Uttak extends Component<PureOwnProps & MappedOwnProps & DispatchPro
                         alleKodeverk={alleKodeverk}
                         behandlingsresultat={behandlingsresultat}
                         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-                        kreverSammenhengendeUttak={uttaksresultat.årsakFilter?.kreverSammenhengendeUttak}
-                        utenMinsterett={uttaksresultat.årsakFilter?.utenMinsterett}
-                        søkerErMor={uttaksresultat.årsakFilter?.søkerErMor}
+                        aarsakFilter={aarsakFilter}
                       />
                     )}
                 </>

--- a/packages/prosess-uttak/src/components/UttakActivity.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakActivity.spec.tsx
@@ -62,9 +62,7 @@ describe('<UttakActivity>', () => {
       erSamtidigUttak={false}
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
       reduxFormChange={() => undefined}
     />);
 
@@ -112,9 +110,7 @@ describe('<UttakActivity>', () => {
       erSamtidigUttak={false}
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
       reduxFormChange={() => undefined}
     />);
 
@@ -156,9 +152,7 @@ describe('<UttakActivity>', () => {
       erSamtidigUttak={false}
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
       reduxFormChange={() => undefined}
     />);
 
@@ -206,9 +200,7 @@ describe('<UttakActivity>', () => {
       erSamtidigUttak={false}
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
       reduxFormChange={() => undefined}
     />);
 
@@ -256,9 +248,7 @@ describe('<UttakActivity>', () => {
       erSamtidigUttak={false}
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
       reduxFormChange={() => undefined}
     />);
 

--- a/packages/prosess-uttak/src/components/UttakActivity.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakActivity.spec.tsx
@@ -63,6 +63,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
       reduxFormChange={() => undefined}
     />);
@@ -112,6 +113,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
       reduxFormChange={() => undefined}
     />);
@@ -155,6 +157,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
       reduxFormChange={() => undefined}
     />);
@@ -204,6 +207,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
       reduxFormChange={() => undefined}
     />);
@@ -253,6 +257,7 @@ describe('<UttakActivity>', () => {
       samtidigUttaksprosent="20"
       arbeidsgiverOpplysningerPerId={{}}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
       reduxFormChange={() => undefined}
     />);

--- a/packages/prosess-uttak/src/components/UttakActivity.tsx
+++ b/packages/prosess-uttak/src/components/UttakActivity.tsx
@@ -79,6 +79,7 @@ const mapAarsak = (
   årsakKoder: ArsakKodeverk[],
   utfallType: string,
   kreverSammenhengendeUttak: boolean,
+  utenMinsterett: boolean,
   søkerErMor: boolean,
   utsettelseType?: string,
   periodeType?: string,
@@ -91,9 +92,12 @@ const mapAarsak = (
       if (kodeItem.gyldigForLovendringer === undefined) {
         return true;
       }
-      return kreverSammenhengendeUttak
-        ? kodeItem.gyldigForLovendringer.includes('KREVER_SAMMENHENGENDE_UTTAK')
-        : kodeItem.gyldigForLovendringer.includes('FRITT_UTTAK');
+      if (kreverSammenhengendeUttak) {
+        return kodeItem.gyldigForLovendringer.includes('KREVER_SAMMENHENGENDE_UTTAK');
+      }
+      return utenMinsterett
+        ? kodeItem.gyldigForLovendringer.includes('FRITT_UTTAK')
+        : kodeItem.gyldigForLovendringer.includes('MINSTERETT_2022');
     })
     .filter((kodeItem) => {
       if (kodeItem.synligForRolle === undefined) {
@@ -166,6 +170,7 @@ interface PureOwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   kreverSammenhengendeUttak: boolean;
+  utenMinsterett: boolean;
   søkerErMor: boolean;
   reduxFormChange: (...args: any[]) => any;
 }
@@ -208,6 +213,7 @@ export const UttakActivity: FunctionComponent<PureOwnProps & MappedOwnProps & In
   currentlySelectedStønadskonto,
   arbeidsgiverOpplysningerPerId,
   kreverSammenhengendeUttak,
+  utenMinsterett,
   søkerErMor,
   reduxFormChange,
   ...formProps
@@ -271,6 +277,7 @@ export const UttakActivity: FunctionComponent<PureOwnProps & MappedOwnProps & In
                                   periodeAarsakKoder,
                                   erOppfylt ? 'INNVILGET' : 'AVSLÅTT',
                                   kreverSammenhengendeUttak,
+                                  utenMinsterett,
                                   søkerErMor,
                                   selectedItemData.utsettelseType,
                                   currentlySelectedStønadskonto || selectedItemData.periodeType,

--- a/packages/prosess-uttak/src/components/UttakActivity.tsx
+++ b/packages/prosess-uttak/src/components/UttakActivity.tsx
@@ -40,6 +40,7 @@ import {
 import {
   ArbeidsgiverOpplysningerPerId, AlleKodeverk, Behandling, KodeverkMedNavn,
 } from '@fpsak-frontend/types';
+import { AarsakFilter } from '@fpsak-frontend/types/src/uttaksresultatPeriodeTsType';
 import RenderUttakTable, { AktivitetFieldArray } from './RenderUttakTable';
 import UttakInfo from './UttakInfo';
 
@@ -78,9 +79,7 @@ export type ArsakKodeverk = {
 const mapAarsak = (
   årsakKoder: ArsakKodeverk[],
   utfallType: string,
-  kreverSammenhengendeUttak: boolean,
-  utenMinsterett: boolean,
-  søkerErMor: boolean,
+  aarsakFilter: AarsakFilter,
   utsettelseType?: string,
   periodeType?: string,
   skalFiltrere?: boolean,
@@ -92,10 +91,10 @@ const mapAarsak = (
       if (kodeItem.gyldigForLovendringer === undefined) {
         return true;
       }
-      if (kreverSammenhengendeUttak) {
+      if (aarsakFilter.kreverSammenhengendeUttak) {
         return kodeItem.gyldigForLovendringer.includes('KREVER_SAMMENHENGENDE_UTTAK');
       }
-      return utenMinsterett
+      return aarsakFilter.utenMinsterett
         ? kodeItem.gyldigForLovendringer.includes('FRITT_UTTAK')
         : kodeItem.gyldigForLovendringer.includes('MINSTERETT_2022');
     })
@@ -103,7 +102,7 @@ const mapAarsak = (
       if (kodeItem.synligForRolle === undefined) {
         return true;
       }
-      return søkerErMor
+      return aarsakFilter.søkerErMor
         ? kodeItem.synligForRolle.includes('MOR')
         : kodeItem.synligForRolle.includes('IKKE_MOR');
     });
@@ -169,9 +168,7 @@ interface PureOwnProps {
   alleKodeverk: AlleKodeverk;
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  kreverSammenhengendeUttak: boolean;
-  utenMinsterett: boolean;
-  søkerErMor: boolean;
+  aarsakFilter: AarsakFilter;
   reduxFormChange: (...args: any[]) => any;
 }
 
@@ -212,9 +209,7 @@ export const UttakActivity: FunctionComponent<PureOwnProps & MappedOwnProps & In
   hasValidationError,
   currentlySelectedStønadskonto,
   arbeidsgiverOpplysningerPerId,
-  kreverSammenhengendeUttak,
-  utenMinsterett,
-  søkerErMor,
+  aarsakFilter,
   reduxFormChange,
   ...formProps
 }) => (
@@ -276,9 +271,7 @@ export const UttakActivity: FunctionComponent<PureOwnProps & MappedOwnProps & In
                                 mapAarsak(
                                   periodeAarsakKoder,
                                   erOppfylt ? 'INNVILGET' : 'AVSLÅTT',
-                                  kreverSammenhengendeUttak,
-                                  utenMinsterett,
-                                  søkerErMor,
+                                  aarsakFilter,
                                   selectedItemData.utsettelseType,
                                   currentlySelectedStønadskonto || selectedItemData.periodeType,
                                   selectedItemData.aktiviteter.length === 1,

--- a/packages/prosess-uttak/src/components/UttakMedsokerReadOnly.tsx
+++ b/packages/prosess-uttak/src/components/UttakMedsokerReadOnly.tsx
@@ -7,6 +7,7 @@ import { TimeLineButton, TimeLineDataContainer } from '@navikt/ft-tidslinje';
 import { FloatRight } from '@navikt/ft-ui-komponenter';
 import { ArbeidsgiverOpplysningerPerId, Behandling, AlleKodeverk } from '@fpsak-frontend/types';
 
+import { AarsakFilter } from '@fpsak-frontend/types/src/uttaksresultatPeriodeTsType';
 import UttakActivity from './UttakActivity';
 import { PeriodeMedClassName } from './Uttak';
 
@@ -21,9 +22,7 @@ interface OwnProps {
   alleKodeverk: AlleKodeverk;
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  kreverSammenhengendeUttak: boolean;
-  utenMinsterett: boolean;
-  søkerErMor: boolean;
+  aarsakFilter: AarsakFilter;
 }
 
 const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
@@ -37,9 +36,7 @@ const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
   alleKodeverk,
   behandlingsresultat,
   arbeidsgiverOpplysningerPerId,
-  kreverSammenhengendeUttak,
-  utenMinsterett,
-  søkerErMor,
+  aarsakFilter,
 }) => {
   const intl = useIntl();
   return (
@@ -68,9 +65,7 @@ const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
         alleKodeverk={alleKodeverk}
         behandlingsresultat={behandlingsresultat}
         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-        kreverSammenhengendeUttak={kreverSammenhengendeUttak}
-        utenMinsterett={utenMinsterett}
-        søkerErMor={!søkerErMor}
+        aarsakFilter={aarsakFilter}
       />
     </TimeLineDataContainer>
   );

--- a/packages/prosess-uttak/src/components/UttakMedsokerReadOnly.tsx
+++ b/packages/prosess-uttak/src/components/UttakMedsokerReadOnly.tsx
@@ -22,6 +22,7 @@ interface OwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   kreverSammenhengendeUttak: boolean;
+  utenMinsterett: boolean;
   søkerErMor: boolean;
 }
 
@@ -37,6 +38,7 @@ const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
   behandlingsresultat,
   arbeidsgiverOpplysningerPerId,
   kreverSammenhengendeUttak,
+  utenMinsterett,
   søkerErMor,
 }) => {
   const intl = useIntl();
@@ -67,6 +69,7 @@ const UttakMedsokerReadOnly: FunctionComponent<OwnProps> = ({
         behandlingsresultat={behandlingsresultat}
         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
         kreverSammenhengendeUttak={kreverSammenhengendeUttak}
+        utenMinsterett={utenMinsterett}
         søkerErMor={!søkerErMor}
       />
     </TimeLineDataContainer>

--- a/packages/prosess-uttak/src/components/UttakPanel.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakPanel.spec.tsx
@@ -135,7 +135,6 @@ describe('<UttakPanel>', () => {
       readOnlySubmitButton={false}
       apCodes={[]}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
     />, messages);
     const uttak = wrapper.find(Uttak);
     expect(uttak).toHaveLength(1);
@@ -182,7 +181,6 @@ describe('<UttakPanel>', () => {
       readOnlySubmitButton={false}
       apCodes={[]}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
     />, messages);
     const uttak = wrapper.find(Uttak);
     expect(uttak).toHaveLength(1);

--- a/packages/prosess-uttak/src/components/UttakPanel.tsx
+++ b/packages/prosess-uttak/src/components/UttakPanel.tsx
@@ -107,7 +107,6 @@ interface PureOwnProps {
   apCodes: string[];
   isApOpen: boolean;
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  kreverSammenhengendeUttak: boolean;
 }
 
 interface MappedOwnProps {
@@ -137,7 +136,6 @@ export const UttakPanelImpl: FunctionComponent<PureOwnProps & MappedOwnProps & W
   isApOpen,
   intl,
   arbeidsgiverOpplysningerPerId,
-  kreverSammenhengendeUttak,
   ...formProps
 }) => (
   <>
@@ -184,7 +182,6 @@ export const UttakPanelImpl: FunctionComponent<PureOwnProps & MappedOwnProps & W
           omsorgsovertakelseDato={soknad.omsorgsovertakelseDato}
           tempUpdateStonadskontoer={tempUpdateStonadskontoer}
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-          kreverSammenhengendeUttak={kreverSammenhengendeUttak}
         />
       </form>
     )}

--- a/packages/prosess-uttak/src/components/UttakTimeLineData.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakTimeLineData.spec.tsx
@@ -133,6 +133,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     wrapper.setState({ showDelPeriodeModal: false });
@@ -166,6 +167,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     wrapper.setState({ showDelPeriodeModal: true });
@@ -198,6 +200,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     wrapper.setState({ showDelPeriodeModal: false });
@@ -232,6 +235,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     const buttons = wrapper.find(TimeLineButton);
@@ -263,6 +267,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     const uttakActivity = wrapper.find(UttakActivity);
@@ -295,6 +300,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     const uttak = wrapper.find(AksjonspunktHelpTextTemp);
@@ -327,6 +333,7 @@ describe('<UttakTimeLineData>', () => {
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       kreverSammenhengendeUttak
+      utenMinsterett
       søkerErMor
     />, messages);
     const uttak = wrapper.find(AksjonspunktHelpTextTemp);

--- a/packages/prosess-uttak/src/components/UttakTimeLineData.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakTimeLineData.spec.tsx
@@ -132,9 +132,7 @@ describe('<UttakTimeLineData>', () => {
       harSoktOmFlerbarnsdager={false}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     wrapper.setState({ showDelPeriodeModal: false });
     const modal = wrapper.find(DelOppPeriodeModal);
@@ -166,9 +164,7 @@ describe('<UttakTimeLineData>', () => {
       harSoktOmFlerbarnsdager={false}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     wrapper.setState({ showDelPeriodeModal: true });
     expect(wrapper.state('showDelPeriodeModal')).toBe(true);
@@ -199,9 +195,7 @@ describe('<UttakTimeLineData>', () => {
       harSoktOmFlerbarnsdager={false}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     wrapper.setState({ showDelPeriodeModal: false });
     const modal = wrapper.find(DelOppPeriodeModal);
@@ -234,9 +228,7 @@ describe('<UttakTimeLineData>', () => {
       harSoktOmFlerbarnsdager={false}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     const buttons = wrapper.find(TimeLineButton);
     expect(buttons).toHaveLength(2);
@@ -266,9 +258,7 @@ describe('<UttakTimeLineData>', () => {
       harSoktOmFlerbarnsdager={false}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     const uttakActivity = wrapper.find(UttakActivity);
     expect(uttakActivity).toHaveLength(1);
@@ -299,9 +289,7 @@ describe('<UttakTimeLineData>', () => {
       stonadskonto={stonadskonto}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     const uttak = wrapper.find(AksjonspunktHelpTextTemp);
     expect(uttak).toHaveLength(1);
@@ -332,9 +320,7 @@ describe('<UttakTimeLineData>', () => {
       stonadskonto={stonadskontoFlerGarTom}
       alleKodeverk={kodeverk}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      kreverSammenhengendeUttak
-      utenMinsterett
-      søkerErMor
+      aarsakFilter={{ kreverSammenhengendeUttak: false, utenMinsterett: false, søkerErMor: true }}
     />, messages);
     const uttak = wrapper.find(AksjonspunktHelpTextTemp);
     expect(uttak).toHaveLength(1);

--- a/packages/prosess-uttak/src/components/UttakTimeLineData.tsx
+++ b/packages/prosess-uttak/src/components/UttakTimeLineData.tsx
@@ -129,6 +129,7 @@ interface OwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   kreverSammenhengendeUttak: boolean;
+  utenMinsterett: boolean;
   søkerErMor: boolean;
 }
 
@@ -242,6 +243,7 @@ export class UttakTimeLineData extends Component<OwnProps & WrappedComponentProp
       stonadskonto,
       arbeidsgiverOpplysningerPerId,
       kreverSammenhengendeUttak,
+      utenMinsterett,
       søkerErMor,
       reduxFormChange: formChange,
     } = this.props;
@@ -315,6 +317,7 @@ export class UttakTimeLineData extends Component<OwnProps & WrappedComponentProp
           behandlingsresultat={behandlingsresultat}
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
           kreverSammenhengendeUttak={kreverSammenhengendeUttak}
+          utenMinsterett={utenMinsterett}
           søkerErMor={søkerErMor}
           reduxFormChange={formChange}
         />

--- a/packages/prosess-uttak/src/components/UttakTimeLineData.tsx
+++ b/packages/prosess-uttak/src/components/UttakTimeLineData.tsx
@@ -16,6 +16,7 @@ import KodeverkType from '@fpsak-frontend/kodeverk/src/kodeverkTyper';
 import {
   ArbeidsgiverOpplysningerPerId, Behandling, AlleKodeverk, UttakStonadskontoer,
 } from '@fpsak-frontend/types';
+import { AarsakFilter } from '@fpsak-frontend/types/src/uttaksresultatPeriodeTsType';
 import UttakActivity from './UttakActivity';
 import DelOppPeriodeModal, { DeltPeriodeData } from './DelOppPeriodeModal';
 import { PeriodeMedClassName, UttaksresultatActivity } from './Uttak';
@@ -128,9 +129,7 @@ interface OwnProps {
   alleKodeverk: AlleKodeverk;
   behandlingsresultat?: Behandling['behandlingsresultat'];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  kreverSammenhengendeUttak: boolean;
-  utenMinsterett: boolean;
-  søkerErMor: boolean;
+  aarsakFilter: AarsakFilter;
 }
 
 interface OwnState {
@@ -242,9 +241,7 @@ export class UttakTimeLineData extends Component<OwnProps & WrappedComponentProp
       selectedItemData,
       stonadskonto,
       arbeidsgiverOpplysningerPerId,
-      kreverSammenhengendeUttak,
-      utenMinsterett,
-      søkerErMor,
+      aarsakFilter,
       reduxFormChange: formChange,
     } = this.props;
     const { showDelPeriodeModal } = this.state;
@@ -316,9 +313,7 @@ export class UttakTimeLineData extends Component<OwnProps & WrappedComponentProp
           alleKodeverk={alleKodeverk}
           behandlingsresultat={behandlingsresultat}
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-          kreverSammenhengendeUttak={kreverSammenhengendeUttak}
-          utenMinsterett={utenMinsterett}
-          søkerErMor={søkerErMor}
+          aarsakFilter={aarsakFilter}
           reduxFormChange={formChange}
         />
       </TimeLineDataContainer>

--- a/packages/types/src/uttaksresultatPeriodeTsType.ts
+++ b/packages/types/src/uttaksresultatPeriodeTsType.ts
@@ -41,7 +41,7 @@ type UttaksresultatPeriode = Readonly<{
   perioderAnnenpart: PeriodeSoker[];
   annenForelderHarRett: boolean;
   aleneomsorg: boolean;
-  årsakFilter?: AarsakFilter;
+  årsakFilter: AarsakFilter;
 }>
 
 export default UttaksresultatPeriode;

--- a/packages/types/src/uttaksresultatPeriodeTsType.ts
+++ b/packages/types/src/uttaksresultatPeriodeTsType.ts
@@ -30,12 +30,18 @@ export type PeriodeSoker = Readonly<{
   oppholdÅrsak: string;
 }>
 
+export type AarsakFilter = Readonly<{
+  kreverSammenhengendeUttak: boolean;
+  utenMinsterett: boolean;
+  søkerErMor: boolean;
+}>
+
 type UttaksresultatPeriode = Readonly<{
   perioderSøker: PeriodeSoker[];
   perioderAnnenpart: PeriodeSoker[];
-  søkerErMor: boolean;
   annenForelderHarRett: boolean;
   aleneomsorg: boolean;
+  årsakFilter?: AarsakFilter;
 }>
 
 export default UttaksresultatPeriode;


### PR DESCRIPTION
Bruker info om sammenhengende uttak, minsterett og mor fra ny filter-del i Dto.

Fjerner ref til ressurslenke for krever-sammenhengende-uttak

@tor-nav burde vi sende uttaksresultat lenger ned til der den egentlig trengs - dvs mapAarsaker i UttakActivity ?