### PR TITLE
TFP-5668: Flytter forhåndsvisning av brev til å gå gjennom fpsak.

### DIFF
--- a/apps/fp-frontend-app/src/behandlingsupport/melding/MeldingIndex.spec.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/melding/MeldingIndex.spec.tsx
@@ -85,7 +85,7 @@ describe('<MeldingIndex>', () => {
     const data = [
       { key: FagsakApiKeys.INIT_FETCH.name, global: true, data: { innloggetBruker: { navn: 'Peder' } } },
       { key: FagsakApiKeys.KODEVERK.name, global: true, data: kodeverk },
-      { key: FagsakApiKeys.PREVIEW_MESSAGE.name, data: {} },
+      { key: FagsakApiKeys.PREVIEW_MESSAGE_MENU.name, data: {} },
     ];
 
     let axiosMock: MockAdapter;

--- a/apps/fp-frontend-app/src/behandlingsupport/melding/MeldingIndex.spec.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/melding/MeldingIndex.spec.tsx
@@ -85,7 +85,7 @@ describe('<MeldingIndex>', () => {
     const data = [
       { key: FagsakApiKeys.INIT_FETCH.name, global: true, data: { innloggetBruker: { navn: 'Peder' } } },
       { key: FagsakApiKeys.KODEVERK.name, global: true, data: kodeverk },
-      { key: FagsakApiKeys.PREVIEW_MESSAGE_FORMIDLING.name, data: {} },
+      { key: FagsakApiKeys.PREVIEW_MESSAGE.name, data: {} },
     ];
 
     let axiosMock: MockAdapter;

--- a/apps/fp-frontend-app/src/data/behandlingContextApi.ts
+++ b/apps/fp-frontend-app/src/data/behandlingContextApi.ts
@@ -260,7 +260,6 @@ export const behandlingEndepunkter = new RestApiConfigBuilder()
   })
 
   .withPost('/fpsak/api/brev/forhandsvis/manuell', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
-  //.withRel('brev-vis', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
 
   .build();
 

--- a/apps/fp-frontend-app/src/data/behandlingContextApi.ts
+++ b/apps/fp-frontend-app/src/data/behandlingContextApi.ts
@@ -260,7 +260,7 @@ export const behandlingEndepunkter = new RestApiConfigBuilder()
   })
 
   /* FPFORMIDLING */
-  .withPost('/fpformidling/api/brev/forhaandsvis', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
+  .withPost('/fpsak/api/brev/forhandsvis/manuell', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
 
   .build();
 

--- a/apps/fp-frontend-app/src/data/behandlingContextApi.ts
+++ b/apps/fp-frontend-app/src/data/behandlingContextApi.ts
@@ -259,7 +259,7 @@ export const behandlingEndepunkter = new RestApiConfigBuilder()
     isResponseBlob: true,
   })
 
-  .withPost('/fpsak/api/brev/forhandsvis/manuell', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
+  .withPost('/fpsak/api/brev/forhandsvis', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
 
   .build();
 

--- a/apps/fp-frontend-app/src/data/behandlingContextApi.ts
+++ b/apps/fp-frontend-app/src/data/behandlingContextApi.ts
@@ -259,8 +259,8 @@ export const behandlingEndepunkter = new RestApiConfigBuilder()
     isResponseBlob: true,
   })
 
-  /* FPFORMIDLING */
   .withPost('/fpsak/api/brev/forhandsvis/manuell', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
+  //.withRel('brev-vis', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
 
   .build();
 

--- a/apps/fp-frontend-app/src/data/fagsakContextApi.ts
+++ b/apps/fp-frontend-app/src/data/fagsakContextApi.ts
@@ -59,7 +59,7 @@ export const FagsakApiKeys = {
   ALL_DOCUMENTS: new RestKey<Dokument[], { saksnummer: string }>('ALL_DOCUMENTS'),
   SAVE_TOTRINNSAKSJONSPUNKT: new RestKey<Behandling, any>('SAVE_TOTRINNSAKSJONSPUNKT'),
   SUBMIT_MESSAGE: new RestKey<void, SubmitMessageParams>('SUBMIT_MESSAGE'),
-  PREVIEW_MESSAGE: new RestKey<void, ForhåndsvisMeldingParams>('PREVIEW_MESSAGE'),
+  PREVIEW_MESSAGE_MENU: new RestKey<void, ForhåndsvisMeldingParams>('PREVIEW_MESSAGE_MENU'),
   LAGRE_NOTAT: new RestKey<void, { saksnummer: string; notat: string }>('LAGRE_NOTAT'),
   KAN_TILBAKEKREVING_OPPRETTES: new RestKey<boolean, { saksnummer: string; uuid: string }>(
     'KAN_TILBAKEKREVING_OPPRETTES',
@@ -68,7 +68,6 @@ export const FagsakApiKeys = {
     'KAN_TILBAKEKREVING_REVURDERING_OPPRETTES',
   ),
   PREVIEW_MESSAGE_TILBAKEKREVING: new RestKey<any, any>('PREVIEW_MESSAGE_TILBAKEKREVING'),
-  PREVIEW_MESSAGE_FORMIDLING: new RestKey<any, ForhåndsvisMeldingParams>('PREVIEW_MESSAGE_FORMIDLING'),
   PREVIEW_MESSAGE_TILBAKEKREVING_HENLEGGELSE: new RestKey<any, any>('PREVIEW_MESSAGE_TILBAKEKREVING_HENLEGGELSE'),
   ENDRE_SAK_MARKERING: new RestKey<void, { saksnummer: string; fagsakMarkering: string }>('ENDRE_SAK_MARKERING'),
 };
@@ -94,7 +93,7 @@ const fagsakEndepunkter = new RestApiConfigBuilder()
   // Behandling
   .withRel('bekreft-totrinnsaksjonspunkt', FagsakApiKeys.SAVE_TOTRINNSAKSJONSPUNKT)
   .withRel('brev-bestill', FagsakApiKeys.SUBMIT_MESSAGE)
-  .withRel('brev-vis', FagsakApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
+  .withRel('brev-vis', FagsakApiKeys.PREVIEW_MESSAGE_MENU, { isResponseBlob: true })
 
   .withPost('/fptilbake/api/brev/forhandsvis', FagsakApiKeys.PREVIEW_MESSAGE_TILBAKEKREVING, { isResponseBlob: true })
   .withPost(
@@ -105,9 +104,6 @@ const fagsakEndepunkter = new RestApiConfigBuilder()
   .withAsyncPost('/fptilbake/api/behandlinger/opprett', FagsakApiKeys.NEW_BEHANDLING_FPTILBAKE)
   .withAsyncPut('/fpsak/api/behandlinger', FagsakApiKeys.NEW_BEHANDLING_FPSAK)
   .withGet('/fpsak/api/aktoer-info', FagsakApiKeys.AKTOER_INFO)
-
-  // FpFormidling
-  .withPost('/fpformidling/api/brev/forhaandsvis', FagsakApiKeys.PREVIEW_MESSAGE_FORMIDLING, { isResponseBlob: true })
 
   // Kun brukt for søk på localhost
   .withPost('/fpsak/api/fagsak/sok', FagsakApiKeys.SEARCH_FAGSAK)

--- a/apps/fp-frontend-app/src/data/fagsakContextApi.ts
+++ b/apps/fp-frontend-app/src/data/fagsakContextApi.ts
@@ -59,6 +59,7 @@ export const FagsakApiKeys = {
   ALL_DOCUMENTS: new RestKey<Dokument[], { saksnummer: string }>('ALL_DOCUMENTS'),
   SAVE_TOTRINNSAKSJONSPUNKT: new RestKey<Behandling, any>('SAVE_TOTRINNSAKSJONSPUNKT'),
   SUBMIT_MESSAGE: new RestKey<void, SubmitMessageParams>('SUBMIT_MESSAGE'),
+  PREVIEW_MESSAGE: new RestKey<void, ForhåndsvisMeldingParams>('PREVIEW_MESSAGE'),
   LAGRE_NOTAT: new RestKey<void, { saksnummer: string; notat: string }>('LAGRE_NOTAT'),
   KAN_TILBAKEKREVING_OPPRETTES: new RestKey<boolean, { saksnummer: string; uuid: string }>(
     'KAN_TILBAKEKREVING_OPPRETTES',
@@ -93,6 +94,7 @@ const fagsakEndepunkter = new RestApiConfigBuilder()
   // Behandling
   .withRel('bekreft-totrinnsaksjonspunkt', FagsakApiKeys.SAVE_TOTRINNSAKSJONSPUNKT)
   .withRel('brev-bestill', FagsakApiKeys.SUBMIT_MESSAGE)
+  .withRel('brev-vis', FagsakApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true })
 
   .withPost('/fptilbake/api/brev/forhandsvis', FagsakApiKeys.PREVIEW_MESSAGE_TILBAKEKREVING, { isResponseBlob: true })
   .withPost(

--- a/apps/fp-frontend-app/src/data/useVisForhandsvisningAvMelding.tsx
+++ b/apps/fp-frontend-app/src/data/useVisForhandsvisningAvMelding.tsx
@@ -32,7 +32,7 @@ const useVisForhandsvisningAvMelding = (behandlingType?: string): ForhandsvisFun
     FagsakApiKeys.PREVIEW_MESSAGE_TILBAKEKREVING,
   );
   const { startRequest: forhandsvisMelding } = restFagsakApiHooks.useRestApiRunner(
-    FagsakApiKeys.PREVIEW_MESSAGE,
+    FagsakApiKeys.PREVIEW_MESSAGE_MENU,
   );
 
   const erTilbakekreving =

--- a/apps/fp-frontend-app/src/data/useVisForhandsvisningAvMelding.tsx
+++ b/apps/fp-frontend-app/src/data/useVisForhandsvisningAvMelding.tsx
@@ -32,7 +32,7 @@ const useVisForhandsvisningAvMelding = (behandlingType?: string): ForhandsvisFun
     FagsakApiKeys.PREVIEW_MESSAGE_TILBAKEKREVING,
   );
   const { startRequest: forhandsvisMelding } = restFagsakApiHooks.useRestApiRunner(
-    FagsakApiKeys.PREVIEW_MESSAGE_FORMIDLING,
+    FagsakApiKeys.PREVIEW_MESSAGE,
   );
 
   const erTilbakekreving =


### PR DESCRIPTION
@tor-nav jeg er usikker hvorfor det ikke virker om jeg gjør det likt som i fagsakContext

  .withPost('/fpsak/api/brev/forhandsvis/manuell', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true }) -- virker
//.withRel('brev-vis', BehandlingApiKeys.PREVIEW_MESSAGE, { isResponseBlob: true }) --virker ikke 

Men det virker helt ok for de generelle brev fra Meldinger menu.