### PR TITLE
TFP-5867 be om termindato dersom ES

### DIFF
--- a/packages/papirsoknad-ui-komponenter/src/fodselPanel/FodselPapirsoknadIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/fodselPanel/FodselPapirsoknadIndex.spec.tsx
@@ -68,8 +68,8 @@ describe('<FodselPapirsoknadIndex>', () => {
     expect(
       screen.queryByText('Rett til prematuruker vil kun sjekkes når du også oppgir termindato'),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText('Termindato')).not.toBeInTheDocument();
-    expect(screen.queryByText('Utstedt dato fra terminbekreftelsen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Termindato')).toBeInTheDocument();
+    expect(screen.queryByText('Utstedt dato fra terminbekreftelsen')).toBeInTheDocument();
   });
 
   it('skal velge at barnet ikke er født', async () => {

--- a/packages/papirsoknad-ui-komponenter/src/fodselPanel/FodselPapirsoknadIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/fodselPanel/FodselPapirsoknadIndex.spec.tsx
@@ -40,9 +40,7 @@ describe('<FodselPapirsoknadIndex>', () => {
     await userEvent.type(termindatoInput, '14.09.2022');
     fireEvent.blur(termindatoInput);
 
-    const utstedDatoInput = utils.getByLabelText('Utstedt dato fra terminbekreftelsen');
-    await userEvent.type(utstedDatoInput, '15.09.2022');
-    fireEvent.blur(utstedDatoInput);
+    expect(screen.queryByText('Utstedt dato fra terminbekreftelsen')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
 
@@ -51,7 +49,6 @@ describe('<FodselPapirsoknadIndex>', () => {
       antallBarn: '2',
       erBarnetFodt: true,
       foedselsDato: dayjs().subtract(10, 'day').format(ISO_DATE_FORMAT),
-      terminbekreftelseDato: '2022-09-15',
       termindato: '2022-09-14',
     });
   });
@@ -69,7 +66,7 @@ describe('<FodselPapirsoknadIndex>', () => {
       screen.queryByText('Rett til prematuruker vil kun sjekkes når du også oppgir termindato'),
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Termindato')).toBeInTheDocument();
-    expect(screen.queryByText('Utstedt dato fra terminbekreftelsen')).toBeInTheDocument();
+    expect(screen.queryByText('Utstedt dato fra terminbekreftelsen')).not.toBeInTheDocument();
   });
 
   it('skal velge at barnet ikke er født', async () => {

--- a/packages/papirsoknad-ui-komponenter/src/fodselPanel/components/TerminFodselDatoPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/fodselPanel/components/TerminFodselDatoPanel.tsx
@@ -158,26 +158,26 @@ const TerminFodselDatoPanel: FunctionComponent<OwnProps> = ({ readOnly, erForeld
                     </Label>
                   </Alert>
                   <VerticalSpacer sixteenPx />
-                  <FlexRow>
-                    <FlexColumn>
-                      <Datepicker
-                        name="termindato"
-                        label={intl.formatMessage({ id: 'Registrering.Termindato' })}
-                        isReadOnly={readOnly}
-                        validate={[hasValidDate]}
-                      />
-                    </FlexColumn>
-                    <FlexColumn>
-                      <Datepicker
-                        name="terminbekreftelseDato"
-                        label={intl.formatMessage({ id: 'Registrering.UtstedtDato' })}
-                        isReadOnly={readOnly}
-                        validate={[hasValidDate]}
-                      />
-                    </FlexColumn>
-                  </FlexRow>
                 </>
               )}
+              <FlexRow>
+                <FlexColumn>
+                  <Datepicker
+                    name="termindato"
+                    label={intl.formatMessage({ id: 'Registrering.Termindato' })}
+                    isReadOnly={readOnly}
+                    validate={[hasValidDate]}
+                  />
+                </FlexColumn>
+                <FlexColumn>
+                  <Datepicker
+                    name="terminbekreftelseDato"
+                    label={intl.formatMessage({ id: 'Registrering.UtstedtDato' })}
+                    isReadOnly={readOnly}
+                    validate={[hasValidDate]}
+                  />
+                </FlexColumn>
+              </FlexRow>
             </FlexContainer>
           </ArrowBox>
         </>

--- a/packages/papirsoknad-ui-komponenter/src/fodselPanel/components/TerminFodselDatoPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/fodselPanel/components/TerminFodselDatoPanel.tsx
@@ -169,14 +169,6 @@ const TerminFodselDatoPanel: FunctionComponent<OwnProps> = ({ readOnly, erForeld
                     validate={[hasValidDate]}
                   />
                 </FlexColumn>
-                <FlexColumn>
-                  <Datepicker
-                    name="terminbekreftelseDato"
-                    label={intl.formatMessage({ id: 'Registrering.UtstedtDato' })}
-                    isReadOnly={readOnly}
-                    validate={[hasValidDate]}
-                  />
-                </FlexColumn>
               </FlexRow>
             </FlexContainer>
           </ArrowBox>


### PR DESCRIPTION
Vil dette funke? Har prøvd å isolere Alert til foreldrepenger
Fjerner utstedtdato for tilfelle fødsel - det blir ikke brukt backend - se XSD og subklasser til SoekersRelasjonTilBarnet.
Se storybook /fp-papirsoknad og forskjellen på papirsoknad-es (grid) og papirsoknad-fp (liste av bokser)
