### PR TITLE
fiks feil i skjult formlogikk i papirsoknad

### DIFF
--- a/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
+++ b/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
@@ -145,9 +145,11 @@
   "BehovForTilretteleggingPanel.BehovForTilrettelegging": "Behov for tilrettelegging",
   "BehovForTilretteleggingPanel.TilretteleggingFra": "Jordmor/lege oppgir at tilrettelegging er nødvendig fra og med",
   "BehovForTilretteleggingPanel.SokForSelvstendigNaringsdrivende": "Søkes det om svangerskapspenger som selvstendig næringsdrivende?",
-
   "BehovForTilretteleggingPanel.SokForFrilans": "Søkes det om svangerskapspenger som frilanser?",
   "BehovForTilretteleggingPanel.SokForArbeidsgiver": "Søkes det om svangerskapspenger som arbeidstaker?",
+  "BehovForTilretteleggingPanel.TittelSN": "Tilretteleggingsbehov for selvstendig næringsdrivende",
+  "BehovForTilretteleggingPanel.TittelFrilans": "Tilretteleggingsbehov for frilanser",
+  "BehovForTilretteleggingPanel.TittelArbeidstaker": "Tilretteleggingsbehov for arbeidstaker",
   "BehovForTilretteleggingPanel.MinstEnMaaVereJa": "Minst ett av spørsmålene må besvares med alternativ Ja",
 
   "BehovForTilrettteleggingFieldArray.LeggTilTilretteleggingsbehov": "Legg til tilretteleggingsbehov",
@@ -158,9 +160,11 @@
   "BehovForTilrettteleggingFieldArray.RedusertArbeid": "b) kan gjennomføres slik at arbeidstakeren kan fortsette med redusert arbeidstid fra og med",
   "BehovForTilrettteleggingFieldArray.KanIkkeGjennomfores": "c) kan ikke gjennomføres og arbeidstakeren må midlertidig gå ut av sitt arbeid fra og med",
 
-  "TilretteleggingForArbeidsgiverFieldArray.OrgNr": "Arbeidsgivers orgnr/fnr",
-  "TilretteleggingForArbeidsgiverFieldArray.TilretteleggingFra": "Jordmor/lege oppgir at tilrettelegging er nødvendig fra og med",
+  "TilretteleggingForArbeidsgiverFieldArray.Title": "Arbeidsgivere med tilretteleggingsbehov",
+  "TilretteleggingForArbeidsgiverFieldArray.ArrayMinLength": "Det må registreres minst 1 arbeidsforhold",
   "TilretteleggingForArbeidsgiverFieldArray.LeggTilArbeidsgiver": "Legg til arbeidsgiver",
+  "RegistrerArbeidsgiverRad.OrgNr": "Arbeidsgivers orgnr/fnr",
+  "RegistrerArbeidsgiverRad.TilretteleggingFra": "Jordmor/lege oppgir at tilrettelegging er nødvendig fra og med",
 
   "Registrering.Dekningsgrad.Title": "Dekningsgrad",
   "Registrering.Dekningsgrad.prosent.80": "80 prosent",

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/PermisjonPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/PermisjonPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useFormContext, UseFormGetValues } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { ErrorMessage, Heading, VStack } from '@navikt/ds-react';
@@ -23,14 +23,6 @@ import { PermisjonOppholdPanel } from './opphold/PermisjonOppholdPanel';
 import { PermisjonOverforingAvKvoterPanel } from './overforeKvote/PermisjonOverforingAvKvoterPanel';
 import { PermisjonUtsettelsePanel } from './utsettelse/PermisjonUtsettelsePanel';
 
-const getIsRequired = (getValues: UseFormGetValues<PermisjonFormValues>) => {
-  const fulltUttak = getValues(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.fulltUttak`) || false;
-  const skalGradere = getValues(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.skalGradere`) || false;
-  const skalUtsette = getValues(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.skalUtsette`) || false;
-  const skalOvertaKvote = getValues(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.skalOvertaKvote`) || false;
-  return !fulltUttak && !skalGradere && !skalUtsette && !skalOvertaKvote;
-};
-
 interface Props {
   foreldreType: string;
   readOnly: boolean;
@@ -46,20 +38,25 @@ interface Props {
 export const PermisjonPanel = ({ foreldreType, readOnly, alleKodeverk, erEndringssøknad }: Props) => {
   const intl = useIntl();
 
-  const { setError, clearErrors, getValues, formState } = useFormContext<PermisjonFormValues>();
+  const { setError, clearErrors, formState, watch } = useFormContext<PermisjonFormValues>();
+  const [fulltUttak, skalGradere, skalUtsette, skalOvertaKvote] = watch([
+    `${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.fulltUttak`,
+    `${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.skalGradere`,
+    `${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.skalUtsette`,
+    `${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.skalOvertaKvote`,
+  ]);
 
-  const isError = getIsRequired(getValues);
   useEffect(() => {
+    const isError = !fulltUttak && !skalGradere && !skalUtsette && !skalOvertaKvote;
     if (isError) {
       setError(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.notRegisteredInput`, {
         type: 'custom',
         message: intl.formatMessage({ id: 'PermisjonPanel.MinstEnPeriodeRequired' }),
       });
-    }
-    if (!isError) {
+    } else {
       clearErrors(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.notRegisteredInput`);
     }
-  }, [isError]);
+  }, [fulltUttak, skalGradere, skalUtsette, skalOvertaKvote]);
 
   return (
     <BorderBox>

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.spec.tsx
@@ -1,6 +1,7 @@
 import { composeStories } from '@storybook/react';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { expect } from 'vitest';
 
 import { TilretteleggingType } from '@navikt/fp-kodeverk';
 
@@ -8,7 +9,7 @@ import * as stories from './BehovForTilretteleggingPanel.stories';
 
 const { Default } = composeStories(stories);
 
-describe('<BehovForTilretteleggingPanel>', () => {
+describe('BehovForTilretteleggingPanel', () => {
   it('skal velge nei på alle de obligatoriske spørsmålene og da få feilmelding', async () => {
     const lagre = vi.fn();
 
@@ -169,4 +170,30 @@ describe('<BehovForTilretteleggingPanel>', () => {
       ],
     });
   });
+
+  it(
+    'skal slette alle arbeidsgivere og gi beskje om at den trenger minst et element i arbeidsgiiverlisten',
+    { timeout: 30000 },
+    async () => {
+      const lagre = vi.fn();
+
+      await Default.run({
+        parameters: {
+          submitCallback: lagre,
+        },
+      });
+
+      await userEvent.click(screen.getAllByText('Nei')[0]);
+      await userEvent.click(screen.getAllByText('Nei')[1]);
+      await userEvent.click(screen.getAllByText('Ja')[2]);
+
+      await userEvent.click(screen.getByLabelText('Slett rad'));
+
+      await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
+
+      expect(await screen.findByText('Det må registreres minst 1 arbeidsforhold')).toBeInTheDocument();
+
+      expect(lagre).toHaveBeenCalledTimes(0);
+    },
+  );
 });

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.spec.tsx
@@ -1,7 +1,6 @@
 import { composeStories } from '@storybook/react';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { expect } from 'vitest';
 
 import { TilretteleggingType } from '@navikt/fp-kodeverk';
 

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.tsx
@@ -13,7 +13,7 @@ import { BehovForTilretteleggingFieldArray } from './components/BehovForTilrette
 import { TilretteleggingForArbeidsgiverFieldArray } from './components/TilretteleggingForArbeidsgiverFieldArray';
 import {
   FRILANS_FIELD_ARRAY_NAME,
-  SELVSTENDIG_NARINGS_DRIVENDE_FIELD_ARRAY_NAME,
+  SELVSTENDIG_NARINGSDRIVENDE_FIELD_ARRAY_NAME,
   TILRETTELEGGING_NAME_PREFIX,
 } from './constants';
 import { transformTilretteleggingsArbeidsforhold } from './transformer';
@@ -30,10 +30,14 @@ interface Props {
 export const BehovForTilretteleggingPanel = ({ readOnly }: Props) => {
   const { watch, setError, clearErrors, formState } = useFormContext<FormValues>();
 
-  const { sokForSelvstendigNaringsdrivende, sokForFrilans, sokForArbeidsgiver } = watch(TILRETTELEGGING_NAME_PREFIX);
+  const [sokSN, sokFrilans, sokArbeid] = watch([
+    `${TILRETTELEGGING_NAME_PREFIX}.sokForSelvstendigNaringsdrivende`,
+    `${TILRETTELEGGING_NAME_PREFIX}.sokForFrilans`,
+    `${TILRETTELEGGING_NAME_PREFIX}.sokForArbeidsgiver`,
+  ]);
 
   useEffect(() => {
-    const isError = !sokForSelvstendigNaringsdrivende && !sokForFrilans && !sokForArbeidsgiver;
+    const isError = !sokSN && !sokFrilans && !sokArbeid;
     if (isError) {
       setError(`${TILRETTELEGGING_NAME_PREFIX}.notRegisteredInput`, {
         type: 'custom',
@@ -42,7 +46,7 @@ export const BehovForTilretteleggingPanel = ({ readOnly }: Props) => {
     } else {
       clearErrors(`${TILRETTELEGGING_NAME_PREFIX}.notRegisteredInput`);
     }
-  }, [sokForArbeidsgiver, sokForFrilans, sokForArbeidsgiver]);
+  }, [sokSN, sokFrilans, sokArbeid]);
 
   return (
     <RawIntlProvider value={intl}>
@@ -62,16 +66,21 @@ export const BehovForTilretteleggingPanel = ({ readOnly }: Props) => {
             readOnly={readOnly}
             trueContent={
               <ArrowBox marginTop={4}>
-                <Datepicker
-                  name={`${TILRETTELEGGING_NAME_PREFIX}.behovsdatoSN`}
-                  label={intl.formatMessage({ id: 'BehovForTilretteleggingPanel.TilretteleggingFra' })}
-                  validate={[required]}
-                  isReadOnly={readOnly}
-                />
-                <BehovForTilretteleggingFieldArray
-                  name={`${TILRETTELEGGING_NAME_PREFIX}.${SELVSTENDIG_NARINGS_DRIVENDE_FIELD_ARRAY_NAME}`}
-                  readOnly={readOnly}
-                />
+                <VStack gap="4">
+                  <Heading size="small">
+                    <FormattedMessage id="BehovForTilretteleggingPanel.TittelSN" />
+                  </Heading>
+                  <Datepicker
+                    name={`${TILRETTELEGGING_NAME_PREFIX}.behovsdatoSN`}
+                    label={intl.formatMessage({ id: 'BehovForTilretteleggingPanel.TilretteleggingFra' })}
+                    validate={[required]}
+                    isReadOnly={readOnly}
+                  />
+                  <BehovForTilretteleggingFieldArray
+                    name={`${TILRETTELEGGING_NAME_PREFIX}.${SELVSTENDIG_NARINGSDRIVENDE_FIELD_ARRAY_NAME}`}
+                    readOnly={readOnly}
+                  />
+                </VStack>
               </ArrowBox>
             }
           />
@@ -82,16 +91,21 @@ export const BehovForTilretteleggingPanel = ({ readOnly }: Props) => {
             readOnly={readOnly}
             trueContent={
               <ArrowBox marginTop={4}>
-                <Datepicker
-                  name={`${TILRETTELEGGING_NAME_PREFIX}.behovsdatoFrilans`}
-                  label={intl.formatMessage({ id: 'BehovForTilretteleggingPanel.TilretteleggingFra' })}
-                  validate={[required]}
-                  isReadOnly={readOnly}
-                />
-                <BehovForTilretteleggingFieldArray
-                  name={`${TILRETTELEGGING_NAME_PREFIX}.${FRILANS_FIELD_ARRAY_NAME}`}
-                  readOnly={readOnly}
-                />
+                <VStack gap="4">
+                  <Heading size="small">
+                    <FormattedMessage id="BehovForTilretteleggingPanel.TittelFrilans" />
+                  </Heading>
+                  <Datepicker
+                    name={`${TILRETTELEGGING_NAME_PREFIX}.behovsdatoFrilans`}
+                    label={intl.formatMessage({ id: 'BehovForTilretteleggingPanel.TilretteleggingFra' })}
+                    validate={[required]}
+                    isReadOnly={readOnly}
+                  />
+                  <BehovForTilretteleggingFieldArray
+                    name={`${TILRETTELEGGING_NAME_PREFIX}.${FRILANS_FIELD_ARRAY_NAME}`}
+                    readOnly={readOnly}
+                  />
+                </VStack>
               </ArrowBox>
             }
           />
@@ -101,7 +115,12 @@ export const BehovForTilretteleggingPanel = ({ readOnly }: Props) => {
             readOnly={readOnly}
             trueContent={
               <ArrowBox marginTop={4}>
-                <TilretteleggingForArbeidsgiverFieldArray readOnly={readOnly} />
+                <VStack gap="4">
+                  <Heading size="small">
+                    <FormattedMessage id="BehovForTilretteleggingPanel.TittelArbeidstaker" />
+                  </Heading>
+                  <TilretteleggingForArbeidsgiverFieldArray readOnly={readOnly} />
+                </VStack>
               </ArrowBox>
             }
           />

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
@@ -2,13 +2,13 @@ import React, { useEffect } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
-import { TrashIcon } from '@navikt/aksel-icons';
-import { Button, HStack } from '@navikt/ds-react';
+import { Box } from '@navikt/ds-react';
 import { Datepicker, InputField, PeriodFieldArray, SelectField } from '@navikt/ft-form-hooks';
 import { maxValue, required } from '@navikt/ft-form-validators';
 
 import { TilretteleggingType } from '@navikt/fp-kodeverk';
 
+import { FieldArrayRow } from '../../felles/FieldArrayRow';
 import { Tilrettelegging } from '../types';
 
 const maxValue3 = maxValue(100);
@@ -40,25 +40,21 @@ export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => 
   }, []);
 
   return (
-    <PeriodFieldArray
-      fields={fields}
-      emptyPeriodTemplate={defaultTilrettelegging}
-      bodyText={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.LeggTilTilretteleggingsbehov' })}
-      readOnly={readOnly}
-      append={append}
-      remove={remove}
-    >
-      {(field, index) => (
-        <HStack key={field.id} wrap={false} gap="4">
-          <HStack gap="4">
+    <Box background="surface-action-subtle" padding="3" style={{ borderLeft: '4px solid var(--a-lightblue-700)' }}>
+      <PeriodFieldArray
+        fields={fields}
+        emptyPeriodTemplate={defaultTilrettelegging}
+        bodyText={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.LeggTilTilretteleggingsbehov' })}
+        readOnly={readOnly}
+        append={append}
+        remove={remove}
+      >
+        {(field, index) => (
+          <FieldArrayRow key={field.id} readOnly={readOnly} remove={remove} index={index}>
             <SelectField
               readOnly={readOnly}
               name={`${name}.${index}.tilretteleggingType`}
-              label={
-                index === 0
-                  ? intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.BehovForTilrettelegging' })
-                  : ''
-              }
+              label={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.BehovForTilrettelegging' })}
               validate={[required]}
               selectValues={[
                 <option value={TilretteleggingType.HEL_TILRETTELEGGING} key={TilretteleggingType.HEL_TILRETTELEGGING}>
@@ -82,32 +78,20 @@ export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => 
             <Datepicker
               isReadOnly={readOnly}
               name={`${name}.${index}.dato`}
-              label={index === 0 ? intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDato' }) : ''}
+              label={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDato' })}
               validate={[required]}
             />
 
             <InputField
               readOnly={readOnly}
               name={`${name}.${index}.stillingsprosent`}
-              label={
-                index === 0 ? intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.Stillingsprosent' }) : ''
-              }
+              label={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.Stillingsprosent' })}
               validate={[required, maxValue3]}
               maxLength={99}
             />
-          </HStack>
-
-          {!readOnly && index > 0 && (
-            <Button
-              size="small"
-              type="button"
-              variant="tertiary-neutral"
-              icon={<TrashIcon />}
-              onClick={() => remove(index)}
-            />
-          )}
-        </HStack>
-      )}
-    </PeriodFieldArray>
+          </FieldArrayRow>
+        )}
+      </PeriodFieldArray>
+    </Box>
   );
 };

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/RegistrerArbeidgiverRad.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/RegistrerArbeidgiverRad.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useIntl } from 'react-intl';
+
+import { ChevronDownIcon, ChevronUpIcon, TrashIcon } from '@navikt/aksel-icons';
+import { BodyShort, Box, Button, HStack, Table, VStack } from '@navikt/ds-react';
+import { Datepicker, InputField } from '@navikt/ft-form-hooks';
+import { hasNoWhiteSpace, hasValidOrgNumberOrFodselsnr, required } from '@navikt/ft-form-validators';
+
+import {
+  BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME,
+  TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME,
+  TILRETTELEGGING_NAME_PREFIX,
+} from '../constants';
+import { FormValues } from '../types';
+import { BehovForTilretteleggingFieldArray } from './BehovForTilretteleggingFieldArray';
+
+const FA_PREFIX = `${TILRETTELEGGING_NAME_PREFIX}.${TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME}`;
+const getPrefix = (index: number) => `${FA_PREFIX}.${index}`;
+
+interface Props {
+  index: number;
+  readOnly?: boolean;
+  remove: () => void;
+  open: boolean;
+}
+
+export const RegistrerArbeidsgiverRad = ({ open, readOnly = false, index, remove }: Props) => {
+  const { getFieldState, watch } = useFormContext<FormValues>();
+  const { error } = getFieldState(`${FA_PREFIX}.${index}`);
+  const organisasjonsnummer = watch(`${FA_PREFIX}.${index}.organisasjonsnummer`);
+  const [isOpen, setIsOpen] = useState(open);
+  const intl = useIntl();
+
+  return (
+    <Table.Row shadeOnHover={false} style={{ backgroundColor: error && !isOpen ? 'var(--a-red-50)' : 'none' }}>
+      <Table.DataCell valign="top">
+        <Button
+          type="button"
+          variant="tertiary-neutral"
+          onClick={() => setIsOpen(curr => !curr)}
+          icon={isOpen ? <ChevronUpIcon aria-label="Vis mindre" /> : <ChevronDownIcon aria-label="Vis mer" />}
+        />
+      </Table.DataCell>
+      <Table.DataCell valign="top">
+        <Box hidden={isOpen} paddingBlock="3">
+          <BodyShort weight="semibold">{organisasjonsnummer}</BodyShort>
+        </Box>
+        <VStack gap="4" hidden={!isOpen}>
+          <HStack gap="4">
+            <InputField
+              readOnly={readOnly}
+              name={`${getPrefix(index)}.organisasjonsnummer`}
+              label={intl.formatMessage({ id: 'RegistrerArbeidsgiverRad.OrgNr' })}
+              validate={[required, (value: any) => hasNoWhiteSpace(value.toString()), hasValidOrgNumberOrFodselsnr]}
+              maxLength={99}
+            />
+            <Datepicker
+              name={`${getPrefix(index)}.behovsdato`}
+              label={intl.formatMessage({ id: 'RegistrerArbeidsgiverRad.TilretteleggingFra' })}
+              validate={[required]}
+              isReadOnly={readOnly}
+            />
+          </HStack>
+          <BehovForTilretteleggingFieldArray
+            name={`${getPrefix(index)}.${BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME}`}
+            readOnly={readOnly}
+          />
+        </VStack>
+      </Table.DataCell>
+      <Table.DataCell valign="top" align="right">
+        <Button
+          type="button"
+          variant="tertiary-neutral"
+          onClick={remove}
+          onKeyDown={remove}
+          icon={<TrashIcon aria-label="Slett rad" />}
+        />
+      </Table.DataCell>
+    </Table.Row>
+  );
+};

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/RegistrerArbeidgiverRad.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/RegistrerArbeidgiverRad.tsx
@@ -52,7 +52,11 @@ export const RegistrerArbeidsgiverRad = ({ open, readOnly = false, index, remove
               readOnly={readOnly}
               name={`${getPrefix(index)}.organisasjonsnummer`}
               label={intl.formatMessage({ id: 'RegistrerArbeidsgiverRad.OrgNr' })}
-              validate={[required, (value: any) => hasNoWhiteSpace(value.toString()), hasValidOrgNumberOrFodselsnr]}
+              validate={[
+                required,
+                (value: string | number) => hasNoWhiteSpace(value.toString()),
+                hasValidOrgNumberOrFodselsnr,
+              ]}
               maxLength={99}
             />
             <Datepicker

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/TilretteleggingForArbeidsgiverFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/TilretteleggingForArbeidsgiverFieldArray.tsx
@@ -2,19 +2,12 @@ import React, { useEffect } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { XMarkIcon } from '@navikt/aksel-icons';
-import { Button, HStack, VStack } from '@navikt/ds-react';
-import { Datepicker, InputField } from '@navikt/ft-form-hooks';
-import { hasNoWhiteSpace, hasValidOrgNumberOrFodselsnr, required } from '@navikt/ft-form-validators';
-import { AvsnittSkiller } from '@navikt/ft-ui-komponenter';
+import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { Button, ErrorMessage, Table, VStack } from '@navikt/ds-react';
 
-import {
-  BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME,
-  TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME,
-  TILRETTELEGGING_NAME_PREFIX,
-} from '../constants';
+import { TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME, TILRETTELEGGING_NAME_PREFIX } from '../constants';
 import { FormValues } from '../types';
-import { BehovForTilretteleggingFieldArray } from './BehovForTilretteleggingFieldArray';
+import { RegistrerArbeidsgiverRad } from './RegistrerArbeidgiverRad';
 
 const defaultArbeidsgiver = {
   organisasjonsnummer: '',
@@ -26,15 +19,20 @@ interface Props {
 }
 
 const FA_PREFIX = `${TILRETTELEGGING_NAME_PREFIX}.${TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME}`;
-const getPrefix = (index: number) => `${FA_PREFIX}.${index}`;
 
 export const TilretteleggingForArbeidsgiverFieldArray = ({ readOnly }: Props) => {
   const intl = useIntl();
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<FormValues>();
 
-  const { control } = useFormContext<FormValues>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: FA_PREFIX,
+    rules: {
+      required: intl.formatMessage({ id: 'TilretteleggingForArbeidsgiverFieldArray.ArrayMinLength' }),
+    },
   });
 
   const leggTilArbeidsgiver = () => {
@@ -48,46 +46,46 @@ export const TilretteleggingForArbeidsgiverFieldArray = ({ readOnly }: Props) =>
   }, []);
 
   return (
-    <>
-      {fields.map((field, index: number) => (
-        <div key={field.id}>
-          {index > 0 && <AvsnittSkiller spaceUnder spaceAbove />}
-          <HStack wrap={false} justify="space-between">
-            <VStack>
-              <HStack gap="4">
-                <InputField
-                  readOnly={readOnly}
-                  name={`${getPrefix(index)}.organisasjonsnummer`}
-                  label={intl.formatMessage({ id: 'TilretteleggingForArbeidsgiverFieldArray.OrgNr' })}
-                  validate={[required, (value: any) => hasNoWhiteSpace(value.toString()), hasValidOrgNumberOrFodselsnr]}
-                  maxLength={99}
-                />
+    <VStack gap="4">
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell style={{ width: '48px' }} />
+            <Table.HeaderCell>
+              <FormattedMessage id="TilretteleggingForArbeidsgiverFieldArray.Title" />
+            </Table.HeaderCell>
+            <Table.HeaderCell style={{ width: '48px' }} />
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {fields.map((field, index: number) => (
+            <RegistrerArbeidsgiverRad
+              key={field.id}
+              index={index}
+              open={index + 1 === fields.length}
+              remove={() => remove(index)}
+              readOnly={readOnly}
+            />
+          ))}
+        </Table.Body>
+      </Table>
 
-                <Datepicker
-                  name={`${getPrefix(index)}.behovsdato`}
-                  label={intl.formatMessage({ id: 'TilretteleggingForArbeidsgiverFieldArray.TilretteleggingFra' })}
-                  validate={[required]}
-                  isReadOnly={readOnly}
-                />
-              </HStack>
-
-              <BehovForTilretteleggingFieldArray
-                name={`${getPrefix(index)}.${BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME}`}
-                readOnly={readOnly}
-              />
-            </VStack>
-            {!readOnly && index > 0 && (
-              <div>
-                <Button type="button" variant="tertiary-neutral" icon={<XMarkIcon />} onClick={() => remove(index)} />
-              </div>
-            )}
-          </HStack>
-        </div>
-      ))}
-
-      <Button size="small" variant="secondary" onClick={leggTilArbeidsgiver} type="button">
-        <FormattedMessage id="TilretteleggingForArbeidsgiverFieldArray.LeggTilArbeidsgiver" />
-      </Button>
-    </>
+      {errors[TILRETTELEGGING_NAME_PREFIX]?.[TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME]?.root?.message && (
+        <ErrorMessage>
+          {errors[TILRETTELEGGING_NAME_PREFIX]?.[TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME].root?.message}
+        </ErrorMessage>
+      )}
+      <div>
+        <Button
+          size="small"
+          variant="tertiary"
+          onClick={leggTilArbeidsgiver}
+          type="button"
+          icon={<PlusCircleIcon aria-hidden />}
+        >
+          <FormattedMessage id="TilretteleggingForArbeidsgiverFieldArray.LeggTilArbeidsgiver" />
+        </Button>
+      </div>
+    </VStack>
   );
 };

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/constants.ts
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/constants.ts
@@ -1,7 +1,7 @@
 export const TILRETTELEGGING_NAME_PREFIX = 'tilretteleggingArbeidsforhold';
 
 export const TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME = 'tilretteleggingForArbeidsgiver';
-export const SELVSTENDIG_NARINGS_DRIVENDE_FIELD_ARRAY_NAME = 'tilretteleggingSelvstendigNaringsdrivende';
+export const SELVSTENDIG_NARINGSDRIVENDE_FIELD_ARRAY_NAME = 'tilretteleggingSelvstendigNaringsdrivende';
 export const FRILANS_FIELD_ARRAY_NAME = 'tilretteleggingFrilans';
 
 export const BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME = 'tilretteleggingArbeidsgiver';

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/types.ts
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/types.ts
@@ -1,7 +1,7 @@
 import {
   BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME,
   FRILANS_FIELD_ARRAY_NAME,
-  SELVSTENDIG_NARINGS_DRIVENDE_FIELD_ARRAY_NAME,
+  SELVSTENDIG_NARINGSDRIVENDE_FIELD_ARRAY_NAME,
   TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME,
   TILRETTELEGGING_NAME_PREFIX,
 } from './constants';
@@ -18,18 +18,18 @@ type VirtuellFeilType = {
 
 export type FormValues = {
   [TILRETTELEGGING_NAME_PREFIX]: {
+    sokForArbeidsgiver?: boolean;
     [TILRETTELEGGING_FOR_ARBEIDSGIVER_FIELD_ARRAY_NAME]?: {
       behovsdato?: string;
       organisasjonsnummer?: string;
       [BEHOV_FOR_TILRETTELEGGING_FIELD_ARRAY_NAME]?: Tilrettelegging[];
     }[];
-    sokForArbeidsgiver?: boolean;
     sokForFrilans?: boolean;
     behovsdatoFrilans?: string;
     [FRILANS_FIELD_ARRAY_NAME]?: Tilrettelegging[];
     sokForSelvstendigNaringsdrivende?: boolean;
     behovsdatoSN?: string;
-    [SELVSTENDIG_NARINGS_DRIVENDE_FIELD_ARRAY_NAME]?: Tilrettelegging[];
+    [SELVSTENDIG_NARINGSDRIVENDE_FIELD_ARRAY_NAME]?: Tilrettelegging[];
   } & VirtuellFeilType;
 };
 

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/VirksomhetPapirsoknadIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/VirksomhetPapirsoknadIndex.spec.tsx
@@ -7,7 +7,7 @@ import * as stories from './VirksomhetPapirsoknadIndex.stories';
 
 const { Default } = composeStories(stories);
 
-describe('<VirksomhetPapirsoknadIndex>', () => {
+describe('VirksomhetPapirsoknadIndex', () => {
   it('skal velge at søker ikke har arbeidet i egen næringsvirksomhet', async () => {
     const lagre = vi.fn();
 
@@ -61,8 +61,8 @@ describe('<VirksomhetPapirsoknadIndex>', () => {
 
     await userEvent.selectOptions(screen.getByLabelText('Hvilket land er virksomheten registrert i?'), 'AND');
 
-    await userEvent.type(screen.getByLabelText('Fra og med'), '2022-06-01');
-    await userEvent.type(screen.getByLabelText('Til og med'), '2022-06-03');
+    await userEvent.type(screen.getByLabelText('Fra og med'), '01.06.2022');
+    await userEvent.type(screen.getByLabelText('Til og med'), '03.06.2022');
 
     await userEvent.click(screen.getByLabelText('Fiske'));
 
@@ -74,7 +74,7 @@ describe('<VirksomhetPapirsoknadIndex>', () => {
     expect(screen.getByText('Årsak')).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText('Varig endring i næring'));
 
-    await userEvent.type(screen.getByLabelText('Gjeldende f.o.m.'), '2022-05-03');
+    await userEvent.type(screen.getByLabelText('Gjeldende f.o.m.'), '03.05.2022');
 
     await userEvent.type(screen.getByLabelText('Beskriv endringen i næring'), 'Dette er en endring');
 
@@ -145,7 +145,7 @@ describe('<VirksomhetPapirsoknadIndex>', () => {
         screen.getByText('Ja, søker har arbeidet i egen næringsvirksomhet i løpet av de 10 siste månedene'),
       );
 
-      await userEvent.click(screen.getByLabelText('Slett virksomhet'));
+      await userEvent.click(screen.getByLabelText('Slett rad'));
 
       await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
 

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/RegistrerVirksomhetPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/RegistrerVirksomhetPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -38,22 +38,32 @@ export const RegistrerVirksomhetPanel = ({ readOnly = false, alleKodeverk }: Pro
       required: intl.formatMessage({ id: 'Registrering.RegistrerVirksomhetPanel.ArrayMinLength' }),
     },
   });
+  const leggTilVirksomhet = () => {
+    append(VirksomhetRad.initialValues());
+  };
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      leggTilVirksomhet();
+    }
+  }, []);
 
   return (
     <>
       <Table>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell colSpan={3}>
+            <Table.HeaderCell style={{ width: '48px' }} />
+            <Table.HeaderCell>
               <FormattedMessage id="Registrering.RegistrerVirksomhetPanel.Name" />
             </Table.HeaderCell>
+            <Table.HeaderCell style={{ width: '48px' }} />
           </Table.Row>
         </Table.Header>
         <Table.Body>
           {fields.map((field, index) => (
             <VirksomhetRad
               key={field.id}
-              field={field}
               index={index}
               open={index + 1 === fields.length}
               remove={() => remove(index)}
@@ -72,7 +82,7 @@ export const RegistrerVirksomhetPanel = ({ readOnly = false, alleKodeverk }: Pro
           size="small"
           variant="tertiary"
           type="button"
-          onClick={() => append(VirksomhetRad.initialValues())}
+          onClick={leggTilVirksomhet}
           icon={<PlusCircleIcon aria-hidden />}
         >
           <FormattedMessage id="Registrering.RegistrerVirksomhetPanel.Add" />

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetRad.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetRad.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { FieldArrayWithId, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
-import { TrashIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Table, VStack } from '@navikt/ds-react';
+import { ChevronDownIcon, ChevronUpIcon, TrashIcon } from '@navikt/aksel-icons';
+import { BodyShort, Box, Button, Table, VStack } from '@navikt/ds-react';
 import { InputField } from '@navikt/ft-form-hooks';
 import { required } from '@navikt/ft-form-validators';
 
@@ -21,54 +21,54 @@ interface Props {
   index: number;
   readOnly?: boolean;
   alleKodeverk: AlleKodeverk;
-  field: FieldArrayWithId<VirksomhetFormValues, typeof VIRKSOMHET_FORM_NAME_PREFIX, 'id'>;
   remove: () => void;
   open: boolean;
 }
 
-export const VirksomhetRad = ({ open, readOnly = false, alleKodeverk, index, field, remove }: Props) => {
+export const VirksomhetRad = ({ open, readOnly = false, alleKodeverk, index, remove }: Props) => {
   const { getFieldState, watch } = useFormContext<VirksomhetFormValues>();
   const { error } = getFieldState(`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}`);
   const virksomhetNavn = watch(`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.navn`);
   const [isOpen, setIsOpen] = useState(open);
+
   return (
-    <Table.ExpandableRow
-      key={field.id}
-      open={isOpen}
-      style={{ backgroundColor: error && !isOpen ? 'var(--a-red-50)' : undefined }}
-      onOpenChange={() => setIsOpen(!isOpen)}
-      content={
-        <VStack gap="4">
-          <VirksomhetIdentifikasjonPanel readOnly={readOnly} index={index} alleKodeverk={alleKodeverk} />
-          <VirksomhetTypeNaringPanel readOnly={readOnly} index={index} alleKodeverk={alleKodeverk} />
-          <VirksomhetStartetEndretPanel readOnly={readOnly} index={index} />
-          <VirksomhetRegnskapPanel readOnly={readOnly} index={index} />
-          <VirksomhetRelasjonPanel readOnly={readOnly} index={index} />
-        </VStack>
-      }
-    >
-      <Table.DataCell>
-        {isOpen ? (
+    <Table.Row shadeOnHover={false} style={{ backgroundColor: error && !isOpen ? 'var(--a-red-50)' : 'none' }}>
+      <Table.DataCell valign="top">
+        <Button
+          type="button"
+          variant="tertiary-neutral"
+          onClick={() => setIsOpen(curr => !curr)}
+          icon={isOpen ? <ChevronUpIcon aria-label="Vis mindre" /> : <ChevronDownIcon aria-label="Vis mer" />}
+        />
+      </Table.DataCell>
+      <Table.DataCell valign="top">
+        <Box hidden={isOpen} paddingBlock="3">
+          <BodyShort weight="semibold">{virksomhetNavn}</BodyShort>
+        </Box>
+        <VStack gap="4" hidden={!isOpen}>
           <InputField
             name={`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.navn`}
             validate={[required]}
             label={<FormattedMessage id="Registrering.VirksomhetIdentifikasjonPanel.Name" />}
             readOnly={readOnly}
           />
-        ) : (
-          <BodyShort weight="semibold">{virksomhetNavn}</BodyShort>
-        )}
+          <VirksomhetIdentifikasjonPanel readOnly={readOnly} index={index} alleKodeverk={alleKodeverk} />
+          <VirksomhetTypeNaringPanel readOnly={readOnly} index={index} alleKodeverk={alleKodeverk} />
+          <VirksomhetStartetEndretPanel readOnly={readOnly} index={index} />
+          <VirksomhetRegnskapPanel readOnly={readOnly} index={index} />
+          <VirksomhetRelasjonPanel readOnly={readOnly} index={index} />
+        </VStack>
       </Table.DataCell>
-      <Table.DataCell align="right">
+      <Table.DataCell valign="top" align="right">
         <Button
-          variant="tertiary"
-          size="small"
+          type="button"
+          variant="tertiary-neutral"
           onClick={remove}
           onKeyDown={remove}
-          icon={<TrashIcon aria-label="Slett virksomhet" />}
+          icon={<TrashIcon aria-label="Slett rad" />}
         />
       </Table.DataCell>
-    </Table.ExpandableRow>
+    </Table.Row>
   );
 };
 


### PR DESCRIPTION
papirsoknaden inneholdt inputfelter som hadde betinget visning, det gjorde at form felter som ble skjult ved bruk av `<Table.ExpandableRow>` gjorde at feltene ble uregistrer da react hook form ikke lenger fant dem i DOMen.