### PR TITLE
Forskjellig tekst for aksjonspunkt 5031 og 5032

### DIFF
--- a/apps/fp-frontend-app/i18n/nb_NO.json
+++ b/apps/fp-frontend-app/i18n/nb_NO.json
@@ -104,12 +104,10 @@
   "Behandlingspunkt.Beregning": "Beregning",
   "Behandlingspunkt.Soknadsfristvilkaret": "Søknadsfrist",
 
-  "AdopsjonVilkarForm.VurderGjelderSammeBarn": "Vurder om tidligere utbetalte foreldrepenger eller engangsstønad gjelder for samme barn. Dersom det gjelder for samme barn er dette vilkåret ikke oppfylt.",
-  "FodselVilkarForm.VurderGjelderSammeBarn": "Vurder om tidligere utbetalte foreldrepenger eller engangsstønad gjelder for samme barn. Dersom det gjelder for samme barn er dette vilkåret ikke oppfylt.",
-  "ErForeldreansvarVilkaarOppfyltForm.Vurder": "Vurder om tidligere utbetalte foreldrepenger eller engangsstønad gjelder for samme barn. Dersom det gjelder for samme barn er dette vilkåret ikke oppfylt.",
+  "SRBVilkarForm.VurderSammeBarn": "Vurder om tidligere utbetalte foreldrepenger eller engangsstønad gjelder for samme barn. Dersom det gjelder for samme barn er dette vilkåret ikke oppfylt.",
+  "SRBVilkarForm.VurderAnnenForelderSammeBarn": "Vurder om annen forelders foreldrepenger eller engangsstønad gjelder samme barn og påvirker utfall.",
   "ErForeldreansvarVilkaarOppfyltForm.2LeddParagrafEngangsStonad": "Vurder om vilkår om foreldreansvaret etter § 14-17 andre ledd er oppfylt",
   "ErForeldreansvarVilkaarOppfyltForm.4LeddParagraf": "Vurder om vilkårene i § 14-17 fjerde ledd for far er oppfylt (når far overtar foreldreansvaret alene)",
-  "ErOmsorgVilkaarOppfyltForm.Vurder": "Vurder om tidligere utbetalte foreldrepenger eller engangsstønad gjelder for samme barn. Dersom det gjelder for samme barn er dette vilkåret ikke oppfylt.",
   "ErOmsorgVilkaarOppfyltForm.Paragraf": "Vurder om vilkårene i § 14-17 tredje ledd for far er oppfylt (når mor dør ifm fødsel/omsorgsovertakelse)",
 
   "ArbeidsforholdInfoPanel.Title": "Arbeidsforhold",

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/inngangsvilkarPaneler/AdopsjonInngangsvilkarInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/inngangsvilkarPaneler/AdopsjonInngangsvilkarInitPanel.tsx
@@ -1,16 +1,26 @@
 import React, { FunctionComponent } from 'react';
-import { useIntl } from 'react-intl';
+import { IntlShape, useIntl } from 'react-intl';
 
 import { VilkarType } from '@navikt/ft-kodeverk';
 import { VerticalSpacer } from '@navikt/ft-ui-komponenter';
 
 import { AksjonspunktCode } from '@navikt/fp-kodeverk';
 import { AdopsjonVilkarProsessIndex } from '@navikt/fp-prosess-vilkar-adopsjon';
-import { AksessRettigheter } from '@navikt/fp-types';
+import { Aksjonspunkt, AksessRettigheter } from '@navikt/fp-types';
 
 import InngangsvilkarPanelInitProps from '../../../felles/typer/inngangsvilkarPanelInitProps';
 import InngangsvilkarDefaultInitPanel from '../../../felles/prosess/InngangsvilkarDefaultInitPanel';
 import OverstyringPanelDef from '../../../felles/prosess/OverstyringPanelDef';
+
+const AKSJONSPUNKT_TEKST_PER_KODE = {
+  [AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderSammeBarn',
+  [AksjonspunktCode.AVKLAR_OM_STONAD_TIL_ANNEN_FORELDER_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderAnnenForelderSammeBarn',
+} as Record<string, string>;
+
+const hentAksjonspunktTekst = (intl: IntlShape, aksjonspunkter: Aksjonspunkt[] = []): string =>
+  aksjonspunkter.length > 0
+    ? intl.formatMessage({ id: AKSJONSPUNKT_TEKST_PER_KODE[aksjonspunkter[0].definisjon] })
+    : '';
 
 const AKSJONSPUNKT_KODER = [
   AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN,
@@ -37,7 +47,7 @@ const AdopsjonInngangsvilkarInitPanel: FunctionComponent<OwnProps & Inngangsvilk
       aksjonspunktKoder={AKSJONSPUNKT_KODER}
       vilkarKoder={VILKAR_KODER}
       inngangsvilkarPanelKode="ADOPSJON"
-      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'AdopsjonVilkarForm.VurderGjelderSammeBarn' })}
+      hentInngangsvilkarPanelTekst={data => hentAksjonspunktTekst(intl, data.aksjonspunkter)}
       renderPanel={(data, erOverstyrt, toggleOverstyring) => (
         <>
           {data.aksjonspunkter.length === 0 && (

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/inngangsvilkarPaneler/FodselInngangsvilkarInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/inngangsvilkarPaneler/FodselInngangsvilkarInitPanel.tsx
@@ -1,14 +1,24 @@
 import React, { FunctionComponent } from 'react';
-import { useIntl } from 'react-intl';
+import { IntlShape, useIntl } from 'react-intl';
 
 import { VerticalSpacer } from '@navikt/ft-ui-komponenter';
 import { AksjonspunktCode, VilkarType, fagsakYtelseType } from '@navikt/fp-kodeverk';
 import { FodselVilkarProsessIndex } from '@navikt/fp-prosess-vilkar-fodsel';
-import { AksessRettigheter } from '@navikt/fp-types';
+import { Aksjonspunkt, AksessRettigheter } from '@navikt/fp-types';
 
 import InngangsvilkarPanelInitProps from '../../../felles/typer/inngangsvilkarPanelInitProps';
 import InngangsvilkarDefaultInitPanel from '../../../felles/prosess/InngangsvilkarDefaultInitPanel';
 import OverstyringPanelDef from '../../../felles/prosess/OverstyringPanelDef';
+
+const AKSJONSPUNKT_TEKST_PER_KODE = {
+  [AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderSammeBarn',
+  [AksjonspunktCode.AVKLAR_OM_STONAD_TIL_ANNEN_FORELDER_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderAnnenForelderSammeBarn',
+} as Record<string, string>;
+
+const hentAksjonspunktTekst = (intl: IntlShape, aksjonspunkter: Aksjonspunkt[] = []): string =>
+  aksjonspunkter.length > 0
+    ? intl.formatMessage({ id: AKSJONSPUNKT_TEKST_PER_KODE[aksjonspunkter[0].definisjon] })
+    : '';
 
 const AKSJONSPUNKT_KODER = [
   AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN,
@@ -35,7 +45,7 @@ const FodselInngangsvilkarInitPanel: FunctionComponent<OwnProps & Inngangsvilkar
       aksjonspunktKoder={AKSJONSPUNKT_KODER}
       vilkarKoder={VILKAR_KODER}
       inngangsvilkarPanelKode="FODSEL"
-      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'FodselVilkarForm.VurderGjelderSammeBarn' })}
+      hentInngangsvilkarPanelTekst={data => hentAksjonspunktTekst(intl, data.aksjonspunkter)}
       renderPanel={(data, erOverstyrt, toggleOverstyring) => (
         <>
           {data.aksjonspunkter.length === 0 && (

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/inngangsvilkarPaneler/OmsorgInngangsvilkarInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/inngangsvilkarPaneler/OmsorgInngangsvilkarInitPanel.tsx
@@ -10,8 +10,8 @@ import InngangsvilkarDefaultInitPanel from '../../../felles/prosess/Inngangsvilk
 
 const AKSJONSPUNKT_TEKST_PER_KODE = {
   [AksjonspunktCode.MANUELL_VURDERING_AV_OMSORGSVILKARET]: 'ErOmsorgVilkaarOppfyltForm.Paragraf',
-  [AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN]: 'ErOmsorgVilkaarOppfyltForm.Vurder',
-  [AksjonspunktCode.AVKLAR_OM_STONAD_TIL_ANNEN_FORELDER_GJELDER_SAMME_BARN]: 'ErOmsorgVilkaarOppfyltForm.Vurder',
+  [AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderSammeBarn',
+  [AksjonspunktCode.AVKLAR_OM_STONAD_TIL_ANNEN_FORELDER_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderAnnenForelderSammeBarn',
 } as Record<string, string>;
 
 const hentAksjonspunktTekst = (intl: IntlShape, aksjonspunkter: Aksjonspunkt[] = []): string =>

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/inngangsvilkarPaneler/ForeldreansvarInngangsvilkarInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/inngangsvilkarPaneler/ForeldreansvarInngangsvilkarInitPanel.tsx
@@ -21,9 +21,9 @@ const AKSJONSPUNKT_TEKST_PER_KODE = {
     'ErForeldreansvarVilkaarOppfyltForm.2LeddParagrafEngangsStonad',
   [AksjonspunktCode.MANUELL_VURDERING_AV_FORELDREANSVARSVILKARET_4_LEDD]:
     'ErForeldreansvarVilkaarOppfyltForm.4LeddParagraf',
-  [AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN]: 'ErForeldreansvarVilkaarOppfyltForm.Vurder',
+  [AksjonspunktCode.AVKLAR_OM_STONAD_GJELDER_SAMME_BARN]: 'SRBVilkarForm.VurderSammeBarn',
   [AksjonspunktCode.AVKLAR_OM_STONAD_TIL_ANNEN_FORELDER_GJELDER_SAMME_BARN]:
-    'ErForeldreansvarVilkaarOppfyltForm.Vurder',
+    'SRBVilkarForm.VurderAnnenForelderSammeBarn',
 } as Record<string, string>;
 
 const hentAksjonspunktTekst = (intl: IntlShape, aksjonspunkter: Aksjonspunkt[] = []): string =>

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/AdopsjonInngangsvilkarFpInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/AdopsjonInngangsvilkarFpInitPanel.tsx
@@ -35,7 +35,7 @@ const AdopsjonInngangsvilkarFpInitPanel: FunctionComponent<OwnProps & Inngangsvi
       aksjonspunktKoder={AKSJONSPUNKT_KODER}
       vilkarKoder={VILKAR_KODER}
       inngangsvilkarPanelKode="ADOPSJON"
-      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'AdopsjonVilkarForm.VurderGjelderSammeBarn' })}
+      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'SRBVilkarForm.VurderSammeBarn' })}
       renderPanel={(data, erOverstyrt, toggleOverstyring) => (
         <>
           {data.aksjonspunkter.length === 0 && (

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/FodselInngangsvilkarFpInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/FodselInngangsvilkarFpInitPanel.tsx
@@ -35,7 +35,7 @@ const FodselInngangsvilkarFpInitPanel: FunctionComponent<OwnProps & Inngangsvilk
       aksjonspunktKoder={AKSJONSPUNKT_KODER}
       vilkarKoder={VILKAR_KODER}
       inngangsvilkarPanelKode="FODSEL"
-      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'FodselVilkarForm.VurderGjelderSammeBarn' })}
+      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'SRBVilkarForm.VurderSammeBarn' })}
       renderPanel={(data, erOverstyrt, toggleOverstyring) => (
         <>
           {data.aksjonspunkter.length === 0 && (

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/OmsorgInngangsvilkarFpInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/OmsorgInngangsvilkarFpInitPanel.tsx
@@ -31,7 +31,7 @@ const OmsorgInngangsvilkarFpInitPanel: FunctionComponent<OwnProps & Inngangsvilk
       aksjonspunktKoder={AKSJONSPUNKT_KODER}
       vilkarKoder={VILKAR_KODER}
       inngangsvilkarPanelKode="OMSORG"
-      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'ErOmsorgVilkaarOppfyltForm.Vurder' })}
+      hentInngangsvilkarPanelTekst={() => intl.formatMessage({ id: 'SRBVilkarForm.VurderSammeBarn' })}
       renderPanel={data => (
         <>
           <OmsorgVilkarProsessIndex {...data} />


### PR DESCRIPTION
Aksjonspunkt 5031 om brukers ytelse gjelder samme barn brukes for ES og FP - oppstår dersom det er søkt på både ES og FP.
Aksjonspunkt 5032 (annen forelders ytelse gjelder samme barn) oppstår kun for ES
Det er brukt samme tekst for begge aksjonspunktene i 4 varianter av SøkersRelasjonTilBarnet-Vilkår-panel. 
Saksbehandlere har reagert og tilpasser derfor tekstene med rammeverk fra OmsorgVilkårpanelet