### PR TITLE
TFP-5589 erstatning for ventegraf - alle førstegang på vent fordelt på frist

### DIFF
--- a/packages/los-avdelingsleder/i18n/nb_NO.json
+++ b/packages/los-avdelingsleder/i18n/nb_NO.json
@@ -82,6 +82,9 @@
   "ManueltPaVentPanel.SattPaVent": "Antall behandlinger satt på vent manuelt",
   "ManueltPaVentPanel.Alle": "Alle",
 
+  "VentefristUtløperPanel.SattPaVent": "Førstegangsbehandlinger på vent fordelt på utløp av ventefrist",
+  "VentefristUtløperPanel.Alle": "Alle",
+
   "OppgaverSomErApneEllerPaVentPanel.Apne": "Åpne behandlinger foreldrepenger fordelt på første uttaksdag fra søknad",
   "OppgaverSomErApneEllerPaVentGraf.PaVent": "På vent",
   "OppgaverSomErApneEllerPaVentGraf.IkkePaVent": "Ikke på vent",

--- a/packages/los-avdelingsleder/src/AvdelingslederIndex.stories.tsx
+++ b/packages/los-avdelingsleder/src/AvdelingslederIndex.stories.tsx
@@ -39,6 +39,7 @@ const Template: StoryFn<{ avdelinger?: Avdeling[]; navAnsatt: NavAnsatt }> = ({ 
     { key: RestApiPathsKeys.HENT_OPPGAVER_FOR_AVDELING.name, data: [] },
     { key: RestApiPathsKeys.HENT_OPPGAVER_PER_DATO.name, data: [] },
     { key: RestApiPathsKeys.HENT_OPPGAVER_APNE_ELLER_PA_VENT.name, data: [] },
+    { key: RestApiPathsKeys.HENT_BEHANDLINGER_FRISTUTLOP.name, data: [] },
     { key: RestApiPathsKeys.HENT_OPPGAVER_MANUELT_PA_VENT.name, data: [] },
     { key: RestApiPathsKeys.HENT_OPPGAVER_PER_FORSTE_STONADSDAG.name, data: [] },
     { key: RestApiPathsKeys.RESERVASJONER_FOR_AVDELING.name, data: [] },

--- a/packages/los-avdelingsleder/src/data/fplosRestApi.tsx
+++ b/packages/los-avdelingsleder/src/data/fplosRestApi.tsx
@@ -52,6 +52,9 @@ export const RestApiPathsKeys = {
   HENT_OPPGAVER_MANUELT_PA_VENT: new RestKey<OppgaverManueltPaVent[], { avdelingEnhet: string }>(
     'HENT_OPPGAVER_MANUELT_PA_VENT',
   ),
+  HENT_BEHANDLINGER_FRISTUTLOP: new RestKey<OppgaverManueltPaVent[], { avdelingEnhet: string }>(
+    'HENT_BEHANDLINGER_FRISTUTLOP',
+  ),
   HENT_OPPGAVER_APNE_ELLER_PA_VENT: new RestKey<OppgaverSomErApneEllerPaVent[], { avdelingEnhet: string }>(
     'HENT_OPPGAVER_APNE_ELLER_PA_VENT',
   ),
@@ -183,6 +186,7 @@ export const endpoints = new RestApiConfigBuilder()
     RestApiPathsKeys.HENT_OPPGAVER_PER_FORSTE_STONADSDAG,
   )
   .withGet('/fplos/api/avdelingsleder/nøkkeltall/åpne-behandlinger', RestApiPathsKeys.HENT_OPPGAVER_APNE_ELLER_PA_VENT)
+  .withGet('/fplos/api/avdelingsleder/nøkkeltall/frist-utløp', RestApiPathsKeys.HENT_BEHANDLINGER_FRISTUTLOP)
   .withGet('/fplos/api/avdelingsleder/reservasjoner', RestApiPathsKeys.RESERVASJONER_FOR_AVDELING)
   .withPost('/fplos/api/avdelingsleder/reservasjoner/opphev', RestApiPathsKeys.AVDELINGSLEDER_OPPHEVER_RESERVASJON)
 

--- a/packages/los-avdelingsleder/src/nokkeltall/NokkeltallIndex.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/NokkeltallIndex.tsx
@@ -11,6 +11,7 @@ import NokkeltallPanel from './components/NokkeltallPanel';
 const EMPTY_ARRAY_AVDELING: OppgaverForAvdeling[] = [];
 const EMPTY_ARRAY_DATO: OppgaveForDato[] = [];
 const EMPTY_ARRAY_PA_VENT: OppgaverManueltPaVent[] = [];
+const EMPTY_ARRAY_VENTEFRIST: OppgaverManueltPaVent[] = [];
 const EMPTY_ARRAY_STONADSDAG: OppgaverForForsteStonadsdag[] = [];
 const EMPTY_ARRAY_APNE_ELLER_PA_VENT: OppgaverSomErApneEllerPaVent[] = [];
 
@@ -34,6 +35,10 @@ const NokkeltallIndex: FunctionComponent<OwnProps> = ({ valgtAvdelingEnhet }) =>
     RestApiPathsKeys.HENT_OPPGAVER_MANUELT_PA_VENT,
     { avdelingEnhet: valgtAvdelingEnhet },
   );
+  const { data: behandlingerPaVent = EMPTY_ARRAY_VENTEFRIST } = restApiHooks.useRestApi(
+    RestApiPathsKeys.HENT_BEHANDLINGER_FRISTUTLOP,
+    { avdelingEnhet: valgtAvdelingEnhet },
+  );
   const { data: oppgaverPerForsteStonadsdag = EMPTY_ARRAY_STONADSDAG } = restApiHooks.useRestApi(
     RestApiPathsKeys.HENT_OPPGAVER_PER_FORSTE_STONADSDAG,
     { avdelingEnhet: valgtAvdelingEnhet },
@@ -48,6 +53,7 @@ const NokkeltallIndex: FunctionComponent<OwnProps> = ({ valgtAvdelingEnhet }) =>
       oppgaverForAvdeling={oppgaverForAvdeling}
       oppgaverPerDato={oppgaverPerDato}
       oppgaverManueltPaVent={oppgaverManueltPaVent}
+      behandlingerPaVent={behandlingerPaVent}
       oppgaverPerForsteStonadsdag={oppgaverPerForsteStonadsdag}
       oppgaverApneEllerPaVent={oppgaverApneEllerPaVent}
     />

--- a/packages/los-avdelingsleder/src/nokkeltall/components/NokkeltallPanel.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/NokkeltallPanel.tsx
@@ -12,11 +12,13 @@ import TilBehandlingPanel from './tilBehandling/TilBehandlingPanel';
 import ManueltPaVentPanel from './manueltSattPaVent/ManueltPaVentPanel';
 import OppgaverPerForsteStonadsdagPanel from './antallBehandlingerPerForsteStonadsdag/OppgaverPerForsteStonadsdagPanel';
 import OppgaverSomErApneEllerPaVentPanel from './apneOgPaVentBehandlinger/OppgaverSomErApneEllerPaVentPanel';
+import VentefristUtløperPanel from "./ventefristUtløper/VentefristUtløperPanel";
 
 interface OwnProps {
   oppgaverForAvdeling: OppgaverForAvdeling[];
   oppgaverPerDato: OppgaveForDato[];
   oppgaverManueltPaVent: OppgaverManueltPaVent[];
+  behandlingerPaVent: OppgaverManueltPaVent[];
   oppgaverPerForsteStonadsdag: OppgaverForForsteStonadsdag[];
   oppgaverApneEllerPaVent: OppgaverSomErApneEllerPaVent[];
 }
@@ -28,6 +30,7 @@ const NokkeltallPanel: FunctionComponent<OwnProps> = ({
   oppgaverForAvdeling,
   oppgaverPerDato,
   oppgaverManueltPaVent,
+  behandlingerPaVent,
   oppgaverPerForsteStonadsdag,
   oppgaverApneEllerPaVent,
 }) => {
@@ -52,6 +55,12 @@ const NokkeltallPanel: FunctionComponent<OwnProps> = ({
       <ManueltPaVentPanel
         height={height}
         oppgaverManueltPaVent={oppgaverManueltPaVent}
+        getValueFromLocalStorage={getValueFromLocalStorage}
+      />
+      <VerticalSpacer twentyPx />
+      <VentefristUtløperPanel
+        height={height}
+        behandlingerPaVent={behandlingerPaVent}
         getValueFromLocalStorage={getValueFromLocalStorage}
       />
       <VerticalSpacer twentyPx />

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperGraf.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperGraf.tsx
@@ -1,0 +1,106 @@
+import React, { FunctionComponent, useMemo } from 'react';
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { Panel } from '@navikt/ds-react';
+import { DDMMYYYY_DATE_FORMAT } from '@navikt/ft-utils';
+import { ReactECharts } from '@navikt/fp-los-felles';
+
+import OppgaverManueltPaVent from '../../../typer/oppgaverManueltPaVentTsType';
+
+dayjs.extend(isSameOrBefore);
+
+interface Koordinat {
+  x: number;
+  y: number;
+}
+
+const lagKoordinater = (oppgaverManueltPaVent: OppgaverManueltPaVent[]): Koordinat[] =>
+  oppgaverManueltPaVent.map(o => ({
+    x: dayjs(o.behandlingFrist).startOf('day').toDate().getTime(),
+    y: o.antall,
+  }));
+
+const lagDatastruktur = (koordinater: Koordinat[]): (number | Date)[][] => {
+  const nyeKoordinater = [];
+  const periodeStart = koordinater
+    .map(koordinat => dayjs(koordinat.x))
+    .reduce(
+      (tidligesteDato, dato) => (tidligesteDato.isSameOrBefore(dato) ? tidligesteDato : dato),
+      dayjs().startOf('day'),
+    )
+    .toDate();
+  const periodeSlutt = koordinater
+    .map(koordinat => dayjs(koordinat.x))
+    .reduce((senesteDato, dato) => (senesteDato.isSameOrAfter(dato) ? senesteDato : dato), dayjs().startOf('day'))
+    .toDate();
+
+  for (let dato = dayjs(periodeStart); dato.isSameOrBefore(periodeSlutt); dato = dato.add(1, 'days')) {
+    const funnetKoordinat = koordinater.find(k => dayjs(k.x).isSame(dato));
+    nyeKoordinater.push([dato.toDate(), funnetKoordinat ? funnetKoordinat.y : 0]);
+  }
+
+  return nyeKoordinater;
+};
+
+interface OwnProps {
+  height: number;
+  behandlingerPaVent: OppgaverManueltPaVent[];
+}
+
+/**
+ * VentefristUtløperGraf.
+ */
+const VentefristUtløperGraf: FunctionComponent<OwnProps> = ({ height, behandlingerPaVent }) => {
+  const koordinater = useMemo(() => lagKoordinater(behandlingerPaVent), [behandlingerPaVent]);
+  const data = useMemo(() => lagDatastruktur(koordinater), [koordinater]);
+  return (
+    <Panel>
+      <ReactECharts
+        height={height}
+        option={{
+          tooltip: {
+            trigger: 'axis',
+            axisPointer: {
+              snap: true,
+              label: {
+                formatter: params => {
+                  if (params.axisDimension === 'y') {
+                    return parseInt(params.value as string, 10).toString();
+                  }
+                  return dayjs(params.value).format(DDMMYYYY_DATE_FORMAT);
+                },
+              },
+            },
+          },
+          toolbox: {
+            feature: {
+              saveAsImage: {
+                title: 'Lagre ',
+                name: 'Antall_forstegangsbehandlinger_der_frist_utloper',
+              },
+            },
+          },
+          xAxis: {
+            type: 'time',
+            axisLabel: {
+              formatter: '{dd}.{MM}.{yyyy}',
+            },
+          },
+          yAxis: {
+            type: 'value',
+          },
+          series: [
+            {
+              data,
+              type: 'line',
+              areaStyle: {},
+            },
+          ],
+          color: ['#337c9b'],
+        }}
+      />
+    </Panel>
+  );
+};
+
+export default VentefristUtløperGraf;

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.spec.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from './VenManueltPaVentPanel.stories';
+
+const { Default } = composeStories(stories);
+
+describe('<VentefristUtløperPanel>', () => {
+  // TODO echarts-testing
+  it.skip('skal vise graffilter', async () => {
+    const { getByLabelText } = render(<Default />);
+    expect(await screen.findByText('Førstegangsbehandlinger på vent fordelt på utløp av ventefrist')).toBeInTheDocument();
+
+    expect(getByLabelText('Foreldrepenger')).not.toBeChecked();
+    expect(getByLabelText('Engangsstønad')).not.toBeChecked();
+    expect(getByLabelText('Svangerskapspenger')).not.toBeChecked();
+    expect(getByLabelText('Alle')).toBeChecked();
+  });
+});

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.spec.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
-import * as stories from './VenManueltPaVentPanel.stories';
+import * as stories from './VentefristUtløperPanel.stories';
 
 const { Default } = composeStories(stories);
 

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.stories.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.stories.tsx
@@ -24,14 +24,14 @@ export default {
 // https://github.com/storybookjs/storybook/issues/12208
 const FIVE = 5;
 
-const Template: StoryFn<{ oppgaverManueltPaVent: OppgaverManueltPaVent[] }> = ({ oppgaverManueltPaVent }) => {
+const Template: StoryFn<{ behandlingerPaVent: OppgaverManueltPaVent[] }> = ({ behandlingerPaVent }) => {
   const data = [{ key: RestApiGlobalStatePathsKeys.KODEVERK_LOS.name, data: alleKodeverkLos, global: true }];
 
   return (
     <RestApiMock data={data} requestApi={requestApi}>
       <VentefristUtløperPanel
         height={300}
-        oppgaverManueltPaVent={oppgaverManueltPaVent}
+        behandlingerPaVent={behandlingerPaVent}
         getValueFromLocalStorage={() => ''}
       />
     </RestApiMock>

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.stories.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { StoryFn } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { ISO_DATE_FORMAT } from '@navikt/ft-utils';
+import { FagsakYtelseType } from '@navikt/ft-kodeverk';
+
+import { RestApiMock } from '@navikt/fp-utils-test';
+import { getIntlDecorator, alleKodeverkLos } from '@navikt/fp-storybook-utils';
+
+import OppgaverManueltPaVent from '../../../typer/oppgaverManueltPaVentTsType';
+import { RestApiGlobalStatePathsKeys, requestApi } from '../../../data/fplosRestApi';
+
+import messages from '../../../../i18n/nb_NO.json';
+import VentefristUtløperPanel from "./VentefristUtløperPanel";
+
+const withIntl = getIntlDecorator(messages);
+
+export default {
+  title: 'los/avdelingsleder/nokkeltall/ManueltPaVentPanel',
+  component: VentefristUtløperPanel,
+  decorators: [withIntl],
+};
+
+// https://github.com/storybookjs/storybook/issues/12208
+const FIVE = 5;
+
+const Template: StoryFn<{ oppgaverManueltPaVent: OppgaverManueltPaVent[] }> = ({ oppgaverManueltPaVent }) => {
+  const data = [{ key: RestApiGlobalStatePathsKeys.KODEVERK_LOS.name, data: alleKodeverkLos, global: true }];
+
+  return (
+    <RestApiMock data={data} requestApi={requestApi}>
+      <VentefristUtløperPanel
+        height={300}
+        oppgaverManueltPaVent={oppgaverManueltPaVent}
+        getValueFromLocalStorage={() => ''}
+      />
+    </RestApiMock>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  oppgaverManueltPaVent: [
+    {
+      fagsakYtelseType: FagsakYtelseType.FORELDREPENGER,
+      behandlingFrist: dayjs().format(ISO_DATE_FORMAT),
+      antall: 10,
+    },
+    {
+      fagsakYtelseType: FagsakYtelseType.ENGANGSSTONAD,
+      behandlingFrist: dayjs().add(FIVE, 'd').format(ISO_DATE_FORMAT),
+      antall: 4,
+    },
+    {
+      fagsakYtelseType: FagsakYtelseType.ENGANGSSTONAD,
+      behandlingFrist: dayjs().add(FIVE, 'w').format(ISO_DATE_FORMAT),
+      antall: 14,
+    },
+  ],
+};

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.stories.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.stories.tsx
@@ -16,7 +16,7 @@ import VentefristUtløperPanel from "./VentefristUtløperPanel";
 const withIntl = getIntlDecorator(messages);
 
 export default {
-  title: 'los/avdelingsleder/nokkeltall/ManueltPaVentPanel',
+  title: 'los/avdelingsleder/nokkeltall/VentefristUtløperPanel',
   component: VentefristUtløperPanel,
   decorators: [withIntl],
 };
@@ -24,14 +24,14 @@ export default {
 // https://github.com/storybookjs/storybook/issues/12208
 const FIVE = 5;
 
-const Template: StoryFn<{ behandlingerPaVent: OppgaverManueltPaVent[] }> = ({ behandlingerPaVent }) => {
+const Template: StoryFn<{ oppgaverManueltPaVent: OppgaverManueltPaVent[] }> = ({ oppgaverManueltPaVent }) => {
   const data = [{ key: RestApiGlobalStatePathsKeys.KODEVERK_LOS.name, data: alleKodeverkLos, global: true }];
 
   return (
     <RestApiMock data={data} requestApi={requestApi}>
       <VentefristUtløperPanel
         height={300}
-        behandlingerPaVent={behandlingerPaVent}
+        behandlingerPaVent={oppgaverManueltPaVent}
         getValueFromLocalStorage={() => ''}
       />
     </RestApiMock>

--- a/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.tsx
+++ b/packages/los-avdelingsleder/src/nokkeltall/components/ventefristUtløper/VentefristUtløperPanel.tsx
@@ -1,0 +1,101 @@
+import React, { FunctionComponent } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useForm } from 'react-hook-form';
+import { HStack, Label } from '@navikt/ds-react';
+import { Form, RadioGroupPanel } from '@navikt/ft-form-hooks';
+import { VerticalSpacer } from '@navikt/ft-ui-komponenter';
+import { FagsakYtelseType, KodeverkType } from '@navikt/ft-kodeverk';
+import { KodeverkMedNavn } from '@navikt/fp-types';
+
+import OppgaverManueltPaVent from '../../../typer/oppgaverManueltPaVentTsType';
+import StoreValuesInLocalStorage from '../../../data/StoreValuesInLocalStorage';
+import useLosKodeverk from '../../../data/useLosKodeverk';
+import VentefristUtløperGraf from './VentefristUtløperGraf';
+
+const finnFagsakYtelseTypeNavn = (fagsakYtelseTyper: KodeverkMedNavn[], valgtFagsakYtelseType: string): string => {
+  const type = fagsakYtelseTyper.find(fyt => fyt.kode === valgtFagsakYtelseType);
+  return type ? type.navn : '';
+};
+
+export const ALLE_YTELSETYPER_VALGT = 'ALLE';
+
+interface OwnProps {
+  height: number;
+  behandlingerPaVent: OppgaverManueltPaVent[];
+  getValueFromLocalStorage: (key: string) => string | undefined;
+}
+
+const formName = 'ventefristUtløperForm';
+const formDefaultValues = { valgtYtelsetype: ALLE_YTELSETYPER_VALGT };
+
+type FormValues = {
+  valgtYtelsetype: string;
+};
+
+/**
+ * VentefristUtløperPanel.
+ */
+const VentefristUtløperPanel: FunctionComponent<OwnProps> = ({
+  height,
+  behandlingerPaVent,
+  getValueFromLocalStorage,
+}) => {
+  const fagsakYtelseTyper = useLosKodeverk(KodeverkType.FAGSAK_YTELSE);
+  const stringFromStorage = getValueFromLocalStorage(formName);
+  const lagredeVerdier = stringFromStorage ? JSON.parse(stringFromStorage) : undefined;
+
+  const formMethods = useForm<FormValues>({
+    defaultValues: lagredeVerdier || formDefaultValues,
+  });
+
+  const values = formMethods.watch();
+
+  return (
+    <Form<FormValues> formMethods={formMethods}>
+      <StoreValuesInLocalStorage stateKey={formName} values={values} />
+      <Label size="small">
+        <FormattedMessage id="VentefristUtløperPanel.SattPaVent" />
+      </Label>
+      <VerticalSpacer sixteenPx />
+      <HStack gap="4">
+        <RadioGroupPanel
+          name="valgtYtelsetype"
+          isHorizontal
+          radios={[
+            {
+              value: FagsakYtelseType.FORELDREPENGER,
+              label: finnFagsakYtelseTypeNavn(fagsakYtelseTyper, FagsakYtelseType.FORELDREPENGER),
+            },
+            {
+              value: FagsakYtelseType.ENGANGSSTONAD,
+              label: finnFagsakYtelseTypeNavn(fagsakYtelseTyper, FagsakYtelseType.ENGANGSSTONAD),
+            },
+            {
+              value: FagsakYtelseType.SVANGERSKAPSPENGER,
+              label: finnFagsakYtelseTypeNavn(fagsakYtelseTyper, FagsakYtelseType.SVANGERSKAPSPENGER),
+            },
+            {
+              value: ALLE_YTELSETYPER_VALGT,
+              label: <FormattedMessage id="VentefristUtløperPanel.Alle" />,
+            },
+          ]}
+        />
+      </HStack>
+      <VerticalSpacer sixteenPx />
+      <VentefristUtløperGraf
+        height={height}
+        behandlingerPaVent={
+          behandlingerPaVent &&
+          behandlingerPaVent
+            .filter(ompv =>
+              values.valgtYtelsetype === ALLE_YTELSETYPER_VALGT
+                ? true
+                : values.valgtYtelsetype === ompv.fagsakYtelseType,
+            )
+        }
+      />
+    </Form>
+  );
+};
+
+export default VentefristUtløperPanel;


### PR DESCRIPTION
LOS / Avd.leder / Nøkkeltall: Erstatning for graf over manuelt på vent.
Henter og viser liste av enhet, ytelse, behandlingFrist (=autopunkt.frist_tid) og antall (samme innhold som den som erstattes)
Lista hentes fra fpsak (caches 30 min i LOS) og går fra dagens dato og et halvt år fram.

Det kommer sikkert ønske om et kulere ReactEChart etterhvert