### PR TITLE
TFP-5065 standardisere søknadsfrist i søknaddto

### DIFF
--- a/packages/behandling-fp/src/data/fpBehandlingApi.ts
+++ b/packages/behandling-fp/src/data/fpBehandlingApi.ts
@@ -3,7 +3,7 @@ import { RestApiHooks } from '@fpsak-frontend/rest-api-hooks';
 import {
   Aksjonspunkt, ArbeidsgiverOpplysningerWrapper, Behandling, Beregningsgrunnlag, BeregningsresultatFp, FaktaArbeidsforhold,
   FamilieHendelse, FamilieHendelseSamling, Feriepengegrunnlag, ForhåndsvisMeldingParams, InntektArbeidYtelse, Medlemskap, Opptjening, Personoversikt,
-  SimuleringResultat, Soknad, TilbakekrevingValg, UttakKontrollerAktivitetskrav, UttakKontrollerFaktaPerioderWrapper, UttakPeriodeGrense,
+  SimuleringResultat, Soknad, TilbakekrevingValg, UttakKontrollerAktivitetskrav, UttakKontrollerFaktaPerioderWrapper,
   UttaksresultatPeriode, UttakStonadskontoer, Verge, Vilkar, Ytelsefordeling, ArbeidOgInntektsmelding, ManueltArbeidsforhold, ManglendeInntektsmeldingVurdering,
 } from '@fpsak-frontend/types';
 import { NyBehandlendeEnhetParams, SettPaVentParams } from '@fpsak-frontend/behandling-felles';
@@ -35,7 +35,6 @@ export const FpBehandlingApiKeys = {
   BEREGNINGSRESULTAT_ORIGINAL_BEHANDLING: new RestKey<{ 'beregningsresultat-foreldrepenger'?: BeregningsresultatFp; },
     void>('BEREGNINGSRESULTAT_ORIGINAL_BEHANDLING'),
   MEDLEMSKAP: new RestKey<Medlemskap, void>('MEDLEMSKAP'),
-  UTTAK_PERIODE_GRENSE: new RestKey<UttakPeriodeGrense, void>('UTTAK_PERIODE_GRENSE'),
   INNTEKT_ARBEID_YTELSE: new RestKey<InntektArbeidYtelse, void>('INNTEKT_ARBEID_YTELSE'),
   VERGE: new RestKey<Verge, void>('VERGE'),
   YTELSEFORDELING: new RestKey<Ytelsefordeling, void>('YTELSEFORDELING'),
@@ -78,7 +77,6 @@ const endpoints = new RestApiConfigBuilder()
   .withRel('familiehendelse-original-behandling', FpBehandlingApiKeys.FAMILIEHENDELSE_ORIGINAL_BEHANDLING)
   .withRel('beregningsresultat-foreldrepenger-original-behandling', FpBehandlingApiKeys.BEREGNINGSRESULTAT_ORIGINAL_BEHANDLING)
   .withRel('soeker-medlemskap-v2', FpBehandlingApiKeys.MEDLEMSKAP)
-  .withRel('uttak-periode-grense', FpBehandlingApiKeys.UTTAK_PERIODE_GRENSE)
   .withRel('inntekt-arbeid-ytelse', FpBehandlingApiKeys.INNTEKT_ARBEID_YTELSE)
   .withRel('soeker-verge', FpBehandlingApiKeys.VERGE)
   .withRel('ytelsefordeling', FpBehandlingApiKeys.YTELSEFORDELING)

--- a/packages/behandling-fp/src/prosessPaneler/BeregningsgrunnlagProsessStegInitPanel.tsx
+++ b/packages/behandling-fp/src/prosessPaneler/BeregningsgrunnlagProsessStegInitPanel.tsx
@@ -41,7 +41,7 @@ const lagModifisertCallback = (
 const lagStandardPeriode = (beregningsgrunnlag: Beregningsgrunnlag, bgVilkar: FpVilkar): Vilkarperiode => ({
   avslagKode: bgVilkar.avslagKode,
   vurderesIBehandlingen: true,
-  merknadParametere: bgVilkar.merknadParametere,
+  merknadParametere: {},
   periode: {
     fom: beregningsgrunnlag ? beregningsgrunnlag.skjaeringstidspunktBeregning : '',
     tom: TIDENES_ENDE,

--- a/packages/behandling-fp/src/prosessPaneler/SoknadsfristProsessStegInitPanel.tsx
+++ b/packages/behandling-fp/src/prosessPaneler/SoknadsfristProsessStegInitPanel.tsx
@@ -5,7 +5,7 @@ import React, {
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import VurderSoknadsfristForeldrepengerIndex from '@fpsak-frontend/prosess-soknadsfrist';
 import { ProsessStegCode } from '@fpsak-frontend/konstanter';
-import { Aksjonspunkt, Soknad, UttakPeriodeGrense } from '@fpsak-frontend/types';
+import { Aksjonspunkt, Soknad } from '@fpsak-frontend/types';
 import { ProsessDefaultInitPanel, ProsessPanelInitProps, skalViseProsessPanel } from '@fpsak-frontend/behandling-felles';
 import { createIntl } from '@navikt/ft-utils';
 
@@ -21,9 +21,8 @@ type EndepunktInitData = {
   aksjonspunkter: Aksjonspunkt[];
 }
 
-const ENDEPUNKTER_PANEL_DATA = [FpBehandlingApiKeys.UTTAK_PERIODE_GRENSE, FpBehandlingApiKeys.SOKNAD];
+const ENDEPUNKTER_PANEL_DATA = [FpBehandlingApiKeys.SOKNAD];
 type EndepunktPanelData = {
-  uttakPeriodeGrense?: UttakPeriodeGrense;
   soknad: Soknad;
 }
 

--- a/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.spec.tsx
+++ b/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.spec.tsx
@@ -111,7 +111,6 @@ const lagRestApiMockData = () => [
     },
   },
   { key: FpBehandlingApiKeys.UTTAKSRESULTAT_PERIODER.name, data: uttaksresultatPerioder },
-  { key: FpBehandlingApiKeys.UTTAK_PERIODE_GRENSE.name, data: {} },
   {
     key: FpBehandlingApiKeys.FAMILIEHENDELSE.name,
     data: {

--- a/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.tsx
+++ b/packages/behandling-fp/src/prosessPaneler/UttakProsessStegInitPanel.tsx
@@ -10,7 +10,7 @@ import { ProsessStegCode } from '@fpsak-frontend/konstanter';
 import { RestApiState } from '@fpsak-frontend/rest-api-hooks';
 import {
   AksessRettigheter, Aksjonspunkt, ArbeidsgiverOpplysningerPerId, FamilieHendelseSamling,
-  Personoversikt, Soknad, UttakPeriodeGrense, UttaksresultatPeriode, UttakStonadskontoer, Vilkar, Ytelsefordeling,
+  Personoversikt, Soknad, UttaksresultatPeriode, UttakStonadskontoer, Vilkar, Ytelsefordeling,
 } from '@fpsak-frontend/types';
 import { ProsessDefaultInitPanel, ProsessPanelInitProps } from '@fpsak-frontend/behandling-felles';
 import { createIntl } from '@navikt/ft-utils';
@@ -60,14 +60,12 @@ type EndepunktInitData = {
 
 const ENDEPUNKTER_PANEL_DATA = [
   FpBehandlingApiKeys.FAMILIEHENDELSE,
-  FpBehandlingApiKeys.UTTAK_PERIODE_GRENSE,
   FpBehandlingApiKeys.UTTAK_STONADSKONTOER,
   FpBehandlingApiKeys.SOKNAD,
   FpBehandlingApiKeys.YTELSEFORDELING,
 ];
 type EndepunktPanelData = {
   familiehendelse: FamilieHendelseSamling;
-  uttakPeriodeGrense: UttakPeriodeGrense;
   uttakStonadskontoer: UttakStonadskontoer;
   soknad: Soknad;
   ytelsefordeling: Ytelsefordeling;

--- a/packages/behandling-svp/src/data/svpBehandlingApi.ts
+++ b/packages/behandling-svp/src/data/svpBehandlingApi.ts
@@ -3,7 +3,7 @@ import { RestApiHooks } from '@fpsak-frontend/rest-api-hooks';
 import {
   Aksjonspunkt, ArbeidsgiverOpplysningerWrapper, Behandling, Beregningsgrunnlag, BeregningsresultatFp, FamilieHendelseSamling,
   Feriepengegrunnlag, FodselOgTilrettelegging, ForhåndsvisMeldingParams, InntektArbeidYtelse, Medlemskap, Opptjening, Personoversikt,
-  SimuleringResultat, Soknad, TilbakekrevingValg, UttakPeriodeGrense, Verge, Vilkar, Ytelsefordeling, ArbeidOgInntektsmelding,
+  SimuleringResultat, Soknad, TilbakekrevingValg, Verge, Vilkar, Ytelsefordeling, ArbeidOgInntektsmelding,
   ManueltArbeidsforhold, ManglendeInntektsmeldingVurdering,
 } from '@fpsak-frontend/types';
 import { NyBehandlendeEnhetParams, SettPaVentParams } from '@fpsak-frontend/behandling-felles';
@@ -27,7 +27,6 @@ export const SvpBehandlingApiKeys = {
   BEREGNINGSRESULTAT_ORIGINAL_BEHANDLING: new RestKey<{'beregningsresultat-foreldrepenger'?: BeregningsresultatFp; },
     void>('BEREGNINGSRESULTAT_ORIGINAL_BEHANDLING'),
   MEDLEMSKAP: new RestKey<Medlemskap, void>('MEDLEMSKAP'),
-  UTTAK_PERIODE_GRENSE: new RestKey<UttakPeriodeGrense, void>('UTTAK_PERIODE_GRENSE'),
   INNTEKT_ARBEID_YTELSE: new RestKey<InntektArbeidYtelse, void>('INNTEKT_ARBEID_YTELSE'),
   VERGE: new RestKey<Verge, void>('VERGE'),
   YTELSEFORDELING: new RestKey<Ytelsefordeling, void>('YTELSEFORDELING'),
@@ -64,7 +63,6 @@ const endpoints = new RestApiConfigBuilder()
   .withRel('soknad', SvpBehandlingApiKeys.SOKNAD)
   .withRel('beregningsresultat-foreldrepenger-original-behandling', SvpBehandlingApiKeys.BEREGNINGSRESULTAT_ORIGINAL_BEHANDLING)
   .withRel('soeker-medlemskap-v2', SvpBehandlingApiKeys.MEDLEMSKAP)
-  .withRel('uttak-periode-grense', SvpBehandlingApiKeys.UTTAK_PERIODE_GRENSE)
   .withRel('inntekt-arbeid-ytelse', SvpBehandlingApiKeys.INNTEKT_ARBEID_YTELSE)
   .withRel('soeker-verge', SvpBehandlingApiKeys.VERGE)
   .withRel('ytelsefordeling', SvpBehandlingApiKeys.YTELSEFORDELING)

--- a/packages/behandling-svp/src/prosessPaneler/BeregningsgrunnlagProsessStegInitPanel.tsx
+++ b/packages/behandling-svp/src/prosessPaneler/BeregningsgrunnlagProsessStegInitPanel.tsx
@@ -39,7 +39,7 @@ const lagModifisertCallback = (
 const lagStandardPeriode = (beregningsgrunnlag: Beregningsgrunnlag, bgVilkar: FpVilkar): Vilkarperiode => ({
   avslagKode: bgVilkar.avslagKode,
   vurderesIBehandlingen: true,
-  merknadParametere: bgVilkar.merknadParametere,
+  merknadParametere: {},
   periode: {
     fom: beregningsgrunnlag ? beregningsgrunnlag.skjaeringstidspunktBeregning : '',
     tom: TIDENES_ENDE,

--- a/packages/behandling-svp/src/prosessPaneler/SoknadsfristProsessStegInitPanel.tsx
+++ b/packages/behandling-svp/src/prosessPaneler/SoknadsfristProsessStegInitPanel.tsx
@@ -5,7 +5,7 @@ import React, {
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import VurderSoknadsfristForeldrepengerIndex from '@fpsak-frontend/prosess-soknadsfrist';
 import { ProsessStegCode } from '@fpsak-frontend/konstanter';
-import { Aksjonspunkt, Soknad, UttakPeriodeGrense } from '@fpsak-frontend/types';
+import { Aksjonspunkt, Soknad } from '@fpsak-frontend/types';
 import { ProsessDefaultInitPanel, ProsessPanelInitProps, skalViseProsessPanel } from '@fpsak-frontend/behandling-felles';
 import { createIntl } from '@navikt/ft-utils';
 
@@ -21,9 +21,8 @@ type EndepunktInitData = {
   aksjonspunkter: Aksjonspunkt[];
 }
 
-const ENDEPUNKTER_PANEL_DATA = [SvpBehandlingApiKeys.UTTAK_PERIODE_GRENSE, SvpBehandlingApiKeys.SOKNAD];
+const ENDEPUNKTER_PANEL_DATA = [SvpBehandlingApiKeys.SOKNAD];
 type EndepunktPanelData = {
-  uttakPeriodeGrense?: UttakPeriodeGrense;
   soknad: Soknad;
 }
 

--- a/packages/prosess-soknadsfrist/src/VurderSoknadsfristForeldrepengerIndex.stories.tsx
+++ b/packages/prosess-soknadsfrist/src/VurderSoknadsfristForeldrepengerIndex.stories.tsx
@@ -16,15 +16,14 @@ const behandling = {
 
 const soknad = {
   mottattDato: '2019-01-01',
+  søknadsfrist: {
+    mottattDato: '2019-01-01',
+    dagerOversittetFrist: 2,
+    søknadsperiodeStart: '2019-01-01',
+    søknadsperiodeSlutt: '2019-01-10',
+    utledetSøknadsfrist: '2019-10-01',
+  },
 } as Soknad;
-
-const uttakPeriodeGrense = {
-  mottattDato: '2019-01-01',
-  antallDagerLevertForSent: 2,
-  soknadsperiodeStart: '2019-01-01',
-  soknadsperiodeSlutt: '2019-01-10',
-  soknadsfristForForsteUttaksdato: '2019-10-01',
-};
 
 export default {
   title: 'prosess/prosess-soknadsfrist',
@@ -47,7 +46,6 @@ const Template: Story<{
     vilkar={[]}
     alleMerknaderFraBeslutter={{}}
     setFormData={() => undefined}
-    uttakPeriodeGrense={uttakPeriodeGrense}
     soknad={soknad}
     aksjonspunkter={[{
       definisjon: aksjonspunktCodes.VURDER_SOKNADSFRIST_FORELDREPENGER,

--- a/packages/prosess-soknadsfrist/src/VurderSoknadsfristForeldrepengerIndex.tsx
+++ b/packages/prosess-soknadsfrist/src/VurderSoknadsfristForeldrepengerIndex.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { RawIntlProvider } from 'react-intl';
 
-import { Soknad, UttakPeriodeGrense, StandardProsessPanelProps } from '@fpsak-frontend/types';
+import { Soknad, StandardProsessPanelProps } from '@fpsak-frontend/types';
 import { createIntl } from '@navikt/ft-utils';
 
 import VurderSoknadsfristForeldrepengerForm from './components/VurderSoknadsfristForeldrepengerForm';
@@ -10,12 +10,10 @@ import messages from '../i18n/nb_NO.json';
 const intl = createIntl(messages);
 
 interface OwnProps {
-  uttakPeriodeGrense?: UttakPeriodeGrense;
   soknad: Soknad;
 }
 
 const VurderSoknadsfristForeldrepengerIndex: FunctionComponent<OwnProps & StandardProsessPanelProps> = ({
-  uttakPeriodeGrense,
   soknad,
   aksjonspunkter,
   submitCallback,
@@ -27,8 +25,8 @@ const VurderSoknadsfristForeldrepengerIndex: FunctionComponent<OwnProps & Standa
 }) => (
   <RawIntlProvider value={intl}>
     <VurderSoknadsfristForeldrepengerForm
-      uttakPeriodeGrense={uttakPeriodeGrense}
       mottattDato={soknad.mottattDato}
+      søknadsfrist={soknad.søknadsfrist}
       aksjonspunkter={aksjonspunkter}
       submitCallback={submitCallback}
       readOnly={isReadOnly}

--- a/packages/prosess-soknadsfrist/src/components/VurderSoknadsfristForeldrepengerForm.tsx
+++ b/packages/prosess-soknadsfrist/src/components/VurderSoknadsfristForeldrepengerForm.tsx
@@ -18,10 +18,11 @@ import { DDMMYYYY_DATE_FORMAT } from '@navikt/ft-utils';
 import { dateBeforeOrEqualToToday, hasValidDate, required } from '@navikt/ft-form-validators';
 import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
 import { ProsessStegBegrunnelseTextFieldNew, ProsessStegSubmitButtonNew } from '@fpsak-frontend/prosess-felles';
-import { Aksjonspunkt, UttakPeriodeGrense } from '@fpsak-frontend/types';
+import { Aksjonspunkt } from '@fpsak-frontend/types';
 import { VurderSoknadsfristAp } from '@fpsak-frontend/types-avklar-aksjonspunkter';
 import AksjonspunktCode from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 
+import { Søknadsfrist } from '@fpsak-frontend/types/src/soknadTsType';
 import styles from './vurderSoknadsfristForeldrepengerForm.less';
 
 const isEdited = (hasAksjonspunkt: boolean, gyldigSenFremsetting?: boolean): boolean => hasAksjonspunkt && gyldigSenFremsetting !== undefined;
@@ -35,9 +36,9 @@ type FormValues = {
 const buildInitialValues = (
   aksjonspunkter: Aksjonspunkt[],
   mottattDato: string,
-  uttaksperiodegrense?: UttakPeriodeGrense,
+  søknadsfrist?: Søknadsfrist,
 ): FormValues => {
-  const upgMottattDato = uttaksperiodegrense ? uttaksperiodegrense.mottattDato : undefined;
+  const upgMottattDato = søknadsfrist?.mottattDato;
   return {
     gyldigSenFremsetting: isAksjonspunktOpen(aksjonspunkter[0].status) ? undefined : upgMottattDato !== mottattDato,
     ansesMottatt: upgMottattDato,
@@ -53,8 +54,8 @@ const transformValues = (values: FormValues): VurderSoknadsfristAp => ({
 });
 
 interface OwnProps {
-  uttakPeriodeGrense?: UttakPeriodeGrense;
   mottattDato: string;
+  søknadsfrist?: Søknadsfrist
   aksjonspunkter: Aksjonspunkt[];
   submitCallback: (data: VurderSoknadsfristAp) => Promise<void>;
   readOnly: boolean;
@@ -74,22 +75,22 @@ const VurderSoknadsfristForeldrepengerForm: FunctionComponent<OwnProps> = ({
   readOnly,
   readOnlySubmitButton,
   mottattDato,
-  uttakPeriodeGrense,
+  søknadsfrist,
   isApOpen,
   submitCallback,
   formData,
   setFormData,
 }) => {
-  const initialValues = useMemo(() => buildInitialValues(aksjonspunkter, mottattDato, uttakPeriodeGrense), [aksjonspunkter, mottattDato, uttakPeriodeGrense]);
+  const initialValues = useMemo(() => buildInitialValues(aksjonspunkter, mottattDato, søknadsfrist), [aksjonspunkter, mottattDato, søknadsfrist]);
   const formMethods = useForm<FormValues>({
     defaultValues: formData || initialValues,
   });
 
   const gyldigSenFremsetting = formMethods.watch('gyldigSenFremsetting');
 
-  const soknadsperiodeStart = uttakPeriodeGrense?.soknadsperiodeStart;
-  const soknadsperiodeSlutt = uttakPeriodeGrense?.soknadsperiodeSlutt;
-  const soknadsfristdato = uttakPeriodeGrense?.soknadsfristForForsteUttaksdato;
+  const soknadsperiodeStart = søknadsfrist?.søknadsperiodeStart;
+  const soknadsperiodeSlutt = søknadsfrist?.søknadsperiodeSlutt;
+  const soknadsfristdato = søknadsfrist?.utledetSøknadsfrist;
 
   return (
     <Form
@@ -104,7 +105,7 @@ const VurderSoknadsfristForeldrepengerForm: FunctionComponent<OwnProps> = ({
           key="VurderSoknadsfristForeldrepengerForm"
           id="VurderSoknadsfristForeldrepengerForm.AksjonspunktHelpText"
           values={{
-            numberOfDays: uttakPeriodeGrense?.antallDagerLevertForSent,
+            numberOfDays: søknadsfrist?.dagerOversittetFrist,
             soknadsfristdato: soknadsfristdato ? moment(soknadsfristdato).format(DDMMYYYY_DATE_FORMAT) : '',
           }}
         />]}

--- a/packages/prosess-tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
+++ b/packages/prosess-tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
@@ -87,6 +87,7 @@ const TilkjentYtelsePanel: FunctionComponent<PureOwnProps> = ({
 }) => {
   const familiehendelseDato = useMemo(() => getFamilieHendelseDato(familieHendelseSamling), [familieHendelseSamling]);
   const vurderTilbaketrekkAP = useMemo(() => finnTilbaketrekkAksjonspunkt(aksjonspunkter), [aksjonspunkter]);
+  const soknadMottattDato = soknad.søknadsfrist?.mottattDato ? soknad.søknadsfrist?.mottattDato : soknad.mottattDato;
   return (
     <>
       <Undertittel>
@@ -96,7 +97,7 @@ const TilkjentYtelsePanel: FunctionComponent<PureOwnProps> = ({
         <TilkjentYtelse
           items={formatPerioder(beregningresultat.perioder)}
           groups={groups}
-          soknadDate={soknad.mottattDato}
+          soknadDate={soknadMottattDato}
           familiehendelseDate={familiehendelseDato}
           hovedsokerKjonnKode={personoversikt?.bruker ? personoversikt.bruker.kjønn as Kjønnkode : undefined}
           isSoknadSvangerskapspenger={fagsakYtelseTypeKode === fagsakYtelseType.SVANGERSKAPSPENGER}

--- a/packages/prosess-uttak/src/UttakProsessIndex.spec.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.spec.tsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import {
   Aksjonspunkt, AlleKodeverk, Behandling, FamilieHendelseSamling, Personoversikt,
-  Soknad, UttakPeriodeGrense, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
+  Soknad, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
 } from '@fpsak-frontend/types';
 
 import UttakPanel from './components/UttakPanel';
@@ -88,7 +88,6 @@ describe('<UttakProsessIndex>', () => {
       alleKodeverk={{} as AlleKodeverk}
       employeeHasAccess
       tempUpdateStonadskontoer={sinon.spy()}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       status=""
       vilkar={[]}

--- a/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.stories.tsx
@@ -98,20 +98,19 @@ const uttakStonadskontoer = {
   },
 } as UttakStonadskontoer;
 
-const uttakPeriodeGrense = {
-  mottattDato: '2019-11-18',
-  soknadsfristForForsteUttaksdato: '2020-01-31',
-  soknadsperiodeStart: '2019-10-14',
-  soknadsperiodeSlutt: '2020-02-02',
-  antallDagerLevertForSent: -74,
-};
-
 const soknad = {
   soknadType: 'ST-001',
   mottattDato: '2019-11-18',
   fodselsdatoer: {
     1: '2019-11-04',
   } as {[key: number]: string},
+  søknadsfrist: {
+    mottattDato: '2019-11-18',
+    utledetSøknadsfrist: '2020-01-31',
+    søknadsperiodeStart: '2019-10-14',
+    søknadsperiodeSlutt: '2020-02-02',
+    dagerOversittetFrist: -74,
+  },
 } as Soknad;
 
 const personoversikt = {
@@ -161,7 +160,6 @@ const Template: Story<{
     familiehendelse={familiehendelse}
     soknad={soknad}
     personoversikt={personoversikt}
-    uttakPeriodeGrense={uttakPeriodeGrense}
     ytelsefordeling={ytelsefordeling}
     alleKodeverk={alleKodeverk as any}
     employeeHasAccess

--- a/packages/prosess-uttak/src/UttakProsessIndex.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.tsx
@@ -3,7 +3,7 @@ import { RawIntlProvider } from 'react-intl';
 
 import {
   ArbeidsgiverOpplysningerPerId, StandardProsessPanelProps, FamilieHendelseSamling, Personoversikt,
-  Soknad, UttakPeriodeGrense, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
+  Soknad, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
 } from '@fpsak-frontend/types';
 import { createIntl } from '@navikt/ft-utils';
 import { ReduxWrapper } from '@fpsak-frontend/form';

--- a/packages/prosess-uttak/src/UttakProsessIndex.tsx
+++ b/packages/prosess-uttak/src/UttakProsessIndex.tsx
@@ -19,7 +19,6 @@ interface OwnProps {
   uttaksresultatPerioder: UttaksresultatPeriode;
   familiehendelse: FamilieHendelseSamling;
   personoversikt: Personoversikt;
-  uttakPeriodeGrense: UttakPeriodeGrense;
   ytelsefordeling: Ytelsefordeling;
   employeeHasAccess: boolean;
   tempUpdateStonadskontoer: (params: {
@@ -37,7 +36,6 @@ const UttakProsessIndex: FunctionComponent<OwnProps & StandardProsessPanelProps>
   familiehendelse,
   soknad,
   personoversikt,
-  uttakPeriodeGrense,
   ytelsefordeling,
   alleKodeverk,
   employeeHasAccess,
@@ -77,8 +75,6 @@ const UttakProsessIndex: FunctionComponent<OwnProps & StandardProsessPanelProps>
         person={personoversikt}
         // @ts-ignore
         familiehendelse={familiehendelse}
-        // @ts-ignore
-        uttakPeriodeGrense={uttakPeriodeGrense}
         // @ts-ignore
         alleKodeverk={alleKodeverk}
         // @ts-ignore

--- a/packages/prosess-uttak/src/components/Uttak.spec.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.spec.tsx
@@ -14,9 +14,10 @@ import { Tidslinje } from '@navikt/ft-tidslinje';
 import { KjønnkodeEnum } from '@fpsak-frontend/types/src/Kjonnkode';
 import {
   Aksjonspunkt, AlleKodeverk, Behandling, FamilieHendelseSamling, PeriodeSokerAktivitet, Personoversikt,
-  UttakPeriodeGrense, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
+  UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
 } from '@fpsak-frontend/types';
 
+import { Søknadsfrist } from '@fpsak-frontend/types/src/soknadTsType';
 import UttakTimeLineData from './UttakTimeLineData';
 import messages from '../../i18n/nb_NO.json';
 import { Uttak, UttaksresultatActivity, PeriodeMedClassName } from './Uttak';
@@ -74,13 +75,13 @@ describe('<Uttak>', () => {
       medsokerKjonnKode={KjønnkodeEnum.MANN}
       person={{} as Personoversikt}
       familiehendelse={{} as FamilieHendelseSamling}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       behandlingStatus={behandlingStatus.OPPRETTET}
       employeeHasAccess
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
+      søknadsfrist={{} as Søknadsfrist}
       arbeidsgiverOpplysningerPerId={{}}
     />);
     wrapper.setState({ selectedItem: null });
@@ -125,13 +126,13 @@ describe('<Uttak>', () => {
       medsokerKjonnKode={KjønnkodeEnum.MANN}
       person={{} as Personoversikt}
       familiehendelse={{} as FamilieHendelseSamling}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       behandlingStatus={behandlingStatus.OPPRETTET}
       employeeHasAccess
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
+      søknadsfrist={{} as Søknadsfrist}
       arbeidsgiverOpplysningerPerId={{}}
     />);
     wrapper.setState({
@@ -182,13 +183,13 @@ describe('<Uttak>', () => {
       medsokerKjonnKode={KjønnkodeEnum.MANN}
       person={{} as Personoversikt}
       familiehendelse={{} as FamilieHendelseSamling}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       behandlingStatus={behandlingStatus.OPPRETTET}
       employeeHasAccess={false}
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
+      søknadsfrist={{} as Søknadsfrist}
       arbeidsgiverOpplysningerPerId={{}}
     />);
     wrapper.setState({
@@ -247,13 +248,13 @@ describe('<Uttak>', () => {
       medsokerKjonnKode={KjønnkodeEnum.MANN}
       person={{} as Personoversikt}
       familiehendelse={{} as FamilieHendelseSamling}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       behandlingStatus={behandlingStatus.OPPRETTET}
       employeeHasAccess={false}
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
+      søknadsfrist={{} as Søknadsfrist}
       arbeidsgiverOpplysningerPerId={{}}
     />);
     wrapper.setState({
@@ -312,13 +313,13 @@ describe('<Uttak>', () => {
       medsokerKjonnKode={KjønnkodeEnum.MANN}
       person={{} as Personoversikt}
       familiehendelse={{} as FamilieHendelseSamling}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       behandlingStatus={behandlingStatus.OPPRETTET}
       employeeHasAccess
       uttaksresultat={{} as UttaksresultatPeriode}
       mottattDato="10.10.2020"
+      søknadsfrist={{} as Søknadsfrist}
       arbeidsgiverOpplysningerPerId={{}}
     />);
     wrapper.setState({

--- a/packages/prosess-uttak/src/components/Uttak.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.tsx
@@ -759,7 +759,7 @@ const mapStateToProps = (state: any, props: PureOwnProps) => {
     uttaksresultat,
     ytelsefordeling,
   } = props;
-  const periodeGrenseMottatDato = søknadsfrist?.mottattDato;
+  const gjeldendeMottattDato = søknadsfrist?.mottattDato ? søknadsfrist.mottattDato : mottattDato;
   const hovedsokerKjonnKode = person ? person.bruker.kjønn : undefined;
   const annenForelderUttak = uttaksresultat.perioderAnnenpart;
   const viseUttakMedsoker = annenForelderUttak.length > 0;
@@ -791,7 +791,7 @@ const mapStateToProps = (state: any, props: PureOwnProps) => {
     isRevurdering: props.behandlingType === behandlingType.REVURDERING,
     medsokerKjonnKode,
     person,
-    soknadDate: determineMottatDato(periodeGrenseMottatDato, mottattDato),
+    soknadDate: determineMottatDato(gjeldendeMottattDato, mottattDato),
     stonadskonto: formValueSelector(formName)(state, 'stonadskonto'),
     // @ts-ignore
     uttaksresultatActivity: lagUttaksresultatActivity(state, props),

--- a/packages/prosess-uttak/src/components/Uttak.tsx
+++ b/packages/prosess-uttak/src/components/Uttak.tsx
@@ -27,7 +27,7 @@ import soknadType from '@fpsak-frontend/kodeverk/src/soknadType';
 import { Tidslinje, EventProps, TidslinjeTimes } from '@navikt/ft-tidslinje';
 import {
   Aksjonspunkt, Behandling, FamilieHendelseSamling,
-  Soknad, UttakPeriodeGrense, UttaksresultatPeriode, Ytelsefordeling, Kjønnkode, AlleKodeverk,
+  Soknad, UttaksresultatPeriode, Ytelsefordeling, Kjønnkode, AlleKodeverk,
   AvklartBarn, UttakStonadskontoer, PeriodeSoker, ArbeidsgiverOpplysningerPerId, Personoversikt,
 } from '@fpsak-frontend/types';
 
@@ -103,7 +103,6 @@ interface PureOwnProps {
   manuellOverstyring: boolean;
   person: Personoversikt;
   familiehendelse: FamilieHendelseSamling;
-  uttakPeriodeGrense: UttakPeriodeGrense;
   ytelsefordeling: Ytelsefordeling;
   behandlingUuid: string;
   behandlingType: string;
@@ -116,6 +115,7 @@ interface PureOwnProps {
   uttaksresultat: UttaksresultatPeriode;
   behandlingsresultat?: Behandling['behandlingsresultat'];
   mottattDato: Soknad['mottattDato'];
+  søknadsfrist: Soknad['søknadsfrist'];
   fodselsdatoer?: Soknad['fodselsdatoer'];
   termindato?: Soknad['termindato'];
   adopsjonFodelsedatoer?: Soknad['adopsjonFodelsedatoer'];
@@ -753,13 +753,13 @@ const mapStateToProps = (state: any, props: PureOwnProps) => {
   const {
     person,
     mottattDato,
+    søknadsfrist,
     formName,
     familiehendelse,
     uttaksresultat,
-    uttakPeriodeGrense,
     ytelsefordeling,
   } = props;
-  const periodeGrenseMottatDato = uttakPeriodeGrense.mottattDato;
+  const periodeGrenseMottatDato = søknadsfrist?.mottattDato;
   const hovedsokerKjonnKode = person ? person.bruker.kjønn : undefined;
   const annenForelderUttak = uttaksresultat.perioderAnnenpart;
   const viseUttakMedsoker = annenForelderUttak.length > 0;

--- a/packages/prosess-uttak/src/components/UttakPanel.spec.tsx
+++ b/packages/prosess-uttak/src/components/UttakPanel.spec.tsx
@@ -8,7 +8,7 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { AksjonspunktHelpTextTemp } from '@navikt/ft-ui-komponenter';
 import {
   Aksjonspunkt, AlleKodeverk, FamilieHendelseSamling, Personoversikt,
-  Soknad, Stonadskonto, UttakPeriodeGrense, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
+  Soknad, Stonadskonto, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling,
 } from '@fpsak-frontend/types';
 import behandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 import behandlingStatus from '@fpsak-frontend/kodeverk/src/behandlingStatus';
@@ -121,7 +121,6 @@ describe('<UttakPanel>', () => {
       soknad={soknad}
       familiehendelse={{} as FamilieHendelseSamling}
       person={{} as Personoversikt}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       alleKodeverk={kodeverk}
@@ -167,7 +166,6 @@ describe('<UttakPanel>', () => {
       soknad={soknad}
       familiehendelse={{} as FamilieHendelseSamling}
       person={{} as Personoversikt}
-      uttakPeriodeGrense={{} as UttakPeriodeGrense}
       ytelsefordeling={{} as Ytelsefordeling}
       behandlingType={behandlingType.FORSTEGANGSSOKNAD}
       alleKodeverk={kodeverk}

--- a/packages/prosess-uttak/src/components/UttakPanel.tsx
+++ b/packages/prosess-uttak/src/components/UttakPanel.tsx
@@ -13,7 +13,7 @@ import { stonadskontoType, uttakPeriodeNavn } from '@fpsak-frontend/kodeverk/src
 import periodeResultatType from '@fpsak-frontend/kodeverk/src/periodeResultatType';
 import {
   Aksjonspunkt, ArbeidsgiverOpplysningerPerId, Behandling, FamilieHendelseSamling, AlleKodeverk,
-  Soknad, UttakPeriodeGrense, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling, Stonadskonto, Personoversikt,
+  Soknad, UttaksresultatPeriode, UttakStonadskontoer, Ytelsefordeling, Stonadskonto, Personoversikt,
 } from '@fpsak-frontend/types';
 import { UttakAp } from '@fpsak-frontend/types-avklar-aksjonspunkter';
 import { validerApKodeOgHentApEnum } from '@fpsak-frontend/prosess-felles';
@@ -94,7 +94,6 @@ interface PureOwnProps {
   soknad: Soknad;
   person: Personoversikt;
   familiehendelse: FamilieHendelseSamling;
-  uttakPeriodeGrense: UttakPeriodeGrense;
   alleKodeverk: AlleKodeverk;
   ytelsefordeling: Ytelsefordeling;
   tempUpdateStonadskontoer: (params: {
@@ -122,7 +121,6 @@ export const UttakPanelImpl: FunctionComponent<PureOwnProps & MappedOwnProps & W
   soknad,
   person,
   familiehendelse,
-  uttakPeriodeGrense,
   ytelsefordeling,
   behandlingUuid,
   behandlingType,
@@ -162,7 +160,6 @@ export const UttakPanelImpl: FunctionComponent<PureOwnProps & MappedOwnProps & W
           manuellOverstyring={manuellOverstyring}
           person={person}
           familiehendelse={familiehendelse}
-          uttakPeriodeGrense={uttakPeriodeGrense}
           ytelsefordeling={ytelsefordeling}
           behandlingUuid={behandlingUuid}
           behandlingType={behandlingType}
@@ -175,6 +172,7 @@ export const UttakPanelImpl: FunctionComponent<PureOwnProps & MappedOwnProps & W
           uttaksresultat={uttaksresultat}
           behandlingsresultat={behandlingsresultat}
           mottattDato={soknad.mottattDato}
+          søknadsfrist={soknad.søknadsfrist}
           fodselsdatoer={soknad.fodselsdatoer}
           termindato={soknad.termindato}
           adopsjonFodelsedatoer={soknad.adopsjonFodelsedatoer}

--- a/packages/prosess-vedtak/src/VedtakProsessIndex.stories.tsx
+++ b/packages/prosess-vedtak/src/VedtakProsessIndex.stories.tsx
@@ -541,7 +541,6 @@ AvslåttForRevurderingForeldrepengerDerSøknadsfristvilkåretIkkeErOppfylt.args 
     vilkarType: vilkarType.SOKNADFRISTVILKARET,
     vilkarStatus: vilkarUtfallType.IKKE_OPPFYLT,
     overstyrbar: true,
-    merknadParametere: {},
   }],
   isReadOnly: false,
   submitCallback: action('button-click') as (data: any) => Promise<any>,

--- a/packages/prosess-vilkar-soknadsfrist/src/SoknadsfristVilkarProsessIndex.stories.tsx
+++ b/packages/prosess-vilkar-soknadsfrist/src/SoknadsfristVilkarProsessIndex.stories.tsx
@@ -25,9 +25,6 @@ const defaultBehandling = {
 
 const vilkar = [{
   vilkarType: vilkarType.SOKNADFRISTVILKARET,
-  merknadParametere: {
-    antallDagerSoeknadLevertForSent: '2',
-  },
 }] as Vilkar[];
 
 const soknad = {
@@ -35,6 +32,11 @@ const soknad = {
   mottattDato: '2019-01-01',
   fodselsdatoer: { 1: '2019-01-01' } as {[key: number]: string},
   begrunnelseForSenInnsending: 'Dette er en begrunnelse',
+  søknadsfrist: {
+    mottattDato: '2019-01-01',
+    utledetSøknadsfrist: '2019-07-01',
+    dagerOversittetFrist: 2,
+  },
 } as Soknad;
 
 const familiehendelse = {

--- a/packages/prosess-vilkar-soknadsfrist/src/SoknadsfristVilkarProsessIndex.tsx
+++ b/packages/prosess-vilkar-soknadsfrist/src/SoknadsfristVilkarProsessIndex.tsx
@@ -16,7 +16,6 @@ interface OwnProps {
 
 const SoknadsfristVilkarProsessIndex: FunctionComponent<OwnProps & StandardProsessPanelProps> = ({
   behandling,
-  vilkar,
   soknad,
   familiehendelse,
   aksjonspunkter,
@@ -31,7 +30,6 @@ const SoknadsfristVilkarProsessIndex: FunctionComponent<OwnProps & StandardProse
   <RawIntlProvider value={intl}>
     <ErSoknadsfristVilkaretOppfyltForm
       behandlingsresultat={behandling.behandlingsresultat}
-      vilkar={vilkar}
       soknad={soknad}
       gjeldendeFamiliehendelse={familiehendelse.gjeldende}
       aksjonspunkter={aksjonspunkter}

--- a/packages/prosess-vilkar-soknadsfrist/src/components/ErSoknadsfristVilkaretOppfyltForm.tsx
+++ b/packages/prosess-vilkar-soknadsfrist/src/components/ErSoknadsfristVilkaretOppfyltForm.tsx
@@ -20,7 +20,7 @@ import {
   ProsessStegBegrunnelseTextFieldNew, ProsessStegSubmitButtonNew,
 } from '@fpsak-frontend/prosess-felles';
 import {
-  Aksjonspunkt, AlleKodeverk, Behandling, FamilieHendelse, Soknad, Vilkar,
+  Aksjonspunkt, AlleKodeverk, Behandling, FamilieHendelse, Soknad,
 } from '@fpsak-frontend/types';
 import AksjonspunktKode from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import SoknadsfristAp from '@fpsak-frontend/types-avklar-aksjonspunkter/src/prosess/SoknadsfristAp';
@@ -30,7 +30,7 @@ import styles from './erSoknadsfristVilkaretOppfyltForm.less';
 const findRadioButtonTextCode = (erVilkarOk?: boolean): string => (erVilkarOk
   ? 'ErSoknadsfristVilkaretOppfyltForm.VilkarOppfylt' : 'ErSoknadsfristVilkaretOppfyltForm.VilkarIkkeOppfylt');
 
-const findSoknadsfristDate = (mottattDato: string, antallDagerSoknadLevertForSent?: string): string => (
+const findSoknadsfristDate = (mottattDato: string, antallDagerSoknadLevertForSent?: number): string => (
   moment(mottattDato)
     .subtract(antallDagerSoknadLevertForSent, 'days')
     .format(ISO_DATE_FORMAT)
@@ -83,7 +83,6 @@ const transformValues = (values: Required<FormValues>): SoknadsfristAp => ({
 
 interface OwnProps {
   behandlingsresultat?: Behandling['behandlingsresultat'];
-  vilkar: Vilkar[];
   soknad: Soknad;
   gjeldendeFamiliehendelse: FamilieHendelse;
   aksjonspunkter: Aksjonspunkt[];
@@ -106,7 +105,6 @@ const ErSoknadsfristVilkaretOppfyltForm: FunctionComponent<OwnProps> = ({
   readOnlySubmitButton,
   soknad,
   gjeldendeFamiliehendelse,
-  vilkar,
   behandlingsresultat,
   alleKodeverk,
   aksjonspunkter,
@@ -128,9 +126,7 @@ const ErSoknadsfristVilkaretOppfyltForm: FunctionComponent<OwnProps> = ({
 
   const erVilkarOk = formMethods.watch('erVilkarOk');
 
-  const vilkarCodes = aksjonspunkter.flatMap((a) => (a.vilkarType ? [a.vilkarType] : []));
-  const funnetVilkar = vilkar.find((v) => vilkarCodes.includes(v.vilkarType));
-  const antallDagerSoknadLevertForSent = funnetVilkar?.merknadParametere.antallDagerSoeknadLevertForSent;
+  const antallDagerSoknadLevertForSent = soknad?.søknadsfrist?.dagerOversittetFrist;
 
   const hasAksjonspunkt = aksjonspunkter.length > 0;
 

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -78,7 +78,6 @@ export type {
   default as Opptjening, OpptjeningAktivitet, FastsattOpptjening, FastsattOpptjeningAktivitet,
 } from './src/opptjeningTsType';
 export type { default as TilbakekrevingValg } from './src/tilbakekrevingValgTsType';
-export type { default as UttakPeriodeGrense } from './src/uttakPeriodeGrenseTsType';
 export type { default as TotrinnskontrollAksjonspunkt, OpptjeningAktiviteter } from './src/totrinnskontrollAksjonspunktTsType';
 export type { default as TotrinnskontrollSkjermlenkeContext } from './src/totrinnskontrollSkjermlenkeContextTsType';
 export type {

--- a/packages/types/src/soknadTsType.ts
+++ b/packages/types/src/soknadTsType.ts
@@ -10,6 +10,14 @@ export type UtlandsoppholdPeriode = Readonly<{
   tom: string;
 }>
 
+export type Søknadsfrist = Readonly<{
+  mottattDato?: string;
+  utledetSøknadsfrist?: string;
+  søknadsperiodeStart?: string;
+  søknadsperiodeSlutt?: string;
+  dagerOversittetFrist?: number;
+}>
+
 type Soknad = Readonly<{
   soknadType: string;
   mottattDato: string;
@@ -26,6 +34,7 @@ type Soknad = Readonly<{
   oppgittFordeling: {
     startDatoForPermisjon?: string;
   };
+  søknadsfrist: Søknadsfrist;
   utstedtdato?: string;
   termindato?: string;
   fodselsdatoer?: Record<number, string>;

--- a/packages/types/src/uttakPeriodeGrenseTsType.tsx
+++ b/packages/types/src/uttakPeriodeGrenseTsType.tsx
@@ -1,9 +1,0 @@
-type UttakPeriodeGrense = {
-  mottattDato: string;
-  soknadsfristForForsteUttaksdato: string;
-  soknadsperiodeStart: string;
-  soknadsperiodeSlutt: string;
-  antallDagerLevertForSent: number;
-};
-
-export default UttakPeriodeGrense;

--- a/packages/types/src/vilkarTsType.ts
+++ b/packages/types/src/vilkarTsType.ts
@@ -1,9 +1,6 @@
 type Vilkar = Readonly<{
   vilkarType: string;
   vilkarStatus: string;
-  merknadParametere: {
-    antallDagerSoeknadLevertForSent?: string;
-  };
   avslagKode?: string;
   lovReferanse?: string;
   overstyrbar: boolean;


### PR DESCRIPTION
Uttakperiodegrense er i praksis en overstyrt/gjeldende søknad.mottattDato
* Legger inn overstyrt søknadMottatt, perioder og frister i soknadTsType / søknadsfrist
* Standardiserer bruk av mottattdato i søknadsfristpanelene
* fjerner uttakPeriodeGrense
* Legger til overstyrt mottatt dato i tilkjent ytelse
