### PR TITLE
TFP-5554: Historikkinnslag baserer seg på ny DTO

### DIFF
--- a/apps/fp-frontend-app/i18n/nb_NO.json
+++ b/apps/fp-frontend-app/i18n/nb_NO.json
@@ -54,7 +54,7 @@
   "BehandlingSupportIndex.Godkjenning": "Godkjenning",
   "BehandlingSupportIndex.FraBeslutter": "Fra beslutter",
   "BehandlingSupportIndex.Historikk": "Historikk",
-  "BehandlingSupportIndex.HistorikkV2": "Historikk (ny)",
+  "BehandlingSupportIndex.HistorikkV2": "Historikk",
   "BehandlingSupportIndex.Melding": "Send melding",
   "BehandlingSupportIndex.Dokumenter": "Dokumenter",
   "BehandlingSupportIndex.Notatblokk": "Notatblokk",

--- a/apps/fp-frontend-app/src/behandlingsupport/BehandlingSupportIndex.spec.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/BehandlingSupportIndex.spec.tsx
@@ -9,7 +9,7 @@ import { RestApiMock } from '@navikt/fp-utils-test';
 import { BehandlingAppKontekst, Fagsak, Saksnotat } from '@navikt/fp-types';
 
 import BehandlingSupportIndex from './BehandlingSupportIndex';
-import { requestFagsakApi, FagsakApiKeys } from '../data/fagsakContextApi';
+import { FagsakApiKeys, requestFagsakApi } from '../data/fagsakContextApi';
 import FagsakData from '../fagsak/FagsakData';
 import messages from '../../i18n/nb_NO.json';
 
@@ -60,7 +60,7 @@ describe('<BehandlingSupportIndex>', () => {
       </RawIntlProvider>,
     );
 
-    expect(await screen.findAllByText('Historikk (ny)')).toHaveLength(2);
+    expect(await screen.findAllByText('Historikk')).toHaveLength(2);
     expect(screen.getByText('Filtrer på behandling')).toBeInTheDocument();
 
     expect(screen.getByText('Send melding')).toBeInTheDocument();

--- a/apps/fp-frontend-app/src/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/BehandlingSupportIndex.tsx
@@ -4,15 +4,14 @@ import { useIntl } from 'react-intl';
 
 import { Tabs } from '@navikt/ds-react';
 import {
-  ClockDashedIcon,
-  PersonCheckmarkFillIcon,
   ArrowUndoIcon,
+  ClockDashedIcon,
+  DocPencilIcon,
   FolderIcon,
   PaperplaneIcon,
-  DocPencilIcon,
+  PersonCheckmarkFillIcon,
 } from '@navikt/aksel-icons';
 import { getSupportPanelLocationCreator } from '../app/paths';
-import HistorikkIndex from './historikk/HistorikkIndex';
 import { HistorikkIndex as HistorikkIndexV2 } from './historikk-v2/HistorikkIndex';
 import MeldingIndex from './melding/MeldingIndex';
 import DokumentIndex from './dokument/DokumentIndex';
@@ -28,7 +27,6 @@ const utledAktivtPanel = (
   skalViseFraBeslutter: boolean,
   skalViseTilGodkjenning: boolean,
   valgtSupportPanel: string,
-  skalViseHistorikkV2: boolean,
 ): string => {
   if (valgtSupportPanel) {
     return valgtSupportPanel;
@@ -39,18 +37,8 @@ const utledAktivtPanel = (
   if (skalViseTilGodkjenning) {
     return SupportTabs.TIL_BESLUTTER;
   }
-  return skalViseHistorikkV2 ? SupportTabs.HISTORIKK_V2 : SupportTabs.HISTORIKK;
+  return SupportTabs.HISTORIKK_V2;
 };
-
-function getEnvironment() {
-  const hostname = window.location.hostname;
-  if (hostname === 'localhost' || hostname === '127.0.0.1') {
-    return 'local';
-  } else if (hostname.includes('intern.dev.nav.no')) {
-    return 'dev';
-  }
-  return 'production';
-}
 
 interface OwnProps {
   fagsakData: FagsakData;
@@ -80,8 +68,6 @@ const BehandlingSupportIndex: FunctionComponent<OwnProps> = ({
     isQueryParam: true,
   });
 
-  const skalViseHistorikkV2 = ['local', 'dev'].includes(getEnvironment());
-
   const [meldingFormData, setMeldingFormData] = useState();
   const [beslutterFormData, setBeslutterFormData] = useState();
 
@@ -95,12 +81,7 @@ const BehandlingSupportIndex: FunctionComponent<OwnProps> = ({
   const skalViseFraBeslutter = !!behandlingTillatteOperasjoner?.behandlingFraBeslutter;
   const skalViseTilGodkjenning = !!behandlingTillatteOperasjoner?.behandlingTilGodkjenning;
 
-  const aktivtSupportPanel = utledAktivtPanel(
-    skalViseFraBeslutter,
-    skalViseTilGodkjenning,
-    valgtSupportPanel,
-    skalViseHistorikkV2,
-  );
+  const aktivtSupportPanel = utledAktivtPanel(skalViseFraBeslutter, skalViseTilGodkjenning, valgtSupportPanel);
 
   const changeRouteCallback = useCallback(
     (supportPanel: string) => {
@@ -127,17 +108,10 @@ const BehandlingSupportIndex: FunctionComponent<OwnProps> = ({
             icon={<PersonCheckmarkFillIcon title={intl.formatMessage({ id: 'BehandlingSupportIndex.Godkjenning' })} />}
           />
         )}
-        {skalViseHistorikkV2 && (
-          <Tabs.Tab
-            className={styles.tab}
-            value={SupportTabs.HISTORIKK_V2}
-            icon={<ClockDashedIcon title={intl.formatMessage({ id: 'BehandlingSupportIndex.HistorikkV2' })} />}
-          />
-        )}
         <Tabs.Tab
           className={styles.tab}
-          value={SupportTabs.HISTORIKK}
-          icon={<ClockDashedIcon title={intl.formatMessage({ id: 'BehandlingSupportIndex.Historikk' })} />}
+          value={SupportTabs.HISTORIKK_V2}
+          icon={<ClockDashedIcon title={intl.formatMessage({ id: 'BehandlingSupportIndex.HistorikkV2' })} />}
         />
         <Tabs.Tab
           className={styles.tab}
@@ -180,24 +154,12 @@ const BehandlingSupportIndex: FunctionComponent<OwnProps> = ({
           />
         )}
       </Tabs.Panel>
-      {skalViseHistorikkV2 && (
-        <Tabs.Panel value={SupportTabs.HISTORIKK_V2}>
-          <HistorikkIndexV2
-            saksnummer={fagsak.saksnummer}
-            behandlingUuid={behandlingUuid}
-            historikkinnslagFpSak={fagsakData.getHistorikkV2FpSak()}
-            historikkinnslagFpTilbake={fagsakData.getHistorikkV2FpTilbake()}
-            kjønn={fagsak.bruker.kjønn}
-          />
-        </Tabs.Panel>
-      )}
-      <Tabs.Panel value={SupportTabs.HISTORIKK}>
-        <HistorikkIndex
+      <Tabs.Panel value={SupportTabs.HISTORIKK_V2}>
+        <HistorikkIndexV2
           saksnummer={fagsak.saksnummer}
           behandlingUuid={behandlingUuid}
-          behandlingVersjon={behandlingVersjon}
-          historikkinnslagFpSak={fagsakData.getHistorikkFpSak()}
-          historikkinnslagFpTilbake={fagsakData.getHistorikkFpTilbake()}
+          historikkinnslagFpSak={fagsakData.getHistorikkV2FpSak()}
+          historikkinnslagFpTilbake={fagsakData.getHistorikkV2FpTilbake()}
           kjønn={fagsak.bruker.kjønn}
         />
       </Tabs.Panel>

--- a/packages/sak-historikk-v2/i18n/nb_NO.json
+++ b/packages/sak-historikk-v2/i18n/nb_NO.json
@@ -1,6 +1,6 @@
 {
   "History.FiltrerPaBehandling": "Filtrer på behandling",
-  "History.Historikk": "Historikk (ny)",
+  "History.Historikk": "Historikk",
 
   "Snakkeboble.Soker": "Søker",
   "Snakkeboble.Saksbehandler": "Saksbehandler",


### PR DESCRIPTION
Legger til at vi bare viser det nye. Opprydding av det gammelt historikkinslag og hodeverk kan vi gjøre etterhvert, i en ny PR. 