### PR TITLE
Ikkje gjer unødvendige kall til backend

### DIFF
--- a/apps/fp-frontend-app/src/behandling/anke/prosessPaneler/AnkeBehandlingProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/anke/prosessPaneler/AnkeBehandlingProsessStegInitPanel.tsx
@@ -29,9 +29,7 @@ export const AnkeBehandlingProsessStegInitPanel = () => {
       prosessPanelKode={ProsessStegCode.ANKEBEHANDLING}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Ankebehandling' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={
-        behandling.behandlingsresultat?.type ? VilkarUtfallType.OPPFYLT : VilkarUtfallType.IKKE_VURDERT
-      }
+      overstyrtStatus={behandling.behandlingsresultat?.type ? VilkarUtfallType.OPPFYLT : VilkarUtfallType.IKKE_VURDERT}
     >
       {ankeVurdering ? (
         <AnkeProsessIndex

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/BeregningEsProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/BeregningEsProsessStegInitPanel.tsx
@@ -32,7 +32,7 @@ export const BeregningEsProsessStegInitPanel = () => {
       prosessPanelKode={ProsessStegCode.BEREGNING}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Beregning' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={
+      overstyrtStatus={
         harLenke(behandling, 'BEREGNINGRESULTAT_ENGANGSSTONAD')
           ? VilkarUtfallType.OPPFYLT
           : VilkarUtfallType.IKKE_VURDERT

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/SoknadsfristEsProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/SoknadsfristEsProsessStegInitPanel.tsx
@@ -28,12 +28,12 @@ export const SoknadsfristEsProsessStegInitPanel = () => {
 
   const api = useBehandlingApi(behandling);
 
-  const { data: søknad } = useQuery(api.søknadOptions(behandling));
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
-
   const harSoknadsfristAp = standardPanelProps.aksjonspunkter.some(
     ap => ap.definisjon === AksjonspunktKode.SOKNADSFRISTVILKARET,
   );
+
+  const { data: søknad } = useQuery(api.søknadOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, harSoknadsfristAp));
 
   return (
     <PanelOverstyringProvider

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/VedtakEsProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/VedtakEsProsessStegInitPanel.tsx
@@ -100,16 +100,16 @@ export const VedtakEsProsessStegInitPanel = () => {
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
       overstyrtStatus={findStatusForVedtak(
-        vilkår || [],
-        behandling.aksjonspunkt || [],
+        vilkår ?? [],
+        behandling.aksjonspunkt ?? [],
         aksjonspunkter,
         behandling.behandlingsresultat,
       )}
       skalMarkeresSomAktiv={
         !behandling.behandlingHenlagt &&
         findStatusForVedtak(
-          vilkår || [],
-          behandling.aksjonspunkt || [],
+          vilkår ?? [],
+          behandling.aksjonspunkt ?? [],
           aksjonspunkter,
           behandling.behandlingsresultat,
         ) !== VilkarUtfallType.IKKE_VURDERT

--- a/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/VedtakEsProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/engangsstonad/prosessPaneler/VedtakEsProsessStegInitPanel.tsx
@@ -99,13 +99,13 @@ export const VedtakEsProsessStegInitPanel = () => {
       prosessPanelKode={ProsessStegCode.VEDTAK}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={findStatusForVedtak(
+      overstyrtStatus={findStatusForVedtak(
         vilkår || [],
         behandling.aksjonspunkt || [],
         aksjonspunkter,
         behandling.behandlingsresultat,
       )}
-      hentSkalMarkeresSomAktiv={
+      skalMarkeresSomAktiv={
         !behandling.behandlingHenlagt &&
         findStatusForVedtak(
           vilkår || [],

--- a/apps/fp-frontend-app/src/behandling/felles/prosess/ProsessDefaultInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/felles/prosess/ProsessDefaultInitPanel.tsx
@@ -11,10 +11,10 @@ import { useProsessMenyRegistrerer } from './useProsessMenyRegistrerer';
 
 export type Props = {
   skalPanelVisesIMeny: boolean;
-  hentOverstyrtStatus?: string;
+  overstyrtStatus?: string;
   prosessPanelKode: ProsessStegCode;
   prosessPanelMenyTekst: string;
-  hentSkalMarkeresSomAktiv?: boolean;
+  skalMarkeresSomAktiv?: boolean;
   standardPanelProps: StandardProsessPanelProps;
   children: ReactElement;
 };
@@ -40,8 +40,8 @@ export type ProsessPanel = {
 };
 
 const ProsessPanel = ({
-  hentOverstyrtStatus,
-  hentSkalMarkeresSomAktiv,
+  overstyrtStatus,
+  skalMarkeresSomAktiv,
   skalPanelVisesIMeny,
   prosessPanelKode,
   prosessPanelMenyTekst,
@@ -51,9 +51,9 @@ const ProsessPanel = ({
 }: Props & ProsessPanel) => {
   const { behandling, fagsak, alleKodeverk } = use(BehandlingDataContext);
 
-  const status = hentOverstyrtStatus ?? standardPanelProps.status;
+  const status = overstyrtStatus ?? standardPanelProps.status;
 
-  const skalMarkeresSomAktiv = !!hentSkalMarkeresSomAktiv && !behandling.behandlingHenlagt;
+  const markertSomAktiv = !!skalMarkeresSomAktiv && !behandling.behandlingHenlagt;
 
   const erPanelValgt = useProsessMenyRegistrerer(
     prosessPanelKode,
@@ -61,7 +61,7 @@ const ProsessPanel = ({
     skalPanelVisesIMeny,
     harApentAksjonspunkt,
     status,
-    skalMarkeresSomAktiv || harApentAksjonspunkt,
+    markertSomAktiv || harApentAksjonspunkt,
   );
 
   const skalVisePanel = erPanelValgt && (harApentAksjonspunkt || status !== VilkarUtfallType.IKKE_VURDERT);

--- a/apps/fp-frontend-app/src/behandling/felles/prosess/ProsessDefaultInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/felles/prosess/ProsessDefaultInitPanel.tsx
@@ -30,7 +30,7 @@ export const ProsessDefaultInitOverstyringPanel = (props: Props) => {
   const { erOverstyrt } = usePanelOverstyring();
 
   const { standardPanelProps } = props;
-  const harApentAksjonspunkt = erOverstyrt || standardPanelProps.isAksjonspunktOpen;
+  const harApentAksjonspunkt = erOverstyrt ?? standardPanelProps.isAksjonspunktOpen;
 
   return <ProsessPanel {...props} harApentAksjonspunkt={harApentAksjonspunkt} />;
 };

--- a/apps/fp-frontend-app/src/behandling/felles/prosess/ProsessDefaultInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/felles/prosess/ProsessDefaultInitPanel.tsx
@@ -30,7 +30,7 @@ export const ProsessDefaultInitOverstyringPanel = (props: Props) => {
   const { erOverstyrt } = usePanelOverstyring();
 
   const { standardPanelProps } = props;
-  const harApentAksjonspunkt = erOverstyrt ?? standardPanelProps.isAksjonspunktOpen;
+  const harApentAksjonspunkt = erOverstyrt || standardPanelProps.isAksjonspunktOpen;
 
   return <ProsessPanel {...props} harApentAksjonspunkt={harApentAksjonspunkt} />;
 };

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/AdopsjonsvilkaretFaktaInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/AdopsjonsvilkaretFaktaInitPanel.tsx
@@ -24,9 +24,11 @@ export const AdopsjonsvilkaretFaktaInitPanel = () => {
 
   const { behandling, fagsak } = use(BehandlingDataContext);
 
+  const skalPanelVisesIMeny = behandling.vilkår.some(v => adopsjonsvilkarene.some(av => av === v.vilkarType));
+
   const api = useBehandlingApi(behandling);
 
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalPanelVisesIMeny));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
 
   return (
@@ -34,7 +36,7 @@ export const AdopsjonsvilkaretFaktaInitPanel = () => {
       standardPanelProps={standardPanelProps}
       faktaPanelKode={FaktaPanelCode.ADOPSJONSVILKARET}
       faktaPanelMenyTekst={useIntl().formatMessage({ id: 'FaktaInitPanel.Title.Adopsjon' })}
-      skalPanelVisesIMeny={behandling.vilkår.some(v => adopsjonsvilkarene.some(av => av === v.vilkarType))}
+      skalPanelVisesIMeny={skalPanelVisesIMeny}
     >
       {familiehendelse && søknad ? (
         <AdopsjonFaktaIndex

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/FodselvilkaretFaktaInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/FodselvilkaretFaktaInitPanel.tsx
@@ -20,11 +20,13 @@ export const FodselvilkaretFaktaInitPanel = () => {
 
   const { behandling } = use(BehandlingDataContext);
 
+  const skalPanelVisesIMeny = behandling.vilkår.some(v => fodselsvilkarene.some(fv => fv === v.vilkarType));
+
   const standardPanelProps = useStandardFaktaPanelProps(AKSJONSPUNKT_KODER);
 
   const api = useBehandlingApi(behandling);
 
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalPanelVisesIMeny));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
   const { data: familiehendelseOrigninalBehandling } = useQuery(
     api.familiehendelseOrigninalBehandlingOptions(behandling),
@@ -36,7 +38,7 @@ export const FodselvilkaretFaktaInitPanel = () => {
       standardPanelProps={standardPanelProps}
       faktaPanelKode={FaktaPanelCode.FODSELSVILKARET}
       faktaPanelMenyTekst={intl.formatMessage({ id: 'FaktaInitPanel.Title.Fodsel' })}
-      skalPanelVisesIMeny={behandling.vilkår.some(v => fodselsvilkarene.some(fv => fv === v.vilkarType))}
+      skalPanelVisesIMeny={skalPanelVisesIMeny}
     >
       {familiehendelse && søknad ? (
         <FodselFaktaIndex

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/OmsorgOgForeldreansvarFaktaInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/OmsorgOgForeldreansvarFaktaInitPanel.tsx
@@ -26,10 +26,12 @@ export const OmsorgOgForeldreansvarFaktaInitPanel = ({ personoversikt }: Props) 
 
   const { behandling } = use(BehandlingDataContext);
 
+  const skalPanelVisesIMeny = AKSJONSPUNKT_KODER.some(kode => hasAksjonspunkt(kode, behandling.aksjonspunkt));
+
   const api = useBehandlingApi(behandling);
 
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalPanelVisesIMeny));
   const { data: inntektArbeidYtelse } = useQuery(api.inntektArbeidYtelseOptions(behandling));
 
   return (
@@ -37,7 +39,7 @@ export const OmsorgOgForeldreansvarFaktaInitPanel = ({ personoversikt }: Props) 
       standardPanelProps={standardPanelProps}
       faktaPanelKode={FaktaPanelCode.OMSORGSVILKARET}
       faktaPanelMenyTekst={intl.formatMessage({ id: 'FaktaInitPanel.Title.OmsorgOgForeldreansvar' })}
-      skalPanelVisesIMeny={AKSJONSPUNKT_KODER.some(kode => hasAksjonspunkt(kode, behandling.aksjonspunkt))}
+      skalPanelVisesIMeny={skalPanelVisesIMeny}
     >
       {søknad && familiehendelse && inntektArbeidYtelse ? (
         <OmsorgOgForeldreansvarFaktaIndex

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/OpptjeningsvilkaretFaktaInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/fakta/OpptjeningsvilkaretFaktaInitPanel.tsx
@@ -27,21 +27,22 @@ export const OpptjeningsvilkaretFaktaInitPanel = ({ arbeidsgiverOpplysningerPerI
 
   const standardPanelProps = useStandardFaktaPanelProps(AKSJONSPUNKT_KODER);
 
+  const skalPanelVisesIMeny =
+    behandling.vilkår.some(v => v.vilkarType === VilkarType.OPPTJENINGSVILKARET) &&
+    behandling.vilkår.some(
+      v => v.vilkarType === VilkarType.MEDLEMSKAPSVILKARET && v.vilkarStatus === VilkarUtfallType.OPPFYLT,
+    );
+
   const api = useBehandlingApi(behandling);
 
-  const { data: opptjening, isFetching } = useQuery(api.opptjeningOptions(behandling));
+  const { data: opptjening, isFetching } = useQuery(api.opptjeningOptions(behandling, skalPanelVisesIMeny));
 
   return (
     <FaktaDefaultInitPanel
       standardPanelProps={standardPanelProps}
       faktaPanelKode={FaktaPanelCode.OPPTJENINGSVILKARET}
       faktaPanelMenyTekst={intl.formatMessage({ id: 'FaktaInitPanel.Title.Opptjening' })}
-      skalPanelVisesIMeny={
-        behandling.vilkår.some(v => v.vilkarType === VilkarType.OPPTJENINGSVILKARET) &&
-        behandling.vilkår.some(
-          v => v.vilkarType === VilkarType.MEDLEMSKAPSVILKARET && v.vilkarStatus === VilkarUtfallType.OPPFYLT,
-        )
-      }
+      skalPanelVisesIMeny={skalPanelVisesIMeny}
     >
       {!isFetching ? (
         <OpptjeningFaktaIndex opptjening={opptjening} arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId} />

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/SimuleringProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/SimuleringProsessStegInitPanel.tsx
@@ -54,7 +54,7 @@ export const SimuleringProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }
       standardPanelProps={standardPanelProps}
       prosessPanelKode={ProsessStegCode.SIMULERING}
       prosessPanelMenyTekst={useIntl().formatMessage({ id: 'Behandlingspunkt.Avregning' })}
-      skalPanelVisesIMeny={harLenke(behandling, 'SIMULERING_RESULTAT') || !harVedtakspanel}
+      skalPanelVisesIMeny={harLenke(behandling, 'SIMULERING_RESULTAT') ?? !harVedtakspanel}
       overstyrtStatus={
         harLenke(behandling, 'SIMULERING_RESULTAT') ? VilkarUtfallType.OPPFYLT : VilkarUtfallType.IKKE_VURDERT
       }

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/SimuleringProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/SimuleringProsessStegInitPanel.tsx
@@ -55,7 +55,7 @@ export const SimuleringProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }
       prosessPanelKode={ProsessStegCode.SIMULERING}
       prosessPanelMenyTekst={useIntl().formatMessage({ id: 'Behandlingspunkt.Avregning' })}
       skalPanelVisesIMeny={harLenke(behandling, 'SIMULERING_RESULTAT') || !harVedtakspanel}
-      hentOverstyrtStatus={
+      overstyrtStatus={
         harLenke(behandling, 'SIMULERING_RESULTAT') ? VilkarUtfallType.OPPFYLT : VilkarUtfallType.IKKE_VURDERT
       }
     >

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/SimuleringProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/SimuleringProsessStegInitPanel.tsx
@@ -54,7 +54,7 @@ export const SimuleringProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }
       standardPanelProps={standardPanelProps}
       prosessPanelKode={ProsessStegCode.SIMULERING}
       prosessPanelMenyTekst={useIntl().formatMessage({ id: 'Behandlingspunkt.Avregning' })}
-      skalPanelVisesIMeny={harLenke(behandling, 'SIMULERING_RESULTAT') ?? !harVedtakspanel}
+      skalPanelVisesIMeny={harLenke(behandling, 'SIMULERING_RESULTAT') || !harVedtakspanel}
       overstyrtStatus={
         harLenke(behandling, 'SIMULERING_RESULTAT') ? VilkarUtfallType.OPPFYLT : VilkarUtfallType.IKKE_VURDERT
       }

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/VarselProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/VarselProsessStegInitPanel.tsx
@@ -51,9 +51,11 @@ export const VarselProsessStegInitPanel = () => {
   });
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER, [], lagringSideEffekter);
 
+  const skalPanelVisesIMeny = skalViseProsessPanel(standardPanelProps.aksjonspunkter);
+
   const api = useBehandlingApi(behandling);
 
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalPanelVisesIMeny));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
   const { data: familiehendelseOrigninalBehandling } = useQuery(
     api.familiehendelseOrigninalBehandlingOptions(behandling),
@@ -75,7 +77,7 @@ export const VarselProsessStegInitPanel = () => {
       standardPanelProps={standardPanelProps}
       prosessPanelKode={ProsessStegCode.VARSEL}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.CheckVarselRevurdering' })}
-      skalPanelVisesIMeny={skalViseProsessPanel(standardPanelProps.aksjonspunkter)}
+      skalPanelVisesIMeny={skalPanelVisesIMeny}
     >
       {familiehendelse && søknad && familiehendelseOrigninalBehandling && søknadOriginalBehandling ? (
         <VarselOmRevurderingProsessIndex

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/TilkjentYtelseFpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/TilkjentYtelseFpProsessStegInitPanel.tsx
@@ -26,12 +26,18 @@ export const TilkjentYtelseFpProsessStegInitPanel = ({ arbeidsgiverOpplysningerP
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER);
   const { behandling } = use(BehandlingDataContext);
 
+  const overstyrtStatus = behandling.links.find(link => link.rel === BehandlingRel.BEREGNINGRESULTAT_DAGYTELSE)
+    ? VilkarUtfallType.OPPFYLT
+    : VilkarUtfallType.IKKE_VURDERT;
+
+  const skalHenteData = standardPanelProps.isAksjonspunktOpen || overstyrtStatus !== VilkarUtfallType.IKKE_VURDERT;
+
   const api = useBehandlingApi(behandling);
 
   const { data: beregningsresultatDagytelse } = useQuery(api.beregningsresultatDagytelseOptions(behandling));
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalHenteData));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
-  const { data: feriepengegrunnlag } = useQuery(api.feriepengegrunnlagOptions(behandling));
+  const { data: feriepengegrunnlag } = useQuery(api.feriepengegrunnlagOptions(behandling, skalHenteData));
 
   return (
     <ProsessDefaultInitPanel
@@ -39,11 +45,7 @@ export const TilkjentYtelseFpProsessStegInitPanel = ({ arbeidsgiverOpplysningerP
       prosessPanelKode={ProsessStegCode.TILKJENT_YTELSE}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.TilkjentYtelse' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={
-        behandling.links.find(link => link.rel === BehandlingRel.BEREGNINGRESULTAT_DAGYTELSE)
-          ? VilkarUtfallType.OPPFYLT
-          : VilkarUtfallType.IKKE_VURDERT
-      }
+      overstyrtStatus={overstyrtStatus}
     >
       {beregningsresultatDagytelse && familiehendelse && søknad ? (
         <TilkjentYtelseProsessIndex

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/UttakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/UttakProsessStegInitPanel.tsx
@@ -47,10 +47,14 @@ export const UttakProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, perso
 
   const { rettigheter, behandling } = use(BehandlingDataContext);
 
+  const overstyrtStatus = getStatusFromUttakresultat(behandling);
+
+  const skalHenteData = standardPanelProps.isAksjonspunktOpen || overstyrtStatus !== VilkarUtfallType.IKKE_VURDERT;
+
   const api = useBehandlingApi(behandling);
 
   const { data: uttaksresultat } = useQuery(api.uttaksresultatPerioderOptions(behandling));
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalHenteData));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
   const { data: uttakStønadskontoer } = useQuery(api.uttakStønadskontoerOptions(behandling));
 
@@ -64,7 +68,7 @@ export const UttakProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, perso
       prosessPanelKode={ProsessStegCode.UTTAK}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Uttak' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={getStatusFromUttakresultat(behandling)}
+      overstyrtStatus={overstyrtStatus}
     >
       {uttaksresultat && familiehendelse && søknad && uttakStønadskontoer ? (
         <UttakProsessIndex

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/VedtakFpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/VedtakFpProsessStegInitPanel.tsx
@@ -101,16 +101,16 @@ export const VedtakFpProsessStegInitPanel = () => {
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
       overstyrtStatus={findStatusForVedtak(
-        vilkår || [],
-        behandling.aksjonspunkt || [],
+        vilkår ?? [],
+        behandling.aksjonspunkt ?? [],
         standardPanelProps.aksjonspunkter,
         standardPanelProps.behandling.behandlingsresultat,
       )}
       skalMarkeresSomAktiv={
         !standardPanelProps.behandling.behandlingHenlagt &&
         findStatusForVedtak(
-          vilkår || [],
-          standardPanelProps.behandling.aksjonspunkt || [],
+          vilkår ?? [],
+          standardPanelProps.behandling.aksjonspunkt ?? [],
           standardPanelProps.aksjonspunkter,
           standardPanelProps.behandling.behandlingsresultat,
         ) !== VilkarUtfallType.IKKE_VURDERT

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/VedtakFpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/VedtakFpProsessStegInitPanel.tsx
@@ -100,13 +100,13 @@ export const VedtakFpProsessStegInitPanel = () => {
       prosessPanelKode={ProsessStegCode.VEDTAK}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={findStatusForVedtak(
+      overstyrtStatus={findStatusForVedtak(
         vilkår || [],
         behandling.aksjonspunkt || [],
         standardPanelProps.aksjonspunkter,
         standardPanelProps.behandling.behandlingsresultat,
       )}
-      hentSkalMarkeresSomAktiv={
+      skalMarkeresSomAktiv={
         !standardPanelProps.behandling.behandlingHenlagt &&
         findStatusForVedtak(
           vilkår || [],

--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/OpptjeningInngangsvilkarFpInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/inngangsvilkarPaneler/OpptjeningInngangsvilkarFpInitPanel.tsx
@@ -22,11 +22,13 @@ export const OpptjeningInngangsvilkarFpInitPanel = () => {
 
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER, VILKAR_KODER);
 
+  const harIngenAksjonspunkt = standardPanelProps.aksjonspunkter.length === 0;
+
   const api = useBehandlingApi(standardPanelProps.behandling);
 
-  const { data: opptjening } = useQuery(api.opptjeningOptions(standardPanelProps.behandling));
+  const { data: opptjening } = useQuery(api.opptjeningOptions(standardPanelProps.behandling, !harIngenAksjonspunkt));
 
-  return standardPanelProps.aksjonspunkter.length === 0 ? (
+  return harIngenAksjonspunkt ? (
     <InngangsvilkarOverstyringDefaultInitPanel
       standardPanelProps={standardPanelProps}
       vilkarKoder={VILKAR_KODER}

--- a/apps/fp-frontend-app/src/behandling/innsyn/prosessPaneler/InnsynVedtakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/innsyn/prosessPaneler/InnsynVedtakProsessStegInitPanel.tsx
@@ -52,8 +52,8 @@ export const InnsynVedtakProsessStegInitPanel = () => {
       prosessPanelKode={ProsessStegCode.VEDTAK}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={getVedtakStatus(behandling)}
-      hentSkalMarkeresSomAktiv={getVedtakStatus(behandling) !== VilkarUtfallType.IKKE_VURDERT}
+      overstyrtStatus={getVedtakStatus(behandling)}
+      skalMarkeresSomAktiv={getVedtakStatus(behandling) !== VilkarUtfallType.IKKE_VURDERT}
     >
       <>
         <IverksetterVedtakStatusModal

--- a/apps/fp-frontend-app/src/behandling/klage/prosessPaneler/KlageresultatProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/klage/prosessPaneler/KlageresultatProsessStegInitPanel.tsx
@@ -68,8 +68,8 @@ export const KlageresultatProsessStegInitPanel = () => {
         prosessPanelKode={ProsessStegCode.KLAGE_RESULTAT}
         prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.ResultatKlage' })}
         standardPanelProps={standardPanelProps}
-        hentOverstyrtStatus={vedtakStatus}
-        hentSkalMarkeresSomAktiv={vedtakStatus !== VilkarUtfallType.IKKE_VURDERT}
+        overstyrtStatus={vedtakStatus}
+        skalMarkeresSomAktiv={vedtakStatus !== VilkarUtfallType.IKKE_VURDERT}
       >
         {klageVurdering ? (
           <VedtakKlageProsessIndex klageVurdering={klageVurdering} previewVedtakCallback={forhåndsvis} />

--- a/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
@@ -28,10 +28,16 @@ export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPer
 
   const api = useBehandlingApi(behandling);
 
+  const overstyrtStatus = behandling.links.find(link => link.rel === BehandlingRel.BEREGNINGRESULTAT_DAGYTELSE)
+    ? VilkarUtfallType.OPPFYLT
+    : VilkarUtfallType.IKKE_VURDERT;
+
+  const skalHenteData = standardPanelProps.isAksjonspunktOpen || overstyrtStatus !== VilkarUtfallType.IKKE_VURDERT;
+
   const { data: beregningsresultatDagytelse } = useQuery(api.beregningsresultatDagytelseOptions(behandling));
-  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling));
+  const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalHenteData));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
-  const { data: feriepengegrunnlag } = useQuery(api.feriepengegrunnlagOptions(behandling));
+  const { data: feriepengegrunnlag } = useQuery(api.feriepengegrunnlagOptions(behandling, skalHenteData));
 
   return (
     <ProsessDefaultInitPanel
@@ -39,11 +45,7 @@ export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPer
       prosessPanelKode={ProsessStegCode.TILKJENT_YTELSE}
       prosessPanelMenyTekst={useIntl().formatMessage({ id: 'Behandlingspunkt.TilkjentYtelse' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={
-        behandling.links.find(link => link.rel === BehandlingRel.BEREGNINGRESULTAT_DAGYTELSE)
-          ? VilkarUtfallType.OPPFYLT
-          : VilkarUtfallType.IKKE_VURDERT
-      }
+      overstyrtStatus={overstyrtStatus}
     >
       {beregningsresultatDagytelse && familiehendelse && søknad ? (
         <TilkjentYtelseProsessIndex

--- a/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/VedtakSvpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/VedtakSvpProsessStegInitPanel.tsx
@@ -101,16 +101,16 @@ export const VedtakSvpProsessStegInitPanel = () => {
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
       overstyrtStatus={findStatusForVedtak(
-        vilkår || [],
-        aksjonspunkter || [],
+        vilkår ?? [],
+        aksjonspunkter ?? [],
         standardPanelProps.aksjonspunkter,
         standardPanelProps.behandling.behandlingsresultat,
       )}
       skalMarkeresSomAktiv={
         !standardPanelProps.behandling.behandlingHenlagt &&
         findStatusForVedtak(
-          vilkår || [],
-          aksjonspunkter || [],
+          vilkår ?? [],
+          aksjonspunkter ?? [],
           standardPanelProps.aksjonspunkter,
           standardPanelProps.behandling.behandlingsresultat,
         ) !== VilkarUtfallType.IKKE_VURDERT

--- a/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/VedtakSvpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/VedtakSvpProsessStegInitPanel.tsx
@@ -100,13 +100,13 @@ export const VedtakSvpProsessStegInitPanel = () => {
       prosessPanelKode={ProsessStegCode.VEDTAK}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={findStatusForVedtak(
+      overstyrtStatus={findStatusForVedtak(
         vilkår || [],
         aksjonspunkter || [],
         standardPanelProps.aksjonspunkter,
         standardPanelProps.behandling.behandlingsresultat,
       )}
-      hentSkalMarkeresSomAktiv={
+      skalMarkeresSomAktiv={
         !standardPanelProps.behandling.behandlingHenlagt &&
         findStatusForVedtak(
           vilkår || [],

--- a/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/inngangsvilkarPaneler/OpptjeningInngangsvilkarInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/inngangsvilkarPaneler/OpptjeningInngangsvilkarInitPanel.tsx
@@ -25,12 +25,13 @@ export const OpptjeningInngangsvilkarInitPanel = () => {
   const { behandling } = use(BehandlingDataContext);
 
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER, VILKAR_KODER);
+  const harIngenAksjonspunkt = standardPanelProps.aksjonspunkter.length === 0;
 
   const api = useBehandlingApi(behandling);
 
-  const { data: opptjening } = useQuery(api.opptjeningOptions(behandling));
+  const { data: opptjening } = useQuery(api.opptjeningOptions(behandling, !harIngenAksjonspunkt));
 
-  return standardPanelProps.aksjonspunkter.length === 0 ? (
+  return harIngenAksjonspunkt ? (
     <InngangsvilkarOverstyringDefaultInitPanel
       standardPanelProps={standardPanelProps}
       vilkarKoder={VILKAR_KODER}

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/ForeldelseProsessInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/ForeldelseProsessInitPanel.tsx
@@ -48,7 +48,7 @@ export const ForeldelseProsessInitPanel = ({ tilbakekrevingKodeverk }: Props) =>
       prosessPanelKode={ProsessStegCode.FORELDELSE}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Foreldelse' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={
+      overstyrtStatus={
         harLenke(behandling, 'PERIODER_FORELDELSE') ? VilkarUtfallType.OPPFYLT : VilkarUtfallType.IKKE_VURDERT
       }
     >

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/TilbakekrevingProsessInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/TilbakekrevingProsessInitPanel.tsx
@@ -46,7 +46,7 @@ export const TilbakekrevingProsessInitPanel = ({ tilbakekrevingKodeverk }: Props
       prosessPanelKode={ProsessStegCode.TILBAKEKREVING}
       prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Tilbakekreving' })}
       skalPanelVisesIMeny
-      hentOverstyrtStatus={finnTilbakekrevingStatus(standardPanelProps.aksjonspunkter)}
+      overstyrtStatus={finnTilbakekrevingStatus(standardPanelProps.aksjonspunkter)}
     >
       {perioderForeldelse && vilkårvurderingsperioder && vilkårvurdering ? (
         <Wrapper

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
@@ -99,8 +99,8 @@ export const VedtakTilbakekrevingProsessInitPanel = ({ tilbakekrevingKodeverk }:
             vedtaksbrev={vedtaksbrev}
             kodeverkSamlingFpTilbake={tilbakekrevingKodeverk}
             fetchPreviewVedtaksbrev={forhandsvisVedtaksbrev}
-            erRevurderingTilbakekrevingKlage={erRevurderingTilbakekrevingKlage || false}
-            erRevurderingTilbakekrevingFeilBeløpBortfalt={erRevurderingTilbakekrevingFeilBeløpBortfalt || false}
+            erRevurderingTilbakekrevingKlage={erRevurderingTilbakekrevingKlage ?? false}
+            erRevurderingTilbakekrevingFeilBeløpBortfalt={erRevurderingTilbakekrevingFeilBeløpBortfalt ?? false}
             {...standardPanelProps}
           />
         ) : (

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
@@ -91,7 +91,7 @@ export const VedtakTilbakekrevingProsessInitPanel = ({ tilbakekrevingKodeverk }:
         prosessPanelKode={ProsessStegCode.VEDTAK}
         prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
         skalPanelVisesIMeny
-        hentOverstyrtStatus={getVedtakStatus(behandling.behandlingsresultat)}
+        overstyrtStatus={getVedtakStatus(behandling.behandlingsresultat)}
       >
         {beregningsresultat && vedtaksbrev ? (
           <Wrapper

--- a/apps/fp-frontend-app/src/data/behandlingApi.ts
+++ b/apps/fp-frontend-app/src/data/behandlingApi.ts
@@ -316,10 +316,11 @@ const getBeregningsresultatDagytelseOptions = (links: ApiLink[]) => (behandling:
     staleTime: Infinity,
   });
 
-const getFamiliehendelseOptions = (links: ApiLink[]) => (behandling: Behandling) =>
+const getFamiliehendelseOptions = (links: ApiLink[]) => (behandling: Behandling, isEnabled: boolean) =>
   queryOptions({
     queryKey: [BehandlingRel.FAMILIEHENDELSE, behandling.uuid, behandling.versjon],
     queryFn: () => kyExtended.get(getUrlFromRel('FAMILIEHENDELSE', links)).json<FamilieHendelseSamling>(),
+    enabled: harLenke(behandling, 'FAMILIEHENDELSE') && isEnabled,
     staleTime: Infinity,
   });
 
@@ -330,10 +331,11 @@ const getSøknadOptions = (links: ApiLink[]) => (behandling: Behandling) =>
     staleTime: Infinity,
   });
 
-const getFeriepengegrunnlagOptions = (links: ApiLink[]) => (behandling: Behandling) =>
+const getFeriepengegrunnlagOptions = (links: ApiLink[]) => (behandling: Behandling, isEnabled: boolean) =>
   queryOptions({
     queryKey: [BehandlingRel.FERIEPENGEGRUNNLAG, behandling.uuid, behandling.versjon],
     queryFn: () => kyExtended.get(getUrlFromRel('FERIEPENGEGRUNNLAG', links)).json<Feriepengegrunnlag>(),
+    enabled: harLenke(behandling, 'FERIEPENGEGRUNNLAG') && isEnabled,
     staleTime: Infinity,
   });
 
@@ -389,10 +391,11 @@ const getSvangerskapspengerTilretteleggingOptions = (links: ApiLink[]) => (behan
     staleTime: Infinity,
   });
 
-const getOpptjeningOptions = (links: ApiLink[]) => (behandling: Behandling) =>
+const getOpptjeningOptions = (links: ApiLink[]) => (behandling: Behandling, isEnabled: boolean) =>
   queryOptions({
     queryKey: [BehandlingRel.OPPTJENING, behandling.uuid, behandling.versjon],
     queryFn: () => kyExtended.get(getUrlFromRel('OPPTJENING', links)).json<Opptjening>(),
+    enabled: harLenke(behandling, 'OPPTJENING') && isEnabled,
     staleTime: Infinity,
   });
 


### PR DESCRIPTION
Etter endringa av måten rest-kall blir gjort på, tilbake i januar, så er det nokre unødvendig kall som blir gjort. Dvs. data blir korkje brukt til å utleda om panel skal visast, eller i visning av panel. Eg gjekk først gjennom og tilpassa for alt, men etter å ha testa ein del saker via autotest så ser det ut som det i all hovudsak er tre kall som av og til ikkje bør kallast: opptjening, familiehendelse/v2 og feriepengegrunnlag. Så derfor har eg kun tilpassa desse. 

Ein kunne i staden gjort tilpasninga backend, ved å ikkje senda med lenkene. Men eg trur det får komme i ein større oppryddingsjobb etter at me har tenkt litt meir rundt korleis grensenittet bør sjå ut.