### PR TITLE
Fjern ubrukt funksjonalitet og ikkje bruk sentry lokalt

### DIFF
--- a/apps/fp-frontend-app/src/app/ErrorBoundary.tsx
+++ b/apps/fp-frontend-app/src/app/ErrorBoundary.tsx
@@ -5,6 +5,8 @@ import { captureException, withScope } from '@sentry/browser';
 
 import { ErrorPage } from '@navikt/fp-sak-infosider';
 
+const isDevelopment = import.meta.env.MODE === 'development';
+
 interface OwnProps {
   errorMessageCallback: (error: any) => void;
   children: ReactNode;
@@ -34,13 +36,15 @@ export class ErrorBoundary extends Component<OwnProps, State> {
   override componentDidCatch(error: Error, info: ErrorInfo): void {
     const { errorMessageCallback } = this.props;
 
-    withScope(scope => {
-      Object.keys(info).forEach(key => {
-        // @ts-expect-error Fiks
-        scope.setExtra(key, info[key]);
-        captureException(error);
+    if (!isDevelopment) {
+      withScope(scope => {
+        Object.keys(info).forEach(key => {
+          // @ts-expect-error Fiks
+          scope.setExtra(key, info[key]);
+          captureException(error);
+        });
       });
-    });
+    }
 
     const errorStrings = info.componentStack
       ? [

--- a/apps/fp-frontend-app/src/main.tsx
+++ b/apps/fp-frontend-app/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
-import { breadcrumbsIntegration, type ErrorEvent, type EventHint, init } from '@sentry/browser';
+import { breadcrumbsIntegration, init } from '@sentry/browser';
 import dayjs from 'dayjs';
 
 import { AppIndexWrapper } from './app/AppIndex';
@@ -20,32 +20,14 @@ if (app === null) {
 const environment = window.location.hostname;
 const isDevelopment = import.meta.env.MODE === 'development';
 
-init({
-  dsn: isDevelopment ? 'http://dev@localhost:9010/1' : 'https://d1b7de8cc42949569da03849b47d3ea1@sentry.gc.nav.no/17',
-  release: import.meta.env['SENTRY_RELEASE'] || 'unknown',
-  environment,
-  integrations: [breadcrumbsIntegration({ console: false })],
-  beforeSend: (event: ErrorEvent, hint: EventHint) => {
-    const exception = hint.originalException;
-    // @ts-expect-error
-    if (exception.isAxiosError) {
-      // @ts-expect-error
-      const requestUrl = new URL(exception.request.responseURL);
-      event.fingerprint = [
-        '{{ default }}',
-        // @ts-expect-error
-        String(exception.name),
-        // @ts-expect-error
-        String(exception.message),
-        String(requestUrl.pathname),
-      ];
-      event.extra = event.extra ? event.extra : {};
-      // @ts-expect-error
-      event.extra.callId = exception.response.config.headers['Nav-Callid'];
-    }
-    return event;
-  },
-});
+if (!isDevelopment) {
+  init({
+    dsn: 'https://d1b7de8cc42949569da03849b47d3ea1@sentry.gc.nav.no/17',
+    release: import.meta.env['SENTRY_RELEASE'] || 'unknown',
+    environment,
+    integrations: [breadcrumbsIntegration({ console: false })],
+  });
+}
 
 const root = createRoot(app);
 


### PR DESCRIPTION
Fjerna funksjonalitet for å legga til ekstra info på api-kall som feilar, fordi ein traff aldri denne koden uansett. Det er kun i ErrorBoundary ein rapporterar feil til sentry per i dag. Mogleg me burde lagt det til i api-feilhåndteringa òg, men so lite som me brukar Sentry per no så ser eg ikkje heilt behovet.