### PR TITLE
legge til ny story til sak-historikk

### DIFF
--- a/packages/sak-historikk/src/HistorikkSakIndex.stories.tsx
+++ b/packages/sak-historikk/src/HistorikkSakIndex.stories.tsx
@@ -8,6 +8,7 @@ import historikkOpplysningTypeCodes from './kodeverk/historikkOpplysningTypeCode
 import HistorikkSakIndex from './HistorikkSakIndex';
 import historikkEndretFeltType from './kodeverk/historikkEndretFeltType';
 import historikkinnslagType from './kodeverk/historikkinnslagType';
+import historikkAlleMaler from './saksHistorikkAlleMaler';
 
 const historikkInnslag = [
   {
@@ -27,7 +28,11 @@ const historikkInnslag = [
     ],
     historikkinnslagDeler: [
       {
-        begrunnelsetekst: 'Dette er en tekst',
+        begrunnelsetekst:
+          'Dette er en tekst. Den er uten viktig innhold. Kun en enkel, men litt lengre tekst. ' +
+          'Dette er en tekst. Den er uten viktig innhold. Kun en enkel, men litt lengre tekst. ' +
+          'Dette er en tekst. Den er uten viktig innhold. Kun en enkel, men litt lengre tekst. ' +
+          'Dette er en tekst. Den er uten viktig innhold. Kun en enkel, men litt lengre tekst. ',
         hendelse: {
           navn: 'NYE_REGOPPLYSNINGER',
         },
@@ -120,6 +125,11 @@ const Template: StoryFn<{
     />
   </div>
 );
+export const VisAlleMaler = Template.bind({});
+
+VisAlleMaler.args = {
+  historikkFpSak: historikkAlleMaler,
+};
 
 export const BehandlingIkkeErValgt = Template.bind({});
 BehandlingIkkeErValgt.args = {

--- a/packages/sak-historikk/src/components/DevModeTooltip.tsx
+++ b/packages/sak-historikk/src/components/DevModeTooltip.tsx
@@ -1,0 +1,20 @@
+import React, { FC, PropsWithChildren } from 'react';
+import { Tooltip } from '@navikt/ds-react';
+
+interface OwnProps {
+  content: string;
+  isDevelopment?: boolean;
+}
+
+export const DevModeTooltip: FC<PropsWithChildren<OwnProps>> = ({
+  children,
+  content,
+  isDevelopment = import.meta.env.MODE === 'development',
+}) =>
+  isDevelopment ? (
+    <Tooltip content={content}>
+      <div>{children}</div>
+    </Tooltip>
+  ) : (
+    <>{children}</>
+  );

--- a/packages/sak-historikk/src/components/History.tsx
+++ b/packages/sak-historikk/src/components/History.tsx
@@ -1,203 +1,16 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Location } from 'history';
 import { useIntl } from 'react-intl';
 import moment from 'moment';
-import { Checkbox, Heading } from '@navikt/ds-react';
-
-import { FlexColumn, FlexContainer, FlexRow } from '@navikt/ft-ui-komponenter';
+import { Checkbox, Detail, Heading, HStack, VStack } from '@navikt/ds-react';
 
 import { AlleKodeverk, AlleKodeverkTilbakekreving, Historikkinnslag } from '@navikt/fp-types';
-import { KodeverkType, getKodeverknavnFn, historikkAktor as HistorikkAktor } from '@navikt/fp-kodeverk';
-
-import historikkinnslagType from '../kodeverk/historikkinnslagType';
+import { getKodeverknavnFn, historikkAktor as HistorikkAktor, KodeverkType } from '@navikt/fp-kodeverk';
 import Snakkeboble from './maler/felles/snakkeboble';
-import HistorikkMalType1 from './maler/historikkMalType1';
-import HistorikkMalType2 from './maler/historikkMalType2';
-import HistorikkMalType3 from './maler/historikkMalType3';
-import HistorikkMalType4 from './maler/historikkMalType4';
-import HistorikkMalType5 from './maler/historikkMalType5';
-import HistorikkMalType6 from './maler/HistorikkMalType6';
-import HistorikkMalType7 from './maler/HistorikkMalType7';
-import HistorikkMalType8 from './maler/HistorikkMalType8';
-import HistorikkMalType9 from './maler/HistorikkMalType9';
-import HistorikkMalType10 from './maler/HistorikkMalType10';
-import HistorikkMalTypeFeilutbetaling from './maler/HistorikkMalTypeFeilutbetaling';
-import HistorikkMalTypeTilbakekreving from './maler/HistorikkMalTypeTilbakekreving';
-import HistorikkMalTypeForeldelse from './maler/HistorikkMalTypeForeldelse';
-import PlaceholderHistorikkMal from './maler/placeholderHistorikkMal';
-import HistorikkMalTypeAktivitetskrav from './maler/HistorikkMalTypeAktivitetskrav';
 
 import styles from './history.module.css';
-
-/*
- https://confluence.adeo.no/display/MODNAV/OMR-13+SF4+Sakshistorikk+-+UX+og+grafisk+design
-
- Fem design patterns:
-
- +----------------------------+
- | Type 1                     |
- | BEH_VENT                   |
- | BEH_GJEN                   |
- | KØET_BEH_GJEN              |
- | BEH_STARTET                |
- | VEDLEGG_MOTTATT            |
- | BREV_SENT                  |
- | BREV_BESTILT               |
- | REGISTRER_PAPIRSØK         |
- | MANGELFULL_SØKNAD          |
- +----------------------------+
- <tidspunkt> // <rolle> <id>
- <hendelse>
- <begrunnelsestekst>
- <dokumentLinker>
-
- +----------------------------+
- | Type 2                     |
- | FORSLAG_VEDTAK             |
- | FORSLAG_VEDTAK_UTEN_TOTRINN|
- | VEDTAK_FATTET              |
- | VEDTAK_FATTET_AUTOMATISK   |
- | OVERSTYRT (hvis beslutter) |
- | REGISTRER_OM_VERGE         |
- +----------------------------+
- <tidspunkt> // <rolle> <id>
- <hendelse>: <resultat>
- <skjermlinke>
-
- +----------------------------+
- | Type 3                     |
- | SAK_RETUR                  |
- +----------------------------+
- <tidspunkt> // <rolle> <id>
- <hendelse>
- <begrunnelsestekst>
- <dokumentLinker>
-
- +----------------------------+
- | Type 4                     |
- | AVBRUTT_BEH                |
- | OVERSTYRT (hvis saksbeh.)  |
- +----------------------------+
- <tidspunkt> // <rolle> <id>
- <hendelse>
- <årsak>
- <begrunnelsestekst>
-
- +----------------------------+
- | Type 5                     |
- | FAKTA_ENDRET               |
- +----------------------------+
- <tidspunkt> // <rolle> <id>
- <skjermlinke>
- <feltnavn> er endret <fra-verdi> til <til-verdi>
- <radiogruppe> er satt til <verdi>
- <begrunnelsestekst>
- <dokumentLinker>
-
- +----------------------------+
- | Type 6                     |
- | NY_INFO_FRA_TPS            |
- +----------------------------+
- Ikke definert
-
- +----------------------------+
- | Type 7                     |
- | OVERSTYRT                  |
- +----------------------------+
- <tidspunkt> // <rolle> <id>
- <skjermlinke>
- Overstyrt <vurdering/beregning>: <Utfallet/beløpet> er endret fra <fra-verdi> til <til-verdi>
- <begrunnelsestekst>
-
-+----------------------------+
- | Type 8                     |
- | ???                        |
- +----------------------------+
- Ikke definiert
-
- */
-
-const velgHistorikkMal = (histType: string) => {
-  // NOSONAR
-  switch (
-    histType // NOSONAR
-  ) {
-    case historikkinnslagType.BEH_GJEN:
-    case historikkinnslagType.KOET_BEH_GJEN:
-    case historikkinnslagType.BEH_MAN_GJEN:
-    case historikkinnslagType.BEH_STARTET:
-    case historikkinnslagType.BEH_STARTET_PAA_NYTT:
-    case historikkinnslagType.BEH_STARTET_FORFRA:
-    case historikkinnslagType.VEDLEGG_MOTTATT:
-    case historikkinnslagType.BREV_SENT:
-    case historikkinnslagType.BREV_BESTILT:
-    case historikkinnslagType.REVURD_OPPR:
-    case historikkinnslagType.REGISTRER_PAPIRSOK:
-    case historikkinnslagType.MANGELFULL_SOKNAD:
-    case historikkinnslagType.INNSYN_OPPR:
-    case historikkinnslagType.VRS_REV_IKKE_SNDT:
-    case historikkinnslagType.NYE_REGOPPLYSNINGER:
-    case historikkinnslagType.BEH_AVBRUTT_VUR:
-    case historikkinnslagType.BEH_OPPDATERT_NYE_OPPL:
-    case historikkinnslagType.SPOLT_TILBAKE:
-    case historikkinnslagType.TILBAKEKREVING_OPPR:
-    case historikkinnslagType.MIGRERT_FRA_INFOTRYGD:
-    case historikkinnslagType.MIGRERT_FRA_INFOTRYGD_FJERNET:
-    case historikkinnslagType.ANKEBEH_STARTET:
-    case historikkinnslagType.KLAGEBEH_STARTET:
-    case historikkinnslagType.ENDRET_DEKNINGSGRAD:
-    case historikkinnslagType.OPPGAVE_VEDTAK:
-      return HistorikkMalType1;
-    case historikkinnslagType.FORSLAG_VEDTAK:
-    case historikkinnslagType.FORSLAG_VEDTAK_UTEN_TOTRINN:
-    case historikkinnslagType.VEDTAK_FATTET:
-    case historikkinnslagType.VEDTAK_FATTET_AUTOMATISK:
-    case historikkinnslagType.UENDRET_UTFALL:
-    case historikkinnslagType.REGISTRER_OM_VERGE:
-      return HistorikkMalType2;
-    case historikkinnslagType.SAK_RETUR:
-      return HistorikkMalType3;
-    case historikkinnslagType.AVBRUTT_BEH:
-    case historikkinnslagType.BEH_KØET:
-    case historikkinnslagType.BEH_VENT:
-    case historikkinnslagType.IVERKSETTELSE_VENT:
-    case historikkinnslagType.FJERNET_VERGE:
-      return HistorikkMalType4;
-    case historikkinnslagType.SAK_GODKJENT:
-    case historikkinnslagType.FAKTA_ENDRET:
-    case historikkinnslagType.KLAGE_BEH_NK:
-    case historikkinnslagType.KLAGE_BEH_NFP:
-    case historikkinnslagType.BYTT_ENHET:
-    case historikkinnslagType.UTTAK:
-    case historikkinnslagType.TERMINBEKREFTELSE_UGYLDIG:
-    case historikkinnslagType.ANKE_BEH:
-      return HistorikkMalType5;
-    case historikkinnslagType.NY_INFO_FRA_TPS:
-    case historikkinnslagType.NY_GRUNNLAG_MOTTATT:
-      return HistorikkMalType6;
-    case historikkinnslagType.OVERSTYRT:
-      return HistorikkMalType7;
-    case historikkinnslagType.OPPTJENING:
-      return HistorikkMalType8;
-    case historikkinnslagType.OVST_UTTAK_SPLITT:
-    case historikkinnslagType.FASTSATT_UTTAK_SPLITT:
-    case historikkinnslagType.TILBAKEKR_VIDEREBEHANDLING:
-      return HistorikkMalType9;
-    case historikkinnslagType.OVST_UTTAK:
-    case historikkinnslagType.FASTSATT_UTTAK:
-      return HistorikkMalType10;
-    case historikkinnslagType.FAKTA_OM_FEILUTBETALING:
-      return HistorikkMalTypeFeilutbetaling;
-    case historikkinnslagType.FORELDELSE:
-      return HistorikkMalTypeForeldelse;
-    case historikkinnslagType.TILBAKEKREVING:
-      return HistorikkMalTypeTilbakekreving;
-    case historikkinnslagType.AVKLART_AKTIVITETSKRAV:
-      return HistorikkMalTypeAktivitetskrav;
-    default:
-      return PlaceholderHistorikkMal;
-  }
-};
+import velgHistorikkMal from './historikkMal';
+import { DevModeTooltip } from './DevModeTooltip';
 
 type HistorikkMedTilbakekrevingIndikator = Historikkinnslag & {
   erTilbakekreving?: boolean;
@@ -233,7 +46,7 @@ interface OwnProps {
  *
  * Historikken for en behandling
  */
-const History: FunctionComponent<OwnProps> = ({
+const History: FC<OwnProps> = ({
   historikkFpSak,
   historikkFpTilbake,
   alleKodeverkFpTilbake,
@@ -281,32 +94,17 @@ const History: FunctionComponent<OwnProps> = ({
   return (
     <>
       <div className={styles.header}>
-        <FlexContainer>
-          <FlexRow spaceBetween>
-            <FlexColumn>
-              <Heading size="small">{intl.formatMessage({ id: 'History.Historikk' })}</Heading>
-            </FlexColumn>
-            <FlexColumn>
-              <FlexContainer>
-                <FlexRow>
-                  {valgtBehandlingUuid && (
-                    <FlexColumn className={styles.marginFilter}>
-                      <Checkbox
-                        size="small"
-                        onChange={() => setSkalSortertePaBehandling(!skalSortertePaValgtBehandling)}
-                      >
-                        {intl.formatMessage({ id: 'History.FiltrerPaBehandling' })}
-                      </Checkbox>
-                    </FlexColumn>
-                  )}
-                  <FlexColumn>
-                    <div className={styles.circle}>{filtrerteInnslag.length}</div>
-                  </FlexColumn>
-                </FlexRow>
-              </FlexContainer>
-            </FlexColumn>
-          </FlexRow>
-        </FlexContainer>
+        <HStack justify="space-between">
+          <Heading size="small">{intl.formatMessage({ id: 'History.Historikk' })}</Heading>
+          <HStack gap="6">
+            {valgtBehandlingUuid && (
+              <Checkbox size="small" onChange={() => setSkalSortertePaBehandling(!skalSortertePaValgtBehandling)}>
+                {intl.formatMessage({ id: 'History.FiltrerPaBehandling' })}
+              </Checkbox>
+            )}
+            <Detail className={styles.circle}>{filtrerteInnslag.length}</Detail>
+          </HStack>
+        </HStack>
       </div>
       <div
         style={{ height: `calc(100vh - ${top}px)` }}
@@ -317,39 +115,45 @@ const History: FunctionComponent<OwnProps> = ({
           }
         }}
       >
-        {filtrerteInnslag.map((historikkinnslag, index) => {
-          const HistorikkMal = velgHistorikkMal(historikkinnslag.type);
-          const aktorIsVL = historikkinnslag.aktoer === HistorikkAktor.VEDTAKSLOSNINGEN;
-          const aktorIsSOKER = historikkinnslag.aktoer === HistorikkAktor.SOKER;
-          const aktorIsArbeidsgiver = historikkinnslag.aktoer === HistorikkAktor.ARBEIDSGIVER;
+        <VStack gap="2" paddingBlock="4">
+          {filtrerteInnslag.map((historikkinnslag, index) => {
+            const { aktoer, behandlingUuid, erTilbakekreving, opprettetAv, opprettetTidspunkt, type } =
+              historikkinnslag;
 
-          const getKodeverknavn = historikkinnslag.erTilbakekreving ? getKodeverknavnFpTilbake : getKodeverknavnFpSak;
+            const HistorikkMal = velgHistorikkMal(type);
+            const aktorIsVL = aktoer === HistorikkAktor.VEDTAKSLOSNINGEN;
+            const aktorIsSOKER = aktoer === HistorikkAktor.SOKER;
+            const aktorIsArbeidsgiver = aktoer === HistorikkAktor.ARBEIDSGIVER;
 
-          if (!getKodeverknavn) {
-            return null;
-          }
+            const getKodeverknavn = erTilbakekreving ? getKodeverknavnFpTilbake : getKodeverknavnFpSak;
 
-          return (
-            <Snakkeboble
-              key={historikkinnslag.opprettetTidspunkt + historikkinnslag.type}
-              aktoer={historikkinnslag.aktoer}
-              rolleNavn={getKodeverknavn(historikkinnslag.aktoer, KodeverkType.HISTORIKK_AKTOER)}
-              dato={historikkinnslag.opprettetTidspunkt}
-              kjoenn={kjønn}
-              opprettetAv={aktorIsSOKER || aktorIsArbeidsgiver || aktorIsVL ? '' : historikkinnslag.opprettetAv}
-              erFørsteBoble={index === 0}
-            >
-              <HistorikkMal
-                historikkinnslag={historikkinnslag}
-                behandlingLocation={getBehandlingLocation(historikkinnslag.behandlingUuid)}
-                saksnummer={saksnummer}
-                getKodeverknavn={getKodeverknavn}
-                createLocationForSkjermlenke={createLocationForSkjermlenke}
-                erTilbakekreving={!!historikkinnslag.erTilbakekreving}
-              />
-            </Snakkeboble>
-          );
-        })}
+            if (!getKodeverknavn) {
+              return null;
+            }
+
+            return (
+              <DevModeTooltip key={opprettetTidspunkt + type} content={`${HistorikkMal.name} - ${type}`}>
+                <Snakkeboble
+                  aktoer={aktoer}
+                  rolleNavn={getKodeverknavn(aktoer, KodeverkType.HISTORIKK_AKTOER)}
+                  dato={opprettetTidspunkt}
+                  kjoenn={kjønn}
+                  opprettetAv={aktorIsSOKER || aktorIsArbeidsgiver || aktorIsVL ? '' : opprettetAv}
+                  erFørsteBoble={index === 0}
+                >
+                  <HistorikkMal
+                    historikkinnslag={historikkinnslag}
+                    behandlingLocation={getBehandlingLocation(behandlingUuid)}
+                    saksnummer={saksnummer}
+                    getKodeverknavn={getKodeverknavn}
+                    createLocationForSkjermlenke={createLocationForSkjermlenke}
+                    erTilbakekreving={!!erTilbakekreving}
+                  />
+                </Snakkeboble>
+              </DevModeTooltip>
+            );
+          })}
+        </VStack>
       </div>
     </>
   );

--- a/packages/sak-historikk/src/components/historikkMal.ts
+++ b/packages/sak-historikk/src/components/historikkMal.ts
@@ -1,0 +1,196 @@
+import { Location } from 'history';
+import { Historikkinnslag } from '@navikt/fp-types';
+import { KodeverkType } from '@navikt/fp-kodeverk';
+import historikkinnslagType from '../kodeverk/historikkinnslagType';
+import HistorikkMalType1 from './maler/historikkMalType1';
+import HistorikkMalType2 from './maler/historikkMalType2';
+import HistorikkMalType3 from './maler/historikkMalType3';
+import HistorikkMalType4 from './maler/historikkMalType4';
+import HistorikkMalType5 from './maler/historikkMalType5';
+import HistorikkMalType6 from './maler/HistorikkMalType6';
+import HistorikkMalType7 from './maler/HistorikkMalType7';
+import HistorikkMalType8 from './maler/HistorikkMalType8';
+import HistorikkMalType9 from './maler/HistorikkMalType9';
+import HistorikkMalType10 from './maler/HistorikkMalType10';
+import HistorikkMalTypeFeilutbetaling from './maler/HistorikkMalTypeFeilutbetaling';
+import HistorikkMalTypeTilbakekreving from './maler/HistorikkMalTypeTilbakekreving';
+import HistorikkMalTypeForeldelse from './maler/HistorikkMalTypeForeldelse';
+import PlaceholderHistorikkMal from './maler/placeholderHistorikkMal';
+import HistorikkMalTypeAktivitetskrav from './maler/HistorikkMalTypeAktivitetskrav';
+
+export interface HistorikkMal {
+  historikkinnslag: Historikkinnslag;
+  behandlingLocation: Location;
+  getKodeverknavn: (kode: string, kodeverk: KodeverkType) => string;
+  createLocationForSkjermlenke: (behandlingLocation: Location, skjermlenkeCode: string) => Location | undefined;
+  saksnummer: string;
+  erTilbakekreving: boolean;
+}
+
+/*
+ https://confluence.adeo.no/display/MODNAV/OMR-13+SF4+Sakshistorikk+-+UX+og+grafisk+design
+
+ Fem design patterns:
+
+ +----------------------------+
+ | Type 1                     |
+ | BEH_VENT                   |
+ | BEH_GJEN                   |
+ | KØET_BEH_GJEN              |
+ | BEH_STARTET                |
+ | VEDLEGG_MOTTATT            |
+ | BREV_SENT                  |
+ | BREV_BESTILT               |
+ | REGISTRER_PAPIRSØK         |
+ | MANGELFULL_SØKNAD          |
+ +----------------------------+
+ <tidspunkt> // <rolle> <id>
+ <hendelse>
+ <begrunnelsestekst>
+ <dokumentLinker>
+
+ +----------------------------+
+ | Type 2                     |
+ | FORSLAG_VEDTAK             |
+ | FORSLAG_VEDTAK_UTEN_TOTRINN|
+ | VEDTAK_FATTET              |
+ | VEDTAK_FATTET_AUTOMATISK   |
+ | OVERSTYRT (hvis beslutter) |
+ | REGISTRER_OM_VERGE         |
+ +----------------------------+
+ <tidspunkt> // <rolle> <id>
+ <hendelse>: <resultat>
+ <skjermlinke>
+
+ +----------------------------+
+ | Type 3                     |
+ | SAK_RETUR                  |
+ +----------------------------+
+ <tidspunkt> // <rolle> <id>
+ <hendelse>
+ <begrunnelsestekst>
+ <dokumentLinker>
+
+ +----------------------------+
+ | Type 4                     |
+ | AVBRUTT_BEH                |
+ | OVERSTYRT (hvis saksbeh.)  |
+ +----------------------------+
+ <tidspunkt> // <rolle> <id>
+ <hendelse>
+ <årsak>
+ <begrunnelsestekst>
+
+ +----------------------------+
+ | Type 5                     |
+ | FAKTA_ENDRET               |
+ +----------------------------+
+ <tidspunkt> // <rolle> <id>
+ <skjermlinke>
+ <feltnavn> er endret <fra-verdi> til <til-verdi>
+ <radiogruppe> er satt til <verdi>
+ <begrunnelsestekst>
+ <dokumentLinker>
+
+ +----------------------------+
+ | Type 6                     |
+ | NY_INFO_FRA_TPS            |
+ +----------------------------+
+ Ikke definert
+
+ +----------------------------+
+ | Type 7                     |
+ | OVERSTYRT                  |
+ +----------------------------+
+ <tidspunkt> // <rolle> <id>
+ <skjermlinke>
+ Overstyrt <vurdering/beregning>: <Utfallet/beløpet> er endret fra <fra-verdi> til <til-verdi>
+ <begrunnelsestekst>
+
++----------------------------+
+ | Type 8                     |
+ | ???                        |
+ +----------------------------+
+ Ikke definiert
+
+ */
+const velgHistorikkMal = (histType: string) => {
+  switch (histType) {
+    case historikkinnslagType.BEH_GJEN:
+    case historikkinnslagType.KOET_BEH_GJEN:
+    case historikkinnslagType.BEH_MAN_GJEN:
+    case historikkinnslagType.BEH_STARTET:
+    case historikkinnslagType.BEH_STARTET_PAA_NYTT:
+    case historikkinnslagType.BEH_STARTET_FORFRA:
+    case historikkinnslagType.VEDLEGG_MOTTATT:
+    case historikkinnslagType.BREV_SENT:
+    case historikkinnslagType.BREV_BESTILT:
+    case historikkinnslagType.REVURD_OPPR:
+    case historikkinnslagType.REGISTRER_PAPIRSOK:
+    case historikkinnslagType.MANGELFULL_SOKNAD:
+    case historikkinnslagType.INNSYN_OPPR:
+    case historikkinnslagType.VRS_REV_IKKE_SNDT:
+    case historikkinnslagType.NYE_REGOPPLYSNINGER:
+    case historikkinnslagType.BEH_AVBRUTT_VUR:
+    case historikkinnslagType.BEH_OPPDATERT_NYE_OPPL:
+    case historikkinnslagType.SPOLT_TILBAKE:
+    case historikkinnslagType.TILBAKEKREVING_OPPR:
+    case historikkinnslagType.MIGRERT_FRA_INFOTRYGD:
+    case historikkinnslagType.MIGRERT_FRA_INFOTRYGD_FJERNET:
+    case historikkinnslagType.ANKEBEH_STARTET:
+    case historikkinnslagType.KLAGEBEH_STARTET:
+    case historikkinnslagType.ENDRET_DEKNINGSGRAD:
+    case historikkinnslagType.OPPGAVE_VEDTAK:
+      return HistorikkMalType1;
+    case historikkinnslagType.FORSLAG_VEDTAK:
+    case historikkinnslagType.FORSLAG_VEDTAK_UTEN_TOTRINN:
+    case historikkinnslagType.VEDTAK_FATTET:
+    case historikkinnslagType.VEDTAK_FATTET_AUTOMATISK:
+    case historikkinnslagType.UENDRET_UTFALL:
+    case historikkinnslagType.REGISTRER_OM_VERGE:
+      return HistorikkMalType2;
+    case historikkinnslagType.SAK_RETUR:
+      return HistorikkMalType3;
+    case historikkinnslagType.AVBRUTT_BEH:
+    case historikkinnslagType.BEH_KØET:
+    case historikkinnslagType.BEH_VENT:
+    case historikkinnslagType.IVERKSETTELSE_VENT:
+    case historikkinnslagType.FJERNET_VERGE:
+      return HistorikkMalType4;
+    case historikkinnslagType.SAK_GODKJENT:
+    case historikkinnslagType.FAKTA_ENDRET:
+    case historikkinnslagType.KLAGE_BEH_NK:
+    case historikkinnslagType.KLAGE_BEH_NFP:
+    case historikkinnslagType.BYTT_ENHET:
+    case historikkinnslagType.UTTAK:
+    case historikkinnslagType.TERMINBEKREFTELSE_UGYLDIG:
+    case historikkinnslagType.ANKE_BEH:
+      return HistorikkMalType5;
+    case historikkinnslagType.NY_INFO_FRA_TPS:
+    case historikkinnslagType.NY_GRUNNLAG_MOTTATT:
+      return HistorikkMalType6;
+    case historikkinnslagType.OVERSTYRT:
+      return HistorikkMalType7;
+    case historikkinnslagType.OPPTJENING:
+      return HistorikkMalType8;
+    case historikkinnslagType.OVST_UTTAK_SPLITT:
+    case historikkinnslagType.FASTSATT_UTTAK_SPLITT:
+    case historikkinnslagType.TILBAKEKR_VIDEREBEHANDLING:
+      return HistorikkMalType9;
+    case historikkinnslagType.OVST_UTTAK:
+    case historikkinnslagType.FASTSATT_UTTAK:
+      return HistorikkMalType10;
+    case historikkinnslagType.FAKTA_OM_FEILUTBETALING:
+      return HistorikkMalTypeFeilutbetaling;
+    case historikkinnslagType.FORELDELSE:
+      return HistorikkMalTypeForeldelse;
+    case historikkinnslagType.TILBAKEKREVING:
+      return HistorikkMalTypeTilbakekreving;
+    case historikkinnslagType.AVKLART_AKTIVITETSKRAV:
+      return HistorikkMalTypeAktivitetskrav;
+    default:
+      return PlaceholderHistorikkMal;
+  }
+};
+
+export default velgHistorikkMal;

--- a/packages/sak-historikk/src/components/maler/felles/historikkUtils.tsx
+++ b/packages/sak-historikk/src/components/maler/felles/historikkUtils.tsx
@@ -55,7 +55,7 @@ export const findHendelseText = (
   if (!hendelse || !hendelse.navn) {
     return undefined;
   }
-  if (hendelse.verdi === null) {
+  if (!hendelse.verdi) {
     return getKodeverknavn(hendelse.navn, KodeverkType.HISTORIKKINNSLAG_TYPE);
   }
   return `${getKodeverknavn(hendelse.navn, KodeverkType.HISTORIKKINNSLAG_TYPE)} ${hendelse.verdi}`;

--- a/packages/sak-historikk/src/components/maler/placeholderHistorikkMal.tsx
+++ b/packages/sak-historikk/src/components/maler/placeholderHistorikkMal.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-const PlaceholderHistorikkMal = () => <FormattedMessage id="Historikk.FinnerIngenMal" />;
+const PlaceholderHistorikkMal: FC = () => <FormattedMessage id="Historikk.FinnerIngenMal" />;
 
 export default PlaceholderHistorikkMal;

--- a/packages/sak-historikk/src/saksHistorikkAlleMaler.ts
+++ b/packages/sak-historikk/src/saksHistorikkAlleMaler.ts
@@ -1,0 +1,342 @@
+import { Historikkinnslag, HistorikkinnslagDel, HistorikkinnslagEndretFelt } from '@navikt/fp-types';
+
+const lagHistorikk = (input: Partial<Historikkinnslag>): Historikkinnslag =>
+  ({
+    behandlingUuid: 'f13637fd-ef16-4bd8-b1b1-9b1f876de807',
+    dokumentLinks: [],
+    historikkinnslagDeler: [],
+    ...input,
+  }) as Historikkinnslag;
+
+const lagInnslagDel = (input: Partial<HistorikkinnslagDel>): HistorikkinnslagDel =>
+  ({
+    begrunnelsetekst: null,
+    begrunnelseFritekst: null,
+    hendelse: null,
+    opplysninger: null,
+    soeknadsperiode: null,
+    skjermlenke: null,
+    årsaktekst: null,
+    tema: null,
+    gjeldendeFra: null,
+    resultat: null,
+    endredeFelter: null,
+    aksjonspunkter: null,
+    ...input,
+  }) as HistorikkinnslagDel;
+
+const lagEndretFelt = (input: Partial<HistorikkinnslagEndretFelt>): HistorikkinnslagEndretFelt =>
+  ({
+    endretFeltNavn: 'DOKUMENTASJON_FORELIGGER',
+    navnVerdi: null,
+    fraVerdi: null,
+    klFraVerdi: null,
+    klTilVerdi: null,
+    ...input,
+  }) as HistorikkinnslagEndretFelt;
+
+const historikkAlleMaler: Historikkinnslag[] = [
+  lagHistorikk({
+    type: 'BREV_SENT',
+    aktoer: 'VL',
+    opprettetAv: 'Srvvtp',
+    opprettetTidspunkt: '2024-08-09T13:01:33.074',
+    dokumentLinks: [
+      {
+        tag: 'Innvilgelsesbrev foreldrepenger',
+        url: 'https://example.com',
+        journalpostId: '1',
+        dokumentId: '1',
+        utgått: false,
+      },
+    ],
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        hendelse: {
+          navn: 'BREV_SENT',
+        },
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'VEDTAK_FATTET',
+    aktoer: 'BESL',
+    opprettetAv: 'B123456',
+    opprettetTidspunkt: '2024-08-09T13:02:29.674',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        hendelse: {
+          navn: 'VEDTAK_FATTET',
+        },
+        skjermlenke: 'VEDTAK',
+        resultat: 'INNVILGET',
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'SAK_RETUR',
+    aktoer: 'BESL',
+    opprettetAv: 'B123456',
+    opprettetTidspunkt: '2024-08-09T13:03:32.111',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        hendelse: {
+          navn: 'SAK_RETUR',
+        },
+        skjermlenke: 'FAKTA_FOR_OPPTJENING',
+        aksjonspunkter: [
+          {
+            aksjonspunktBegrunnelse: 'Dette er en begrunnelse',
+            godkjent: false,
+            aksjonspunktKode: '5051',
+          },
+        ],
+      }),
+      lagInnslagDel({
+        skjermlenke: 'BEREGNING_FORELDREPENGER',
+        aksjonspunkter: [
+          {
+            aksjonspunktBegrunnelse: 'Dette er en begrunnelse',
+            godkjent: false,
+            aksjonspunktKode: '5038',
+          },
+        ],
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'BEH_VENT',
+    aktoer: 'VL',
+    opprettetAv: 'Srvfpsak',
+    opprettetTidspunkt: '2024-08-09T13:04:33.7',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        hendelse: {
+          navn: 'BEH_VENT',
+          verdi: '16.08.2024',
+        },
+        årsaktekst: 'Venter på inntektsmelding',
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'BEH_VENT',
+    aktoer: 'VL',
+    opprettetAv: 'Srvfpsak',
+    opprettetTidspunkt: '2024-08-09T13:04:54.289',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        hendelse: {
+          navn: 'BEH_VENT',
+          verdi: '16.08.2024',
+        },
+        årsaktekst: 'Venter på inntektsmelding',
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'FAKTA_ENDRET',
+    aktoer: 'SBH',
+    opprettetAv: 'S123456',
+    opprettetTidspunkt: '2024-08-09T13:05:55.571',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        opplysninger: [
+          {
+            opplysningType: 'ANTALL_BARN',
+            tilVerdi: '1',
+          },
+        ],
+        skjermlenke: 'FAKTA_OM_FOEDSEL',
+        endredeFelter: [
+          lagEndretFelt({
+            endretFeltNavn: 'DOKUMENTASJON_FORELIGGER',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: true,
+          }),
+          lagEndretFelt({
+            endretFeltNavn: 'BRUK_ANTALL_I_SOKNAD',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: true,
+          }),
+        ],
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'OVERSTYRT',
+    aktoer: 'SBH',
+    opprettetAv: 'S123456',
+    opprettetTidspunkt: '2024-08-09T13:07:15.987',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        begrunnelseFritekst: 'avvist',
+        skjermlenke: 'PUNKT_FOR_FOEDSEL',
+        endredeFelter: [
+          lagEndretFelt({
+            endretFeltNavn: 'OVERSTYRT_VURDERING',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            fraVerdi: 'VILKAR_OPPFYLT',
+            tilVerdi: 'VILKAR_IKKE_OPPFYLT',
+            klFraVerdi: 'HISTORIKK_ENDRET_FELT_VERDI_TYPE',
+            klTilVerdi: 'HISTORIKK_ENDRET_FELT_VERDI_TYPE',
+          }),
+        ],
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'TILBAKEKR_VIDEREBEHANDLING',
+    aktoer: 'SBH',
+    opprettetAv: 'S123456',
+    opprettetTidspunkt: '2024-08-09T13:09:49.778',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        begrunnelseFritekst: 'Dette er begrunnelsen',
+        hendelse: {
+          navn: 'TILBAKEKR_VIDEREBEHANDLING',
+        },
+        skjermlenke: 'FAKTA_OM_SIMULERING',
+        endredeFelter: [
+          lagEndretFelt({
+            endretFeltNavn: 'FASTSETT_VIDERE_BEHANDLING',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'TILBAKEKR_IGNORER',
+            klTilVerdi: 'TILBAKEKR_VIDERE_BEH',
+          }),
+        ],
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'FASTSATT_UTTAK',
+    aktoer: 'SBH',
+    opprettetAv: 'S123456',
+    opprettetTidspunkt: '2024-08-09T13:10:25.853',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        begrunnelseFritekst: 'Perioden er avslått av Autotest.',
+        hendelse: {
+          navn: 'FASTSATT_UTTAK',
+        },
+        opplysninger: [
+          {
+            opplysningType: 'UTTAK_PERIODE_FOM',
+            tilVerdi: '31.01.2025',
+          },
+          {
+            opplysningType: 'UTTAK_PERIODE_TOM',
+            tilVerdi: '06.02.2025',
+          },
+        ],
+        skjermlenke: 'UTTAK',
+        endredeFelter: [
+          lagEndretFelt({
+            endretFeltNavn: 'UTTAK_TREKKDAGER',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            fraVerdi: '5.0',
+            tilVerdi: '0.0',
+          }),
+          lagEndretFelt({
+            endretFeltNavn: 'UTTAK_PERIODE_RESULTAT_TYPE',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            fraVerdi: 'MANUELL_BEHANDLING',
+            tilVerdi: 'AVSLÅTT',
+            klFraVerdi: 'PERIODE_RESULTAT_TYPE',
+            klTilVerdi: 'PERIODE_RESULTAT_TYPE',
+          }),
+        ],
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'TILBAKEKREVING',
+    aktoer: 'SBH',
+    opprettetAv: 'S123456',
+    opprettetTidspunkt: '2024-08-09T13:11:21.659',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        begrunnelseFritekst: 'Dette er en aktsomhetsvurdering skrevet av Autotest!',
+        opplysninger: [
+          {
+            opplysningType: 'PERIODE_FOM',
+            tilVerdi: '12.02.2024',
+          },
+          {
+            opplysningType: 'PERIODE_TOM',
+            tilVerdi: '12.02.2024',
+          },
+          {
+            opplysningType: 'TILBAKEKREVING_OPPFYLT_BEGRUNNELSE',
+            tilVerdi: 'Dette er en vilkårsvurdering skrevet av Autotest!',
+          },
+          {
+            opplysningType: 'SÆRLIG_GRUNNER_BEGRUNNELSE',
+            tilVerdi: 'Dette er en særlige grunner vurdering skrevet av Autotest!',
+          },
+        ],
+        skjermlenke: 'TILBAKEKREVING',
+        endredeFelter: [
+          lagEndretFelt({
+            endretFeltNavn: 'ER_VILKARENE_TILBAKEKREVING_OPPFYLT',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'Ja, mottaker forsto eller burde forstått at utbetalingen skyldtes en feil (1. ledd, 1. punkt)',
+          }),
+          lagEndretFelt({
+            endretFeltNavn: 'MOTTAKER_UAKTSOMHET_GRAD',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'Simpel uaktsomhet',
+          }),
+          lagEndretFelt({
+            endretFeltNavn: 'TILBAKEKREV_SMAABELOEP',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'Ja',
+          }),
+          lagEndretFelt({
+            endretFeltNavn: 'ER_SARLIGE_GRUNNER_TIL_REDUKSJON',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'Nei: Om feilen helt eller delvis kan tilskrives NAV, Hvor lang tid siden utbetalingen fant sted',
+          }),
+        ],
+      }),
+    ],
+  }),
+  lagHistorikk({
+    type: 'FAKTA_OM_FEILUTBETALING',
+    aktoer: 'SBH',
+    opprettetAv: 'S123456',
+    opprettetTidspunkt: '2024-08-09T13:12:20.722',
+    historikkinnslagDeler: [
+      lagInnslagDel({
+        begrunnelseFritekst: 'Dette er en begrunnelse dannet av Autotest!',
+        opplysninger: [
+          {
+            opplysningType: 'PERIODE_FOM',
+            tilVerdi: '12.02.2024',
+          },
+          {
+            opplysningType: 'PERIODE_TOM',
+            tilVerdi: '12.02.2024',
+          },
+        ],
+        skjermlenke: 'FAKTA_OM_FEILUTBETALING',
+        endredeFelter: [
+          lagEndretFelt({
+            endretFeltNavn: 'HENDELSE_AARSAK',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'ES_ADOPSJONSVILKAARET_TYPE',
+            klTilVerdi: 'HENDELSE_TYPE',
+          }),
+          lagEndretFelt({
+            endretFeltNavn: 'HENDELSE_UNDER_AARSAK',
+            klNavn: 'HISTORIKK_ENDRET_FELT_TYPE',
+            tilVerdi: 'ES_IKKE_OPPFYLT',
+            klTilVerdi: 'HENDELSE_UNDERTYPE',
+          }),
+        ],
+      }),
+    ],
+  }),
+];
+
+export default historikkAlleMaler;


### PR DESCRIPTION
I forbindelse med nye design endringer i historikkoversikten ser jeg behovet for å ha en egen story som viser alle malene. Det vil gjøre det lettere å diskutere design med Anna fordi da får man mer realistisk data å basere nytt design på. 

Under prosessen for å finne data, ble det tydelig at HistorikkInnslag som vi får fra fpsak gir oss nullable verdier, derfor har jeg introdusert null` i HistorikkInnslag typene.

Jeg oppdaget også at det er svært vanskelig å utlede hvilken mal som brukes til enhver tid, derfor foreslår jeg å bruke komponenten DevModeTooltip til å vise frem hvilken mal som brukes av snakkebobblene når man kjøre applikasjonen i dev-mode. Gjerne gi meg tilbakemelding på hva dere synes om det. 

Del 2 med designendringene kommer på et senere tidspunkt