### PR TITLE
TFP-4873 vise nye/endret perioder som tom kilde

### DIFF
--- a/packages/fakta-uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta-uttak/src/UttakFaktaIndex.spec.tsx
@@ -55,7 +55,7 @@ describe('<UttakFaktaIndex>', () => {
         fom: '2022-11-12',
         tom: '2022-12-01',
         originalFom: '2022-11-12',
-        periodeKilde: 'SØKNAD',
+        periodeKilde: 'SAKSBEHANDLER',
         samtidigUttaksprosent: '10',
         uttakPeriodeType: 'MØDREKVOTE',
         arbeidsforhold: undefined,

--- a/packages/fakta-uttak/src/UttakFaktaIndex.stories.tsx
+++ b/packages/fakta-uttak/src/UttakFaktaIndex.stories.tsx
@@ -356,7 +356,7 @@ VisPanelDerAksjonspunktErLøstOgBehandlingAvsluttet.args = {
     samtidigUttaksprosent: 50,
     morsAktivitet: 'ARBEID',
     flerbarnsdager: true,
-    periodeKilde: 'SØKNAD',
+    periodeKilde: 'SAKSBEHANDLER',
   }],
   submitCallback: action('button-click') as (data: any) => Promise<any>,
   kanOverstyre: false,

--- a/packages/fakta-uttak/src/components/UttakFaktaDetailForm.tsx
+++ b/packages/fakta-uttak/src/components/UttakFaktaDetailForm.tsx
@@ -126,7 +126,7 @@ const transformValues = (values: FormValues): KontrollerFaktaPeriodeMedApMarkeri
     arbeidsgiverReferanse: values.arbeidsgiverId.split('-')[0],
     arbeidType: values.arbeidsgiverId.split('-')[1],
   } : undefined,
-  periodeKilde: FordelingPeriodeKilde.SØKNAD,
+  periodeKilde: FordelingPeriodeKilde.SAKSBEHANDLER,
   aksjonspunktType: undefined,
 });
 

--- a/packages/fakta-uttak/src/components/UttakFaktaTable.tsx
+++ b/packages/fakta-uttak/src/components/UttakFaktaTable.tsx
@@ -17,6 +17,7 @@ import UttakFaktaDetailForm from './UttakFaktaDetailForm';
 import KontrollerFaktaPeriodeMedApMarkering from '../typer/kontrollerFaktaPeriodeMedApMarkering';
 
 import styles from './uttakFaktaTable.less';
+import FordelingPeriodeKilde from '../kodeverk/fordelingPeriodeKilde';
 
 const HEADER_TEXT_CODES = [
   'UttakFaktaTable.Periode',
@@ -45,6 +46,13 @@ const getTextId = (weeks?: number, days?: number): string => {
   }
   return id;
 };
+
+const getKildenavnForVisning = (alleKodeverk: AlleKodeverk, periode?: KontrollerFaktaPeriodeMedApMarkering): string => {
+  if (periode.periodeKilde === FordelingPeriodeKilde.SAKSBEHANDLER) {
+    return '';
+  }
+  return alleKodeverk[KodeverkType.FORDELING_PERIODE_KILDE].find((k) => k.kode === periode.periodeKilde)?.navn;
+}
 
 const getUttakPeriode = (
   alleKodeverk: AlleKodeverk,
@@ -130,9 +138,7 @@ const UttakFaktaTable: FunctionComponent<OwnProps> = ({
                 />
               </TableColumn>
               <TableColumn>{getUttakPeriode(alleKodeverk, periode.uttakPeriodeType, periode.oppholdÅrsak)}</TableColumn>
-              <TableColumn>
-                {alleKodeverk[KodeverkType.FORDELING_PERIODE_KILDE].find((k) => k.kode === periode.periodeKilde)?.navn}
-              </TableColumn>
+              <TableColumn>{getKildenavnForVisning(alleKodeverk, periode)}</TableColumn>
             </>
           );
 

--- a/packages/fakta-uttak/src/components/UttakFaktaTable.tsx
+++ b/packages/fakta-uttak/src/components/UttakFaktaTable.tsx
@@ -52,7 +52,7 @@ const getKildenavnForVisning = (alleKodeverk: AlleKodeverk, periode?: Kontroller
     return '';
   }
   return alleKodeverk[KodeverkType.FORDELING_PERIODE_KILDE].find((k) => k.kode === periode.periodeKilde)?.navn;
-}
+};
 
 const getUttakPeriode = (
   alleKodeverk: AlleKodeverk,

--- a/packages/fakta-uttak/src/kodeverk/fordelingPeriodeKilde.ts
+++ b/packages/fakta-uttak/src/kodeverk/fordelingPeriodeKilde.ts
@@ -1,5 +1,6 @@
 enum FordelingPeriodeKilde {
   SØKNAD = 'SØKNAD',
+  SAKSBEHANDLER = 'SAKSBEHANDLER',
 }
 
 export default FordelingPeriodeKilde;

--- a/packages/storybook-utils/mocks/alleKodeverk.json
+++ b/packages/storybook-utils/mocks/alleKodeverk.json
@@ -2520,6 +2520,11 @@
       "kode": "ANDRE_NAV_VEDTAK",
       "kodeverk": "FORDELING_PERIODE_KILDE",
       "navn": "Vedtak andre ytelser"
+    },
+    {
+      "kode": "SAKSBEHANDLER",
+      "kodeverk": "SAKSBEHANDLER",
+      "navn": "Endret eller lagt til av saksbehandler i denne behandlingen"
     }
   ],
   "KlageVurderingOmgjør": [


### PR DESCRIPTION
@tor-nav du får nesten sanity-sjekke dette

Tanken er: 
* Backend setter kilde = SAKSBEHANDLER dersom ny/endret i denne behandlingen
* Frontend viser kilde = '' dersom kilde === SAKSBEHANDLER 
* Frontend bruker SAKSBEHANDLER for nye og endrete perioder