### PR TITLE
Fiks naturalytelser im panel

### DIFF
--- a/packages/fakta-inntektsmelding/i18n/nb_NO.json
+++ b/packages/fakta-inntektsmelding/i18n/nb_NO.json
@@ -53,5 +53,6 @@
   "InntektsmeldingFaktaPanel.bortfalteNaturalytelser.heading": "Naturalytelser som faller bort",
   "InntektsmeldingFaktaPanel.bortfalteNaturalytelser.ingen": "Ingen",
   "InntektsmeldingFaktaPanel.bortfalteNaturalytelser.fom": "Fra og med",
+  "InntektsmeldingFaktaPanel.bortfalteNaturalytelser.tom": "Til og med",
   "InntektsmeldingFaktaPanel.bortfalteNaturalytelser.verdi": "Verdi pr måned"
 }

--- a/packages/fakta-inntektsmelding/src/InntektsmeldingInnhold.tsx
+++ b/packages/fakta-inntektsmelding/src/InntektsmeldingInnhold.tsx
@@ -193,10 +193,10 @@ const BortfalteNaturalYtelser = ({ inntektsmelding }: { inntektsmelding: Inntekt
                       <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.verdi" />:{' '}
                       {formatCurrencyNoKr(naturalytelse.beloepPerMnd.verdi)}
                     </li>
-                    <li key={naturalytelse.indexKey}>
+                    {naturalytelse.periode.tomDato !== TIDENES_ENDE && (<li key={naturalytelse.indexKey}>
                       <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.tom" />{' '}
                       <DateLabel dateString={naturalytelse.periode.tomDato} />
-                    </li>
+                    </li>)}
                   </>
                 ))}
               </ul>
@@ -218,19 +218,19 @@ const konverterAktivePerioderTilBortfaltePerioder = (inntektsmelding: Inntektsme
     }
 
     return {...prev, [type]: [value]}
-  }, {} as Record<keyof typeof NaturalytelseType, AktivNaturalYtelse[]>)
+  }, {} as Record<string, AktivNaturalYtelse[]>)
 
-  const x = {};
+  const acc = {} as Record<string, AktivNaturalYtelse[]>;
 
   Object.entries(gruppertPåType).map(([key, value]) => {
     const sortert = value.sort((a,b) => sorterPerioder({fom: a.periode.fomDato, tom: a.periode.tomDato}, {fom: b.periode.fomDato, tom: b.periode.tomDato})).reverse();
-    x[key] = sortert.flatMap((current, index, array) => {
+    acc[key] = sortert.flatMap((current, index, array) => {
       const next = array[index + 1];
 
       const nyFom = current.periode.tomDato;
       const nyTom = next?.periode.fomDato;
 
-      if (nyFom == TIDENES_ENDE) {
+      if (nyFom === TIDENES_ENDE) {
         return [];
       }
 
@@ -238,13 +238,13 @@ const konverterAktivePerioderTilBortfaltePerioder = (inntektsmelding: Inntektsme
         ...current,
         periode: {
           fomDato: addDaysToDate(nyFom, 1),
-          tomDato: nyTom ? addDaysToDate(nyTom, -1) : undefined,
+          tomDato: nyTom ? addDaysToDate(nyTom, -1) : TIDENES_ENDE,
         }
       }]
     });
   });
 
-  return x;
+  return acc;
 }
 
 const InntektsmeldingInfoBlokk = ({ tittel, children }: { tittel: string; children: React.ReactNode }) => {

--- a/packages/fakta-inntektsmelding/src/InntektsmeldingInnhold.tsx
+++ b/packages/fakta-inntektsmelding/src/InntektsmeldingInnhold.tsx
@@ -6,11 +6,12 @@ import { InntektsmeldingFaktaProps } from './InntektsmeldingFaktaIndex';
 import { BodyLong, Button, Heading, HGrid, HStack, Label, List, Modal, VStack } from '@navikt/ds-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { DateLabel, DateTimeLabel } from '@navikt/ft-ui-komponenter';
-import { addDaysToDate, formatCurrencyNoKr } from '@navikt/ft-utils';
-import { NaturalytelseType } from '@navikt/fp-types/src/arbeidOgInntektsmeldingTsType';
+import { addDaysToDate, formatCurrencyNoKr, TIDENES_ENDE } from '@navikt/ft-utils';
+import { AktivNaturalYtelse, NaturalytelseType } from '@navikt/fp-types/src/arbeidOgInntektsmeldingTsType';
 import { hentDokumentLenke } from '@navikt/fp-konstanter';
 import { ArrowForwardIcon } from '@navikt/aksel-icons';
 import styles from './inntektsmeldingFakta.module.css';
+import { sorterPerioder } from '@navikt/fp-fakta-medlemskap/src/v3/utils/periodeUtils';
 
 export const InntektsmeldingInnhold = ({
   inntektsmelding,
@@ -164,6 +165,10 @@ const Refusjon = ({ inntektsmelding }: { inntektsmelding: Inntektsmelding }) => 
 const BortfalteNaturalYtelser = ({ inntektsmelding }: { inntektsmelding: Inntektsmelding }) => {
   const intl = useIntl();
 
+  console.log(konverterAktivePerioderTilBortfaltePerioder(inntektsmelding));
+
+  const bortfalteNaturalytelser = konverterAktivePerioderTilBortfaltePerioder(inntektsmelding);
+
   return (
     <InntektsmeldingInfoBlokk
       tittel={intl.formatMessage({ id: 'InntektsmeldingFaktaPanel.bortfalteNaturalytelser.heading' })}
@@ -174,22 +179,26 @@ const BortfalteNaturalYtelser = ({ inntektsmelding }: { inntektsmelding: Inntekt
         </span>
       ) : (
         <VStack>
-          {inntektsmelding.bortfalteNaturalytelser.map(({ type, periode, beloepPerMnd, indexKey }) => (
-            <VStack key={indexKey}>
-              <span>{NaturalytelseType[type]}</span>
+          {Object.entries(bortfalteNaturalytelser).map(([key, value]) => (
+            <VStack key={key}>
+              <span>{NaturalytelseType[key as keyof typeof NaturalytelseType]}</span>
               <ul>
-                <li>
-                  <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.fom" />{' '}
-                  {/*
-                  NOTE: naturalYtelsene som kommer fra fpsak er invertert. Det vil si de sier når en naturalytelse var AKTIV.
-                  Det er angitt som fra år 0 tom siste dagen. For å finne ut fra når den faller bort må vi derfor bruker tomDato + 1
-                  */}
-                  <DateLabel dateString={addDaysToDate(periode.tomDato, 1)} />
-                </li>
-                <li>
-                  <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.verdi" />:{' '}
-                  {formatCurrencyNoKr(beloepPerMnd.verdi)}
-                </li>
+                {value.map(naturalytelse => (
+                  <>
+                    <li key={naturalytelse.indexKey}>
+                      <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.fom" />{' '}
+                      <DateLabel dateString={naturalytelse.periode.fomDato} />
+                    </li>
+                    <li>
+                      <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.verdi" />:{' '}
+                      {formatCurrencyNoKr(naturalytelse.beloepPerMnd.verdi)}
+                    </li>
+                    <li key={naturalytelse.indexKey}>
+                      <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.tom" />{' '}
+                      <DateLabel dateString={naturalytelse.periode.tomDato} />
+                    </li>
+                  </>
+                ))}
               </ul>
             </VStack>
           ))}
@@ -198,6 +207,45 @@ const BortfalteNaturalYtelser = ({ inntektsmelding }: { inntektsmelding: Inntekt
     </InntektsmeldingInfoBlokk>
   );
 };
+
+const konverterAktivePerioderTilBortfaltePerioder = (inntektsmelding: Inntektsmelding) => {
+  const aktiveNaturalytelser = inntektsmelding.bortfalteNaturalytelser;
+
+  const gruppertPåType = aktiveNaturalytelser.reduce((prev, value) => {
+    const type = value.type;
+    if (type in prev) {
+      return {...prev, [type]: [...prev[type], value]}
+    }
+
+    return {...prev, [type]: [value]}
+  }, {} as Record<keyof typeof NaturalytelseType, AktivNaturalYtelse[]>)
+
+  const x = {};
+
+  Object.entries(gruppertPåType).map(([key, value]) => {
+    const sortert = value.sort((a,b) => sorterPerioder({fom: a.periode.fomDato, tom: a.periode.tomDato}, {fom: b.periode.fomDato, tom: b.periode.tomDato})).reverse();
+    x[key] = sortert.flatMap((current, index, array) => {
+      const next = array[index + 1];
+
+      const nyFom = current.periode.tomDato;
+      const nyTom = next?.periode.fomDato;
+
+      if (nyFom == TIDENES_ENDE) {
+        return [];
+      }
+
+      return [{
+        ...current,
+        periode: {
+          fomDato: addDaysToDate(nyFom, 1),
+          tomDato: nyTom ? addDaysToDate(nyTom, -1) : undefined,
+        }
+      }]
+    });
+  });
+
+  return x;
+}
 
 const InntektsmeldingInfoBlokk = ({ tittel, children }: { tittel: string; children: React.ReactNode }) => {
   return (

--- a/packages/types/src/arbeidOgInntektsmeldingTsType.ts
+++ b/packages/types/src/arbeidOgInntektsmeldingTsType.ts
@@ -29,7 +29,7 @@ export type Inntektsmelding = Readonly<{
   begrunnelse?: string;
   kildeSystem: string;
   startDatoPermisjon?: string;
-  bortfalteNaturalytelser: BortfaltNaturalYtelse[];
+  bortfalteNaturalytelser: AktivNaturalYtelse[]; // Navngivingen her er misvisende. Data fra BE gir aktive perioder, ikke de bortfalte.
   refusjonsperioder: Refusjonsperiode[];
   innsendingsårsak: keyof typeof InntektsmeldingInnsendingsårsak;
   tilknyttedeBehandlingIder: string[];
@@ -41,7 +41,7 @@ type Refusjonsperiode = {
   fom: string;
 };
 
-type BortfaltNaturalYtelse = Readonly<{
+export type AktivNaturalYtelse = Readonly<{
   periode: { fomDato: string; tomDato: string };
   beloepPerMnd: Beløp;
   type: keyof typeof NaturalytelseType;


### PR DESCRIPTION
Har til nå hatt en litt hacky måte å vise frem naturalytelser på. Jeg misforstod da jeg skrev backend, slik at det som kommer som "bortfalteNaturalytelser" er faktisk perioder der den er aktiv. Så trengte å invertere denne logikken