### PR TITLE
Håndtere opprettet løpende og utført vanlig medlemskap

### DIFF
--- a/packages/fakta-medlemskap/src/MedlemskapFaktaIndex.spec.tsx
+++ b/packages/fakta-medlemskap/src/MedlemskapFaktaIndex.spec.tsx
@@ -259,7 +259,7 @@ describe('<MedlemskapFaktaIndex>', () => {
         vurderingsdato: '2019-11-07',
         årsaker: ['SKJÆRINGSTIDSPUNKT'],
       }],
-      kode: AksjonspunktCode.AVKLAR_OM_BRUKER_ER_BOSATT,
+      kode: AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP,
     }, {
       begrunnelse: '',
       bekreftedePerioder: [{
@@ -284,7 +284,7 @@ describe('<MedlemskapFaktaIndex>', () => {
         vurderingsdato: '2017-10-05',
         årsaker: ['SKJÆRINGSTIDSPUNKT'],
       }],
-      kode: AksjonspunktCode.AVKLAR_LOVLIG_OPPHOLD,
+      kode: AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP,
     }, {
       begrunnelse: '',
       bekreftedePerioder: [{

--- a/packages/fakta-medlemskap/src/MedlemskapFaktaIndex.spec.tsx
+++ b/packages/fakta-medlemskap/src/MedlemskapFaktaIndex.spec.tsx
@@ -241,53 +241,6 @@ describe('<MedlemskapFaktaIndex>', () => {
     expect(lagreVurdering).toHaveBeenNthCalledWith(1, [{
       begrunnelse: '',
       bekreftedePerioder: [{
-        aksjonspunkter: [AksjonspunktCode.AVKLAR_OM_BRUKER_ER_BOSATT],
-        begrunnelse: 'Dette er en begrunnelse',
-        bosattVurdering: true,
-        medlemskapManuellVurderingType: undefined,
-        personopplysningBruker: {
-          adresser: [{
-            adresseType: 'BOSTEDSADRESSE',
-            adresselinje1: 'Skogvegen 3',
-            land: 'NOR',
-            postNummer: '4353',
-            poststed: 'Klepp Stasjon',
-          }],
-          personstatus: 'BOSA',
-          region: 'NORDEN',
-        },
-        vurderingsdato: '2019-11-07',
-        årsaker: ['SKJÆRINGSTIDSPUNKT'],
-      }],
-      kode: AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP,
-    }, {
-      begrunnelse: '',
-      bekreftedePerioder: [{
-        aksjonspunkter: [AksjonspunktCode.AVKLAR_LOVLIG_OPPHOLD],
-        begrunnelse: 'Dette er en begrunnelse',
-        bosattVurdering: undefined,
-        erEosBorger: false,
-        lovligOppholdVurdering: true,
-        medlemskapManuellVurderingType: undefined,
-        oppholdsrettVurdering: undefined,
-        personopplysningBruker: {
-          adresser: [{
-            adresseType: 'BOSTEDSADRESSE',
-            adresselinje1: 'Skogvegen 3',
-            land: 'NOR',
-            postNummer: '4353',
-            poststed: 'Klepp Stasjon',
-          }],
-          personstatus: 'BOSA',
-          region: 'NORDEN',
-        },
-        vurderingsdato: '2017-10-05',
-        årsaker: ['SKJÆRINGSTIDSPUNKT'],
-      }],
-      kode: AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP,
-    }, {
-      begrunnelse: '',
-      bekreftedePerioder: [{
         aksjonspunkter: [AksjonspunktCode.AVKLAR_LOVLIG_OPPHOLD],
         begrunnelse: 'Dette er en begrunnelse',
         bosattVurdering: undefined,

--- a/packages/fakta-medlemskap/src/MedlemskapFaktaIndex.stories.tsx
+++ b/packages/fakta-medlemskap/src/MedlemskapFaktaIndex.stories.tsx
@@ -398,13 +398,13 @@ AvklarFortsattMedlemskap.args = {
   },
   aksjonspunkter: [{
     definisjon: aksjonspunktCodes.AVKLAR_OM_BRUKER_ER_BOSATT,
-    status: aksjonspunktStatus.OPPRETTET,
+    status: aksjonspunktStatus.UTFORT,
     begrunnelse: undefined,
     kanLoses: true,
     erAktivt: true,
   }, {
     definisjon: aksjonspunktCodes.AVKLAR_LOVLIG_OPPHOLD,
-    status: aksjonspunktStatus.OPPRETTET,
+    status: aksjonspunktStatus.UTFORT,
     begrunnelse: undefined,
     kanLoses: true,
     erAktivt: true,

--- a/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
+++ b/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
@@ -42,11 +42,10 @@ const transformValues = (
   perioder: MedlemPeriode[],
   aksjonspunkter: Aksjonspunkt[],
 ): AksjonspunktData => {
-  const aktiveInngangsAksjonspunkter = aksjonspunkter
-    .filter((ap) => inngangsAksjonspunkter.some((kode) => kode === ap.definisjon));
-  const harÅpneInngangsAksjonspunkter = aktiveInngangsAksjonspunkter.filter((ap) => isAksjonspunktOpen(ap.status)).length > 0;
-  const aktivtFortsattMedlemskapAksjonspunkt = aksjonspunkter
-    .filter((ap) => ap.definisjon === AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP);
+  const aktiveInngangsAksjonspunkter = aksjonspunkter.filter((ap) => inngangsAksjonspunkter.some((kode) => kode === ap.definisjon));
+  const harÅpneInngangsAksjonspunkter = aktiveInngangsAksjonspunkter.some((ap) => isAksjonspunktOpen(ap.status));
+  const aktivtFortsattMedlemskapAksjonspunkt = aksjonspunkter.filter((ap) => ap.definisjon === AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP);
+
   // Submit inngangsaksjonspunkt dersom åpent eller det ikke finnes aksjonspunkt fortsatt medlemskap
   const sendInnAksjonspunkter = harÅpneInngangsAksjonspunkter || aktivtFortsattMedlemskapAksjonspunkt.length === 0
     ? aktiveInngangsAksjonspunkter : aktivtFortsattMedlemskapAksjonspunkt;

--- a/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
+++ b/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading, Button } from '@navikt/ds-react';
 import { Aksjonspunkt } from '@navikt/ft-types';
 import { AksjonspunktHelpTextHTML, VerticalSpacer } from '@navikt/ft-ui-komponenter';
-import { AksjonspunktStatus } from '@navikt/ft-kodeverk';
+import { AksjonspunktStatus , isAksjonspunktOpen } from '@navikt/ft-kodeverk';
 
 import {
   AlleKodeverk, Medlemskap, Soknad, MedlemPeriode,
@@ -45,6 +45,7 @@ const transformValues = (
 ): AksjonspunktData => {
   const aktiveMedlemAksjonspunkter = aksjonspunkter
     .filter((ap) => medlemAksjonspunkter.some((kode) => kode === ap.definisjon))
+    .filter((ap) => isAksjonspunktOpen(ap.status))
     .filter((ap) => ap.erAktivt);
 
   // @ts-ignore Fiks

--- a/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
+++ b/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { Heading, Button } from '@navikt/ds-react';
 import { Aksjonspunkt } from '@navikt/ft-types';
 import { AksjonspunktHelpTextHTML, VerticalSpacer } from '@navikt/ft-ui-komponenter';
-import { AksjonspunktStatus , isAksjonspunktOpen } from '@navikt/ft-kodeverk';
+import { AksjonspunktStatus, isAksjonspunktOpen } from '@navikt/ft-kodeverk';
 
 import {
   AlleKodeverk, Medlemskap, Soknad, MedlemPeriode,

--- a/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
+++ b/packages/fakta-medlemskap/src/components/MedlemskapInfoPanel.tsx
@@ -48,8 +48,8 @@ const transformValues = (
   const aktivtFortsattMedlemskapAksjonspunkt = aksjonspunkter
     .filter((ap) => ap.definisjon === AksjonspunktCode.AVKLAR_FORTSATT_MEDLEMSKAP);
   // Submit inngangsaksjonspunkt dersom åpent eller det ikke finnes aksjonspunkt fortsatt medlemskap
-  const sendInnAksjonspunkter = harÅpneInngangsAksjonspunkter || aktivtFortsattMedlemskapAksjonspunkt.length === 0 ?
-    aktiveInngangsAksjonspunkter : aktivtFortsattMedlemskapAksjonspunkt;
+  const sendInnAksjonspunkter = harÅpneInngangsAksjonspunkter || aktivtFortsattMedlemskapAksjonspunkt.length === 0
+    ? aktiveInngangsAksjonspunkter : aktivtFortsattMedlemskapAksjonspunkt;
 
   // @ts-ignore Fiks
   return sendInnAksjonspunkter.map((ap) => ({


### PR DESCRIPTION
Feltet "erAktivt" i aksjonspunkt er true både for åpne og utførte aksjonspunkt (og slik har det vært siden 2019 ...).
Når 5019 (vanlig medlemskap) er utført og 5053 (løpende) er åpent så lagrer man begge to 
Dermed hoppes det tilbake til medlemskap -> evig løkke.
