### PR TITLE
erstatt ft-ui-komponent > WarningModal med aksel sin Modal

### DIFF
--- a/apps/fp-frontend-app/i18n/nb_NO.json
+++ b/apps/fp-frontend-app/i18n/nb_NO.json
@@ -125,8 +125,8 @@
   "ProsessPanelWrapper.Henlagt": "Behandlingen er henlagt",
 
   "FatterTilbakekrevingVedtakStatusModal.Sendt": "Forslag til vedtak er sendt til beslutter",
-  "BehandlingTilbakekrevingIndex.ApenRevurdering": "Det finnes en åpen revurdering som kan påvirke denne tilbakekrevingsbehandlingen. Vurder konsekvens ved behandling.",
-  "BehandlingTilbakekrevingIndex.ApenRevurderingHeader": "Åpen revurdering",
+  "ÅpenRevurderingModal.ApenRevurdering": "Det finnes en åpen revurdering som kan påvirke denne tilbakekrevingsbehandlingen. Vurder konsekvens ved behandling.",
+  "ÅpenRevurderingModal.ApenRevurderingHeader": "Åpen revurdering",
 
   "BehandlingMenuIndex.Behandlingsmeny": "Behandlingsmeny",
 

--- a/apps/fp-frontend-app/i18n/nb_NO.json
+++ b/apps/fp-frontend-app/i18n/nb_NO.json
@@ -127,6 +127,7 @@
   "FatterTilbakekrevingVedtakStatusModal.Sendt": "Forslag til vedtak er sendt til beslutter",
   "ÅpenRevurderingModal.ApenRevurdering": "Det finnes en åpen revurdering som kan påvirke denne tilbakekrevingsbehandlingen. Vurder konsekvens ved behandling.",
   "ÅpenRevurderingModal.ApenRevurderingHeader": "Åpen revurdering",
+  "ÅpenRevurderingModal.Ok": "OK",
 
   "BehandlingMenuIndex.Behandlingsmeny": "Behandlingsmeny",
 

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.spec.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.spec.tsx
@@ -13,7 +13,7 @@ describe('ÅpenRevurderingModal', () => {
     HTMLDialogElement.prototype.close = vi.fn();
   });
 
-  it('skal vise og lukke modal', async () => {
+  it('skal vise og lukke modal for åpen revurdering', async () => {
     await Default.run({ args: { harÅpenRevurdering: true } });
     expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1);
 
@@ -23,7 +23,7 @@ describe('ÅpenRevurderingModal', () => {
     expect(HTMLDialogElement.prototype.close).toHaveBeenCalledTimes(1);
   });
 
-  it('skal ikke vise modal modal', async () => {
+  it('skal ikke vise modal når ingen åpen revurdering', async () => {
     await Default.run({ args: { harÅpenRevurdering: false } });
     expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(0);
   });

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.spec.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.spec.tsx
@@ -1,0 +1,30 @@
+import { composeStories } from '@storybook/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect } from 'vitest';
+
+import * as stories from './ÅpenRevurderingModal.stories';
+
+const { Default } = composeStories(stories);
+
+describe('ÅpenRevurderingModal', () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn();
+    HTMLDialogElement.prototype.close = vi.fn();
+  });
+
+  it('skal vise og lukke modal', async () => {
+    await Default.run({ args: { harÅpenRevurdering: true } });
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByText('Åpen revurdering')).toBeInTheDocument();
+    expect(screen.getByText(/Det finnes en åpen revurdering som kan påvirke/)).toBeInTheDocument();
+    await userEvent.click(screen.getByText('OK'));
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('skal ikke vise modal modal', async () => {
+    await Default.run({ args: { harÅpenRevurdering: false } });
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.stories.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { getIntlDecorator } from '@navikt/fp-storybook-utils';
+
+import { ÅpenRevurderingModal } from './ÅpenRevurderingModal';
+
+import messages from '../../../../i18n/nb_NO.json';
+
+const withIntl = getIntlDecorator(messages);
+
+const meta = {
+  title: 'behandling/tilbakekreving/ÅpenRevurderingModal',
+  component: ÅpenRevurderingModal,
+  decorators: [withIntl],
+} satisfies Meta<typeof ÅpenRevurderingModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    harÅpenRevurdering: true,
+  },
+};

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.tsx
@@ -6,8 +6,8 @@ import { BodyShort, Button, Heading, HStack, Modal } from '@navikt/ds-react';
 
 export const ÅpenRevurderingModal = ({ harÅpenRevurdering }: { harÅpenRevurdering: boolean }) => {
   const intl = useIntl();
-
   const ref = useRef<HTMLDialogElement>(null);
+
   useEffect(() => {
     if (harÅpenRevurdering) {
       ref.current?.showModal();
@@ -20,7 +20,7 @@ export const ÅpenRevurderingModal = ({ harÅpenRevurdering }: { harÅpenRevurde
       width="small"
       aria-label={intl.formatMessage({ id: 'ÅpenRevurderingModal.ApenRevurderingHeader' })}
     >
-      <Modal.Header>
+      <Modal.Header closeButton={false}>
         <HStack gap="4" align="center">
           <ExclamationmarkTriangleFillIcon width={35} height={35} color="var(--a-orange-600)" />
           <Heading size="small">{intl.formatMessage({ id: 'ÅpenRevurderingModal.ApenRevurderingHeader' })}</Heading>
@@ -31,7 +31,7 @@ export const ÅpenRevurderingModal = ({ harÅpenRevurdering }: { harÅpenRevurde
       </Modal.Body>
       <Modal.Footer>
         <Button size="small" variant="primary" onClick={() => ref.current?.close()} autoFocus type="button">
-          OK
+          {intl.formatMessage({ id: 'ÅpenRevurderingModal.Ok' })}
         </Button>
       </Modal.Footer>
     </Modal>

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from 'react';
+import { useIntl } from 'react-intl';
+
+import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, Heading, HStack, Modal } from '@navikt/ds-react';
+
+export const ÅpenRevurderingModal = ({ harÅpenRevurdering }: { harÅpenRevurdering: boolean }) => {
+  const intl = useIntl();
+
+  const ref = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    if (harÅpenRevurdering) {
+      ref.current?.showModal();
+    }
+  }, [harÅpenRevurdering]);
+
+  return (
+    <Modal
+      ref={ref}
+      width="small"
+      aria-label={intl.formatMessage({ id: 'ÅpenRevurderingModal.ApenRevurderingHeader' })}
+    >
+      <Modal.Header>
+        <HStack gap="4" align="center">
+          <ExclamationmarkTriangleFillIcon width={35} height={35} color="var(--a-orange-600)" />
+          <Heading size="small">{intl.formatMessage({ id: 'ÅpenRevurderingModal.ApenRevurderingHeader' })}</Heading>
+        </HStack>
+      </Modal.Header>
+      <Modal.Body>
+        <BodyShort size="small">{intl.formatMessage({ id: 'ÅpenRevurderingModal.ApenRevurdering' })}</BodyShort>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button size="small" variant="primary" onClick={() => ref.current?.close()} autoFocus type="button">
+          OK
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
@@ -6,7 +6,7 @@ import {
   VedtakAksjonspunktCode,
   VedtakTilbakekrevingProsessIndex,
 } from '@navikt/ft-prosess-tilbakekreving-vedtak';
-import { LoadingPanel, WarningModal } from '@navikt/ft-ui-komponenter';
+import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
@@ -19,6 +19,7 @@ import { FatterVedtakStatusModal } from '../../felles/modaler/vedtak/FatterVedta
 import { ProsessDefaultInitPanel } from '../../felles/prosess/ProsessDefaultInitPanel';
 import { useStandardProsessPanelProps } from '../../felles/prosess/useStandardProsessPanelProps';
 import { ProsessPanelInitProps } from '../../felles/typer/prosessPanelInitProps';
+import { ÅpenRevurderingModal } from '../modaler/ÅpenRevurderingModal';
 
 import '@navikt/ft-prosess-tilbakekreving-vedtak/dist/style.css';
 
@@ -40,7 +41,6 @@ export const VedtakTilbakekrevingProsessInitPanel = ({
 }: Props & ProsessPanelInitProps) => {
   const intl = useIntl();
 
-  const [visApenRevurderingModal, setVisApenRevurderingModal] = useState(harApenRevurdering);
   const [visFatterVedtakModal, setVisFatterVedtakModal] = useState(false);
 
   const lagringSideEffekter = getLagringSideeffekter(setVisFatterVedtakModal);
@@ -73,14 +73,9 @@ export const VedtakTilbakekrevingProsessInitPanel = ({
         }}
         tekst={intl.formatMessage({ id: 'FatterTilbakekrevingVedtakStatusModal.Sendt' })}
       />
-      {visApenRevurderingModal && (
-        <WarningModal
-          headerText={intl.formatMessage({ id: 'BehandlingTilbakekrevingIndex.ApenRevurderingHeader' })}
-          bodyText={intl.formatMessage({ id: 'BehandlingTilbakekrevingIndex.ApenRevurdering' })}
-          showModal
-          submit={() => setVisApenRevurderingModal(false)}
-        />
-      )}
+
+      <ÅpenRevurderingModal harÅpenRevurdering={harApenRevurdering} />
+
       <ProsessDefaultInitPanel
         {...props}
         standardPanelProps={standardPanelProps}


### PR DESCRIPTION
WarningModal er kun brukt et sted i fp-frontend. Den kan med fordel fjernes fra `ft-frontend-saksbehandling` for å minimere vedlikeholdskosten av `ft-frontend-saksbehandling`.

Relatert PR i ft-frontend-saksbehandling: https://github.com/navikt/ft-frontend-saksbehandling/pull/3517

**Før**:
![Skjermbilde 2025-01-28 kl  11 06 40](https://github.com/user-attachments/assets/81d3e0cf-bd26-4cb5-becd-e7d7b765c068)


**Etter:**
![Skjermbilde 2025-01-28 kl  11 12 37](https://github.com/user-attachments/assets/8ef67c14-622a-4f26-b965-29aa3013c7df)

