### PR TITLE
Mappe ned EØS-verdier også for aleneomsorg

### DIFF
--- a/packages/fakta-omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
+++ b/packages/fakta-omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
@@ -20,7 +20,7 @@ export type FormValues = {
   harAleneomsorg: boolean;
   harAnnenForelderRett?: boolean;
   mottarAnnenForelderUforetrygd?: boolean;
-  annenForelderRettEØS?: boolean;
+  harAnnenForelderRettEØS?: boolean;
   begrunnelse: string;
 };
 
@@ -48,7 +48,7 @@ const AleneomsorgForm: FunctionComponent<OwnProps> = ({
       harAleneomsorg: ytelsefordeling?.bekreftetAleneomsorg,
       harAnnenForelderRett: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenforelderRett,
       mottarAnnenForelderUforetrygd: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenforelderUføretrygd,
-      annenForelderRettEØS: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenForelderRettEØS,
+      harAnnenForelderRettEØS: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenForelderRettEØS,
       begrunnelse: aksjonspunkt.begrunnelse ? decodeHtmlEntity(aksjonspunkt.begrunnelse) : undefined,
     },
   });
@@ -64,7 +64,7 @@ const AleneomsorgForm: FunctionComponent<OwnProps> = ({
         aleneomsorg: feltVerdier.harAleneomsorg,
         annenforelderHarRett: feltVerdier.harAnnenForelderRett,
         annenforelderMottarUføretrygd: feltVerdier.mottarAnnenForelderUforetrygd,
-        annenForelderHarRettEØS: feltVerdier.annenForelderRettEØS,
+        annenForelderHarRettEØS: feltVerdier.harAnnenForelderRettEØS,
         begrunnelse: feltVerdier.begrunnelse,
       }),
     [],

--- a/packages/fakta-omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
+++ b/packages/fakta-omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
@@ -20,6 +20,7 @@ export type FormValues = {
   harAleneomsorg: boolean;
   harAnnenForelderRett?: boolean;
   mottarAnnenForelderUforetrygd?: boolean;
+  annenForelderRettEØS?: boolean;
   begrunnelse: string;
 };
 
@@ -47,6 +48,7 @@ const AleneomsorgForm: FunctionComponent<OwnProps> = ({
       harAleneomsorg: ytelsefordeling?.bekreftetAleneomsorg,
       harAnnenForelderRett: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenforelderRett,
       mottarAnnenForelderUforetrygd: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenforelderUføretrygd,
+      annenForelderRettEØS: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenForelderRettEØS,
       begrunnelse: aksjonspunkt.begrunnelse ? decodeHtmlEntity(aksjonspunkt.begrunnelse) : undefined,
     },
   });
@@ -62,6 +64,7 @@ const AleneomsorgForm: FunctionComponent<OwnProps> = ({
         aleneomsorg: feltVerdier.harAleneomsorg,
         annenforelderHarRett: feltVerdier.harAnnenForelderRett,
         annenforelderMottarUføretrygd: feltVerdier.mottarAnnenForelderUforetrygd,
+        annenForelderHarRettEØS: feltVerdier.annenForelderRettEØS,
         begrunnelse: feltVerdier.begrunnelse,
       }),
     [],

--- a/packages/fakta-omsorg-og-rett/src/components/forms/HarAnnenForelderRettFelter.tsx
+++ b/packages/fakta-omsorg-og-rett/src/components/forms/HarAnnenForelderRettFelter.tsx
@@ -8,7 +8,7 @@ import { useFormContext } from 'react-hook-form';
 type FormValues = {
   harAnnenForelderRett: boolean;
   mottarAnnenForelderUforetrygd: boolean;
-  annenForelderRettEØS: boolean;
+  harAnnenForelderRettEØS: boolean;
 };
 
 interface OwnProps {
@@ -20,7 +20,7 @@ interface OwnProps {
 const HarAnnenForelderRettFelter: FunctionComponent<OwnProps> = ({ readOnly, avklareUforetrygd, avklareRettEØS }) => {
   const { watch } = useFormContext<FormValues>();
   const harAnnenForelderRett = watch('harAnnenForelderRett');
-  const annenForelderRettEØS = watch('annenForelderRettEØS');
+  const harAnnenForelderRettEØS = watch('harAnnenForelderRettEØS');
 
   return (
     <>
@@ -44,7 +44,7 @@ const HarAnnenForelderRettFelter: FunctionComponent<OwnProps> = ({ readOnly, avk
       <VerticalSpacer thirtyTwoPx />
       {harAnnenForelderRett === false && avklareRettEØS && (
         <RadioGroupPanel
-          name="annenForelderRettEØS"
+          name="harAnnenForelderRettEØS"
           label={<FormattedMessage id="HarAnnenForelderRettFelter.AnnenForelderRettEØS" />}
           validate={[required]}
           isReadOnly={readOnly}
@@ -61,7 +61,7 @@ const HarAnnenForelderRettFelter: FunctionComponent<OwnProps> = ({ readOnly, avk
           ]}
         />
       )}
-      {harAnnenForelderRett === false && (!avklareRettEØS || annenForelderRettEØS === false) && avklareUforetrygd && (
+      {harAnnenForelderRett === false && (!avklareRettEØS || harAnnenForelderRettEØS === false) && avklareUforetrygd && (
         <>
           <VerticalSpacer thirtyTwoPx />
           <RadioGroupPanel

--- a/packages/fakta-omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
+++ b/packages/fakta-omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
@@ -20,7 +20,7 @@ const maxLength1500 = maxLength(1500);
 export type FormValues = {
   harAnnenForelderRett: boolean;
   mottarAnnenForelderUforetrygd?: boolean;
-  annenForelderRettEØS?: boolean;
+  harAnnenForelderRettEØS?: boolean;
   begrunnelse: string;
 };
 
@@ -47,7 +47,7 @@ const HarAnnenForelderRettForm: FunctionComponent<OwnProps> = ({
     defaultValues: formData || {
       harAnnenForelderRett: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenforelderRett,
       mottarAnnenForelderUforetrygd: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenforelderUføretrygd,
-      annenForelderRettEØS: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenForelderRettEØS,
+      harAnnenForelderRettEØS: ytelsefordeling?.rettigheterAnnenforelder?.bekreftetAnnenForelderRettEØS,
       begrunnelse: aksjonspunkt.begrunnelse ? decodeHtmlEntity(aksjonspunkt.begrunnelse) : undefined,
     },
   });
@@ -65,7 +65,7 @@ const HarAnnenForelderRettForm: FunctionComponent<OwnProps> = ({
         kode: AksjonspunktCode.AVKLAR_ANNEN_FORELDER_RETT,
         annenforelderHarRett: feltVerdier.harAnnenForelderRett,
         annenforelderMottarUføretrygd: feltVerdier.mottarAnnenForelderUforetrygd,
-        annenForelderHarRettEØS: feltVerdier.annenForelderRettEØS,
+        annenForelderHarRettEØS: feltVerdier.harAnnenForelderRettEØS,
         begrunnelse: feltVerdier.begrunnelse,
       }),
     [],


### PR DESCRIPTION
Det er 2 aksjonspunkter med hver sin start-form aleneomsorg og annenForelderRett.
Aleneomsorg mappet ikke inn avklaring av annenForelderEØS - gjør det likt for begge forms og konsekvent med harAnnenForelderRett