### PR TITLE
FIX margin i uttaksdok (etter at Aksel har endra på tabell-komp)

### DIFF
--- a/packages/fakta-uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaTable/uttakDokumentasjonFaktaTable.module.css
+++ b/packages/fakta-uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaTable/uttakDokumentasjonFaktaTable.module.css
@@ -4,5 +4,5 @@
 }
 
 .expansionContentInner {
-  margin: calc(0rem - var(--a-spacing-4)) calc(0rem - var(--a-spacing-2) - 3rem);
+  margin: calc(0rem - var(--a-spacing-4)) calc(0rem - var(--a-spacing-2));
 }


### PR DESCRIPTION
Har endra på margin. Gammal versjon: https://navikt.github.io/fp-frontend/@navikt/fp-fakta-uttaksdokumentasjon/index.html?path=/story/fakta-fakta-uttaksdokumentasjon--aksjonspunkt-med-uavklarte-perioder

Ny versjon:
![uttaksdok](https://github.com/user-attachments/assets/c68d6186-99d9-4cd2-9335-0fb633def69f)

@sirimykland Har fiksa dette eit par andre stader. Veit du om fleire?