### PR TITLE
TFP-4975 historikk for avklart dødsdato

### DIFF
--- a/packages/sak-historikk/i18n/nb_NO.json
+++ b/packages/sak-historikk/i18n/nb_NO.json
@@ -4,6 +4,7 @@
   "Historikk.Foreldreansvar": "Foreldreansvaret",
   "Historikk.Anvendes": "Vilkår som anvendes",
   "Historikk.SokersOpplysningsplikt": "Søkers opplysningsplikt",
+  "Historikk.Fodsel.Dødsdato": "Dødsdato",
   "Historikk.Fodsel.DokumentasjonForeligger": "Dokumentasjon foreligger",
   "Historikk.Fodsel.BrukAntallIYtelsesvedtaket": "Bruk antall fra vedtaket",
   "Historikk.Fodsel.BrukAntallISoknad": "Bruk antall fra søknad",

--- a/packages/sak-historikk/src/kodeverk/historikkEndretFeltTypeCodes.tsx
+++ b/packages/sak-historikk/src/kodeverk/historikkEndretFeltTypeCodes.tsx
@@ -48,6 +48,10 @@ const historikkEndretFeltTypeCodes = {
     kode: 'BRUTTO_NAERINGSINNTEKT',
     feltId: 'HistorikkEndretFelt.FastsettSelvstendigNaeringForm.BruttoBerGr',
   },
+  DODSDATO: {
+    kode: 'DODSDATO',
+    feltId: 'Historikk.Fodsel.Dødsdato',
+  },
   DOKUMENTASJON_FORELIGGER: {
     kode: 'DOKUMENTASJON_FORELIGGER',
     feltId: 'Historikk.Fodsel.DokumentasjonForeligger',

--- a/packages/storybook-utils/mocks/alleKodeverk.json
+++ b/packages/storybook-utils/mocks/alleKodeverk.json
@@ -4264,6 +4264,11 @@
       "navn": "Nytt refusjonskrav"
     },
     {
+      "kode": "DODSDATO",
+      "kodeverk": "HISTORIKK_ENDRET_FELT_TYPE",
+      "navn": "Dødsdato"
+    },
+    {
       "kode": "DOKUMENTASJON_FORELIGGER",
       "kodeverk": "HISTORIKK_ENDRET_FELT_TYPE",
       "navn": "Dokumentasjon foreligger"


### PR DESCRIPTION
Legger til nytt historikkfelt fra backend.
@pekern kan du se noe av frontendkoden for FodselInfoPanel m/deler som tilsier at gjeldende dødsdato ikke er populert i formen? 
Fra TFP: "... dødsdato på barnet. Det er ikke mulig å se det i "fakta om fødsel" eller i historikkinnslaget." 
Såvidt jeg ser av eksempler så er dødsdato utfylt i readOnly-modus - men litt usikker på hva som er prepopulert hvis man i samme behandling først løser aksjonspunkt med dødsdato og så går tilbake og prøver løse aksjonspunktet på nytt ....

Fra DEV: Sak 352012696 oppfører seg som forventet når man løser aksjonspunkt på nytt. Datoer er fylt ut. Bruker den til testing