### PR TITLE
Skriv om alle unicode hyphens til minus

### DIFF
--- a/packages/prosess-felles/src/ProsessStegBegrunnelseTextFieldNew.tsx
+++ b/packages/prosess-felles/src/ProsessStegBegrunnelseTextFieldNew.tsx
@@ -65,7 +65,7 @@ const ProsessStegBegrunnelseTextField: FunctionComponent<OwnProps> & StaticFunct
         maxLength={2000}
         readOnly={readOnly}
         // Må erstatte bindestrek kopiert inn fra Word med vanlig bindestrek
-        parse={value => value.toString().replaceAll('‑', '-')}
+        parse={value => value.toString().replaceAll(/\p{Dash_Punctuation}/gu, '-')}
       />
     </div>
   );

--- a/packages/prosess-formkrav/src/components/FormkravKlageFormNfp.tsx
+++ b/packages/prosess-formkrav/src/components/FormkravKlageFormNfp.tsx
@@ -247,7 +247,7 @@ const FormkravKlageFormNfp: FunctionComponent<OwnProps> = ({
             maxLength={100000}
             readOnly={readOnly}
             // Må erstatte bindestrek kopiert inn fra Word med vanlig bindestrek
-            parse={value => value.toString().replaceAll('‑', '-')}
+            parse={value => value.toString().replaceAll(/\p{Dash_Punctuation}/gu, '-')}
           />
         )}
         <HStack justify="space-between">

--- a/packages/prosess-klagevurdering/src/components/nfp/FritekstKlageBrevTextField.tsx
+++ b/packages/prosess-klagevurdering/src/components/nfp/FritekstKlageBrevTextField.tsx
@@ -27,7 +27,7 @@ const FritekstKlageBrevTextField: FunctionComponent<OwnProps> = ({ sprakkode, re
         },
       ]}
       // Må erstatte bindestrek kopiert inn fra Word med vanlig bindestrek
-      parse={value => value.toString().replaceAll('‑', '-').replaceAll('\t', ' ')}
+      parse={value => value.toString().replaceAll(/\p{Dash_Punctuation}/gu, '-').replaceAll('\t', ' ')}
     />
   </div>
 );

--- a/packages/prosess-vedtak/src/components/felles/ManueltVedtaksbrevPanel.tsx
+++ b/packages/prosess-vedtak/src/components/felles/ManueltVedtaksbrevPanel.tsx
@@ -88,7 +88,7 @@ const ManueltVedtaksbrevPanel: FunctionComponent<OwnProps> = ({
         maxLength={10000}
         readOnly={isReadOnly}
         // Må erstatte bindestrek kopiert inn fra Word med vanlig bindestrek
-        parse={value => value.toString().replaceAll('‑', '-').replaceAll('\t', ' ')}
+        parse={value => value.toString().replaceAll(/\p{Dash_Punctuation}/gu, '-').replaceAll('\t', ' ')}
       />
       {isReadOnly && (
         <>


### PR DESCRIPTION
Denne skal i teorien virke - i følge en chat med Andreas. Eksempler er "‐ , ‑ , ‒, – , —"