### PR TITLE
FIX feil der ein ikkje huksar at brevredigering er gjort ved endring …

### DIFF
--- a/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/VedtakFpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/foreldrepenger/prosessPaneler/VedtakFpProsessStegInitPanel.tsx
@@ -8,7 +8,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { AksjonspunktKode, AksjonspunktStatus, isAvslag, VilkarUtfallType } from '@navikt/fp-kodeverk';
 import { ProsessStegCode } from '@navikt/fp-konstanter';
-import { VedtakProsessIndex } from '@navikt/fp-prosess-vedtak';
+import { VedtakEditeringProvider, VedtakProsessIndex } from '@navikt/fp-prosess-vedtak';
 import type { Aksjonspunkt, Behandlingsresultat, ForhåndsvisMeldingParams, Vilkar } from '@navikt/fp-types';
 import type { ProsessAksjonspunkt } from '@navikt/fp-types-avklar-aksjonspunkter';
 
@@ -72,7 +72,7 @@ export const VedtakFpProsessStegInitPanel = () => {
   );
   const { data: oppgaver, isFetching: isOFetching } = useQuery(api.oppgaverOptions(behandling));
 
-  const { mutateAsync: hentBrevOverstyring } = useMutation({
+  const { mutateAsync: hentBrevOverstyring, isPending } = useMutation({
     mutationFn: () => api.hentBrevOverstyring(),
   });
 
@@ -95,56 +95,61 @@ export const VedtakFpProsessStegInitPanel = () => {
     !isBdFetching && !isTvFetching && !isBgFetching && !isSrFetching && !isBdobFetching && !isOFetching;
 
   return (
-    <ProsessDefaultInitPanel
-      standardPanelProps={standardPanelProps}
-      prosessPanelKode={ProsessStegCode.VEDTAK}
-      prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
-      skalPanelVisesIMeny
-      overstyrtStatus={findStatusForVedtak(
-        vilkår ?? [],
-        behandling.aksjonspunkt ?? [],
-        standardPanelProps.aksjonspunkter,
-        standardPanelProps.behandling.behandlingsresultat,
-      )}
-      skalMarkeresSomAktiv={
-        !standardPanelProps.behandling.behandlingHenlagt &&
-        findStatusForVedtak(
+    <VedtakEditeringProvider
+      behandling={behandling}
+      hentBrevOverstyring={hentBrevOverstyring}
+      hentBrevOverstyringIsPending={isPending}
+      mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
+    >
+      <ProsessDefaultInitPanel
+        standardPanelProps={standardPanelProps}
+        prosessPanelKode={ProsessStegCode.VEDTAK}
+        prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
+        skalPanelVisesIMeny
+        overstyrtStatus={findStatusForVedtak(
           vilkår ?? [],
-          standardPanelProps.behandling.aksjonspunkt ?? [],
+          behandling.aksjonspunkt ?? [],
           standardPanelProps.aksjonspunkter,
           standardPanelProps.behandling.behandlingsresultat,
-        ) !== VilkarUtfallType.IKKE_VURDERT
-      }
-    >
-      <>
-        <IverksetterVedtakStatusModal
-          visModal={visIverksetterVedtakModal}
-          lukkModal={lukkIverksetterModal}
-          behandlingsresultat={standardPanelProps.behandling.behandlingsresultat}
-        />
-        <FatterVedtakStatusModal
-          visModal={visFatterVedtakModal}
-          lukkModal={lukkFatterModal}
-          tekst={intl.formatMessage({ id: 'FatterVedtakStatusModal.SendtBeslutter' })}
-        />
-        {isNotFetching ? (
-          <VedtakProsessIndex
-            tilbakekrevingvalg={tilbakekrevingValg}
-            beregningsresultatOriginalBehandling={beregningDagytelseOriginalBehandling}
-            simuleringResultat={simuleringResultat}
-            beregningresultatDagytelse={beregningsresultatDagytelse}
-            beregningsgrunnlag={beregningsgrunnlag}
-            previewCallback={forhandsvis}
-            vilkar={vilkår}
-            oppgaver={oppgaver}
-            hentBrevOverstyring={hentBrevOverstyring}
-            mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
-          />
-        ) : (
-          <LoadingPanel />
         )}
-      </>
-    </ProsessDefaultInitPanel>
+        skalMarkeresSomAktiv={
+          !standardPanelProps.behandling.behandlingHenlagt &&
+          findStatusForVedtak(
+            vilkår ?? [],
+            standardPanelProps.behandling.aksjonspunkt ?? [],
+            standardPanelProps.aksjonspunkter,
+            standardPanelProps.behandling.behandlingsresultat,
+          ) !== VilkarUtfallType.IKKE_VURDERT
+        }
+      >
+        <>
+          <IverksetterVedtakStatusModal
+            visModal={visIverksetterVedtakModal}
+            lukkModal={lukkIverksetterModal}
+            behandlingsresultat={standardPanelProps.behandling.behandlingsresultat}
+          />
+          <FatterVedtakStatusModal
+            visModal={visFatterVedtakModal}
+            lukkModal={lukkFatterModal}
+            tekst={intl.formatMessage({ id: 'FatterVedtakStatusModal.SendtBeslutter' })}
+          />
+          {isNotFetching ? (
+            <VedtakProsessIndex
+              tilbakekrevingvalg={tilbakekrevingValg}
+              beregningsresultatOriginalBehandling={beregningDagytelseOriginalBehandling}
+              simuleringResultat={simuleringResultat}
+              beregningresultatDagytelse={beregningsresultatDagytelse}
+              beregningsgrunnlag={beregningsgrunnlag}
+              previewCallback={forhandsvis}
+              vilkar={vilkår}
+              oppgaver={oppgaver}
+            />
+          ) : (
+            <LoadingPanel />
+          )}
+        </>
+      </ProsessDefaultInitPanel>
+    </VedtakEditeringProvider>
   );
 };
 

--- a/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/VedtakSvpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/svangerskapspenger/prosessPaneler/VedtakSvpProsessStegInitPanel.tsx
@@ -8,7 +8,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { AksjonspunktKode, AksjonspunktStatus, isAvslag, VilkarUtfallType } from '@navikt/fp-kodeverk';
 import { ProsessStegCode } from '@navikt/fp-konstanter';
-import { VedtakProsessIndex } from '@navikt/fp-prosess-vedtak';
+import { VedtakEditeringProvider, VedtakProsessIndex } from '@navikt/fp-prosess-vedtak';
 import type { Aksjonspunkt, Behandlingsresultat, ForhåndsvisMeldingParams, Vilkar } from '@navikt/fp-types';
 import type { ProsessAksjonspunkt } from '@navikt/fp-types-avklar-aksjonspunkter';
 
@@ -72,7 +72,7 @@ export const VedtakSvpProsessStegInitPanel = () => {
   );
   const { data: oppgaver, isFetching: isOFetching } = useQuery(api.oppgaverOptions(behandling));
 
-  const { mutateAsync: hentBrevOverstyring } = useMutation({
+  const { mutateAsync: hentBrevOverstyring, isPending } = useMutation({
     mutationFn: () => api.hentBrevOverstyring(),
   });
 
@@ -95,56 +95,61 @@ export const VedtakSvpProsessStegInitPanel = () => {
     !isBdFetching && !isTvFetching && !isBgFetching && !isSrFetching && !isBdobFetching && !isOFetching;
 
   return (
-    <ProsessDefaultInitPanel
-      standardPanelProps={standardPanelProps}
-      prosessPanelKode={ProsessStegCode.VEDTAK}
-      prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
-      skalPanelVisesIMeny
-      overstyrtStatus={findStatusForVedtak(
-        vilkår ?? [],
-        aksjonspunkter ?? [],
-        standardPanelProps.aksjonspunkter,
-        standardPanelProps.behandling.behandlingsresultat,
-      )}
-      skalMarkeresSomAktiv={
-        !standardPanelProps.behandling.behandlingHenlagt &&
-        findStatusForVedtak(
+    <VedtakEditeringProvider
+      behandling={behandling}
+      hentBrevOverstyring={hentBrevOverstyring}
+      hentBrevOverstyringIsPending={isPending}
+      mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
+    >
+      <ProsessDefaultInitPanel
+        standardPanelProps={standardPanelProps}
+        prosessPanelKode={ProsessStegCode.VEDTAK}
+        prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.Vedtak' })}
+        skalPanelVisesIMeny
+        overstyrtStatus={findStatusForVedtak(
           vilkår ?? [],
           aksjonspunkter ?? [],
           standardPanelProps.aksjonspunkter,
           standardPanelProps.behandling.behandlingsresultat,
-        ) !== VilkarUtfallType.IKKE_VURDERT
-      }
-    >
-      <>
-        <IverksetterVedtakStatusModal
-          visModal={visIverksetterVedtakModal}
-          lukkModal={lukkIverksetterModal}
-          behandlingsresultat={standardPanelProps.behandling.behandlingsresultat}
-        />
-        <FatterVedtakStatusModal
-          visModal={visFatterVedtakModal}
-          lukkModal={lukkFatterModal}
-          tekst={intl.formatMessage({ id: 'FatterVedtakStatusModal.SendtBeslutter' })}
-        />
-        {isNotFetching ? (
-          <VedtakProsessIndex
-            previewCallback={forhåndsvis}
-            beregningresultatDagytelse={beregningsresultatDagytelse}
-            tilbakekrevingvalg={tilbakekrevingValg}
-            beregningsgrunnlag={beregningsgrunnlag}
-            simuleringResultat={simuleringResultat}
-            beregningsresultatOriginalBehandling={beregingDagytelseOriginalBehandling}
-            vilkar={vilkår}
-            oppgaver={oppgaver}
-            hentBrevOverstyring={hentBrevOverstyring}
-            mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
-          />
-        ) : (
-          <LoadingPanel />
         )}
-      </>
-    </ProsessDefaultInitPanel>
+        skalMarkeresSomAktiv={
+          !standardPanelProps.behandling.behandlingHenlagt &&
+          findStatusForVedtak(
+            vilkår ?? [],
+            aksjonspunkter ?? [],
+            standardPanelProps.aksjonspunkter,
+            standardPanelProps.behandling.behandlingsresultat,
+          ) !== VilkarUtfallType.IKKE_VURDERT
+        }
+      >
+        <>
+          <IverksetterVedtakStatusModal
+            visModal={visIverksetterVedtakModal}
+            lukkModal={lukkIverksetterModal}
+            behandlingsresultat={standardPanelProps.behandling.behandlingsresultat}
+          />
+          <FatterVedtakStatusModal
+            visModal={visFatterVedtakModal}
+            lukkModal={lukkFatterModal}
+            tekst={intl.formatMessage({ id: 'FatterVedtakStatusModal.SendtBeslutter' })}
+          />
+          {isNotFetching ? (
+            <VedtakProsessIndex
+              previewCallback={forhåndsvis}
+              beregningresultatDagytelse={beregningsresultatDagytelse}
+              tilbakekrevingvalg={tilbakekrevingValg}
+              beregningsgrunnlag={beregningsgrunnlag}
+              simuleringResultat={simuleringResultat}
+              beregningsresultatOriginalBehandling={beregingDagytelseOriginalBehandling}
+              vilkar={vilkår}
+              oppgaver={oppgaver}
+            />
+          ) : (
+            <LoadingPanel />
+          )}
+        </>
+      </ProsessDefaultInitPanel>
+    </VedtakEditeringProvider>
   );
 };
 

--- a/packages/prosess/vedtak/index.ts
+++ b/packages/prosess/vedtak/index.ts
@@ -1,2 +1,3 @@
 export { VedtakProsessIndex } from './src/VedtakProsessIndex';
+export { VedtakEditeringProvider } from './src/VedtakEditeringContext';
 export type { ForhandsvisData } from './src/components/forstegang/VedtakForm';

--- a/packages/prosess/vedtak/src/VedtakEditeringContext.tsx
+++ b/packages/prosess/vedtak/src/VedtakEditeringContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, type ReactElement, useContext, useEffect, useMemo, useState } from 'react';
+
+import type { Behandling, BrevOverstyring } from '@navikt/fp-types';
+
+export type VedtakEditeringData = {
+  hentBrevOverstyring: () => Promise<BrevOverstyring>;
+  hentBrevOverstyringIsPending: boolean;
+  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
+  harRedigertBrev: boolean;
+  setHarRedigertBrev: (erRedigert: boolean) => void;
+};
+
+const VedtakEditeringContext = createContext<VedtakEditeringData | null>(null);
+
+export const VedtakEditeringProvider = ({
+  behandling,
+  hentBrevOverstyring,
+  hentBrevOverstyringIsPending,
+  mellomlagreBrevOverstyring,
+  children,
+}: {
+  behandling: Behandling;
+  hentBrevOverstyring: () => Promise<BrevOverstyring>;
+  hentBrevOverstyringIsPending: boolean;
+  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
+  children: ReactElement;
+}) => {
+  const [harRedigertBrev, setHarRedigertBrev] = useState(
+    behandling.behandlingsresultat?.harRedigertVedtaksbrev || false,
+  );
+
+  useEffect(() => {
+    setHarRedigertBrev(behandling.behandlingsresultat?.harRedigertVedtaksbrev || false);
+  }, [behandling.uuid, behandling.versjon]);
+
+  const value = useMemo(
+    () => ({
+      hentBrevOverstyring,
+      hentBrevOverstyringIsPending,
+      mellomlagreBrevOverstyring,
+      harRedigertBrev,
+      setHarRedigertBrev,
+    }),
+    [
+      hentBrevOverstyring,
+      hentBrevOverstyringIsPending,
+      mellomlagreBrevOverstyring,
+      harRedigertBrev,
+      setHarRedigertBrev,
+    ],
+  );
+
+  return <VedtakEditeringContext value={value}>{children}</VedtakEditeringContext>;
+};
+
+export const useVedtakEditeringContext = () => {
+  const context = useContext<VedtakEditeringData | null>(VedtakEditeringContext);
+  if (!context) {
+    throw new Error('VedtakEditeringContext er ikke satt opp');
+  }
+  return context;
+};

--- a/packages/prosess/vedtak/src/VedtakProsessIndex.spec.tsx
+++ b/packages/prosess/vedtak/src/VedtakProsessIndex.spec.tsx
@@ -73,7 +73,7 @@ describe('VedtakProsessIndex', () => {
     ]);
   });
 
-  it.skip('skal redigere innvilget vedtaksbrev, forhåndsvise og så fatte vedtak', async () => {
+  it('skal åpne modal for redigering og så forhåndsvise brev', async () => {
     const lagre = vi.fn();
     const mellomlagreBrev = vi.fn();
     const forhåndsvis = vi.fn();
@@ -105,25 +105,6 @@ describe('VedtakProsessIndex', () => {
       dokumentMal: DokumentMalType.FRITEKST_HTML,
       fritekst: expect.stringContaining('Nav har innvilget søknaden din om 100 prosent foreldrepenger'),
     });
-
-    await userEvent.click(screen.getByText('Lagre og lukk'));
-
-    await waitFor(() => expect(mellomlagreBrev).toHaveBeenCalledTimes(1));
-    expect(mellomlagreBrev).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('Nav har innvilget søknaden din om 100 prosent foreldrepenger'),
-    );
-
-    await userEvent.click(screen.getByText('Til godkjenning'));
-
-    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
-    expect(lagre).toHaveBeenNthCalledWith(1, [
-      {
-        begrunnelse: undefined,
-        kode: '5015',
-        skalBrukeOverstyrendeFritekstBrev: true,
-      },
-    ]);
   });
 
   it('skal redigere innvilget vedtaksbrev, åpne redigeringsmodal, forkaste overstyring og så fatte vedtak', async () => {

--- a/packages/prosess/vedtak/src/VedtakProsessIndex.spec.tsx
+++ b/packages/prosess/vedtak/src/VedtakProsessIndex.spec.tsx
@@ -75,15 +75,10 @@ describe('VedtakProsessIndex', () => {
 
   it('skal åpne modal for redigering og så forhåndsvise brev', async () => {
     const lagre = vi.fn();
-    const mellomlagreBrev = vi.fn();
     const forhåndsvis = vi.fn();
 
     render(
-      <InnvilgetForeldrepengerTilGodkjenningForSaksbehandler
-        submitCallback={lagre}
-        mellomlagreBrevOverstyring={mellomlagreBrev}
-        previewCallback={forhåndsvis}
-      />,
+      <InnvilgetForeldrepengerTilGodkjenningForSaksbehandler submitCallback={lagre} previewCallback={forhåndsvis} />,
     );
 
     expect(await screen.findByText('Vedtak')).toBeInTheDocument();

--- a/packages/prosess/vedtak/src/VedtakProsessIndex.stories.tsx
+++ b/packages/prosess/vedtak/src/VedtakProsessIndex.stories.tsx
@@ -32,6 +32,7 @@ import type {
 
 import mal from '../.storybook/brevmal/mal.html?raw';
 import redigertInnhold from '../.storybook/brevmal/redigertInnhold.html?raw';
+import { VedtakEditeringProvider } from './VedtakEditeringContext';
 import { VedtakProsessIndex } from './VedtakProsessIndex';
 
 const defaultAksjonspunkter = [
@@ -82,21 +83,19 @@ const meta = {
   args: {
     vilkar: defaultVilkar,
     previewCallback: action('button-click'),
-    hentBrevOverstyring: action('button-click') as () => Promise<BrevOverstyring>,
-    mellomlagreBrevOverstyring: action('button-click') as (html: string | null) => Promise<void>,
   },
   render: args => {
     const [redigertHtml, setRedigertHtml] = useState<string | null>(null);
 
     const mellomlagreBrevOverstyring = (redigert: string | null) => {
       setRedigertHtml(redigert);
-      return args.mellomlagreBrevOverstyring(redigert);
+      action('button-click')(redigert);
+      return Promise.resolve();
     };
 
     return (
-      <VedtakProsessIndex
-        {...args}
-        mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
+      <VedtakEditeringProvider
+        behandling={args.behandling ?? defaultBehandling}
         hentBrevOverstyring={() => {
           return redigertHtml && args.brevOverstyring
             ? Promise.resolve({
@@ -105,7 +104,11 @@ const meta = {
               })
             : Promise.resolve(args.brevOverstyring);
         }}
-      />
+        hentBrevOverstyringIsPending={false}
+        mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
+      >
+        <VedtakProsessIndex {...args} />
+      </VedtakEditeringProvider>
     );
   },
 } satisfies Meta<PanelDataArgs & { brevOverstyring: BrevOverstyring } & ComponentProps<typeof VedtakProsessIndex>>;

--- a/packages/prosess/vedtak/src/VedtakProsessIndex.tsx
+++ b/packages/prosess/vedtak/src/VedtakProsessIndex.tsx
@@ -8,7 +8,6 @@ import type {
   Beregningsgrunnlag,
   BeregningsresultatDagytelse,
   BeregningsresultatEs,
-  BrevOverstyring,
   Oppgave,
   SimuleringResultat,
   TilbakekrevingValg,
@@ -36,8 +35,6 @@ interface Props {
   vilkar: Vilkar[];
   previewCallback: (data: ForhandsvisData) => void;
   oppgaver?: Oppgave[];
-  hentBrevOverstyring: () => Promise<BrevOverstyring>;
-  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
 }
 
 export const VedtakProsessIndex = ({
@@ -50,8 +47,6 @@ export const VedtakProsessIndex = ({
   beregningsresultatOriginalBehandling,
   previewCallback,
   oppgaver,
-  hentBrevOverstyring,
-  mellomlagreBrevOverstyring,
 }: Props) => {
   const { behandling, fagsak } = usePanelDataContext();
 
@@ -82,8 +77,6 @@ export const VedtakProsessIndex = ({
           vilkar={vilkar}
           beregningErManueltFastsatt={beregningErManueltFastsatt}
           oppgaver={oppgaver}
-          hentBrevOverstyring={hentBrevOverstyring}
-          mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
         />
       )}
       {behandling.type === BehandlingType.REVURDERING && (
@@ -96,8 +89,6 @@ export const VedtakProsessIndex = ({
           beregningErManueltFastsatt={beregningErManueltFastsatt}
           beregningsresultatOriginalBehandling={originaltBeregningsresultat}
           oppgaver={oppgaver}
-          hentBrevOverstyring={hentBrevOverstyring}
-          mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
         />
       )}
     </RawIntlProvider>

--- a/packages/prosess/vedtak/src/components/editor/useEditorJs.tsx
+++ b/packages/prosess/vedtak/src/components/editor/useEditorJs.tsx
@@ -64,15 +64,12 @@ export const useEditorJs = (
           new Undo({ editor });
           refEditorJs.current = editor;
 
-          //Sjekk om save eksisterar for å unngå warning i test
-          if (editor.save) {
-            // Dette er for å seinare kunne finna ut om innhaldet er endra
-            const innhold = await editor.save();
-            refCurrentHtml.current = edjsHTML().parse(innhold);
-          }
+          // Dette er for å seinare kunne finna ut om innhaldet er endra
+          const innhold = await editor.save();
+          refCurrentHtml.current = edjsHTML().parse(innhold);
         },
         tools: getTools(intl),
-        onChange: async () => {
+        onChange: () => {
           lagreBrevDebouncer(validerOgLagre);
         },
       });

--- a/packages/prosess/vedtak/src/components/felles/OverstyringVedtaksbrev.tsx
+++ b/packages/prosess/vedtak/src/components/felles/OverstyringVedtaksbrev.tsx
@@ -9,28 +9,26 @@ import { DokumentMalType } from '@navikt/fp-kodeverk';
 import type { BrevOverstyring } from '@navikt/fp-types';
 import { usePanelDataContext } from '@navikt/fp-utils';
 
+import { useVedtakEditeringContext } from '../../VedtakEditeringContext';
 import { FritekstRedigeringModal } from '../editor/FritekstRedigeringModal';
 import type { ForhandsvisData } from '../forstegang/VedtakForm';
 
 interface Props {
   forhåndsvisBrev: (data: ForhandsvisData) => void;
-  hentBrevOverstyring: () => Promise<BrevOverstyring>;
-  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
-  setHarRedigertBrev: (harRedigert: boolean) => void;
-  harRedigertBrev: boolean;
   setHarValgtÅRedigereVedtaksbrev: (harOverstyrtVedtaksbrev: boolean) => void;
 }
 
-export const OverstyringVedtaksbrev = ({
-  forhåndsvisBrev,
-  hentBrevOverstyring,
-  mellomlagreBrevOverstyring,
-  setHarRedigertBrev,
-  harRedigertBrev,
-  setHarValgtÅRedigereVedtaksbrev,
-}: Props) => {
+export const OverstyringVedtaksbrev = ({ forhåndsvisBrev, setHarValgtÅRedigereVedtaksbrev }: Props) => {
   const intl = useIntl();
   const { isReadOnly } = usePanelDataContext();
+
+  const {
+    harRedigertBrev,
+    setHarRedigertBrev,
+    hentBrevOverstyring,
+    hentBrevOverstyringIsPending,
+    mellomlagreBrevOverstyring,
+  } = useVedtakEditeringContext();
 
   const [visForkastOverstyringModal, setVisForkastOverstyringModal] = useState(false);
 
@@ -61,6 +59,7 @@ export const OverstyringVedtaksbrev = ({
 
   const forkastOverstyrtBrev = async () => {
     setVisForkastOverstyringModal(false);
+    setHarRedigertBrev(false);
     setHarValgtÅRedigereVedtaksbrev(false);
 
     await mellomlagreBrevOverstyring(null);
@@ -89,12 +88,12 @@ export const OverstyringVedtaksbrev = ({
       <VStack gap="4">
         <Box padding="4" borderRadius="medium" background="surface-subtle">
           <VStack gap="4">
-            {!isReadOnly && !brevOverstyring?.redigertHtml && (
+            {!isReadOnly && !brevOverstyring?.redigertHtml && !hentBrevOverstyringIsPending && (
               <Alert variant="info" size="small">
                 <FormattedMessage id="OverstyringVedtaksbrev.KanRedigeres" />
               </Alert>
             )}
-            {!!brevOverstyring?.redigertHtml && (
+            {!!brevOverstyring?.redigertHtml && !hentBrevOverstyringIsPending && (
               <Alert variant="success" size="small">
                 <FormattedMessage id="OverstyringVedtaksbrev.ErOverstyrt" />
               </Alert>

--- a/packages/prosess/vedtak/src/components/felles/VedtakFellesPanel.tsx
+++ b/packages/prosess/vedtak/src/components/felles/VedtakFellesPanel.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, type ReactNode, useState } from 'react';
+import { type MouseEvent, type ReactNode } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -15,9 +15,10 @@ import {
   KonsekvensForYtelsen,
 } from '@navikt/fp-kodeverk';
 import { ApiPollingStatus } from '@navikt/fp-konstanter';
-import type { Aksjonspunkt, Behandling, Behandlingsresultat, BrevOverstyring, Oppgave } from '@navikt/fp-types';
+import type { Aksjonspunkt, Behandling, Behandlingsresultat, Oppgave } from '@navikt/fp-types';
 import { usePanelDataContext } from '@navikt/fp-utils';
 
+import { useVedtakEditeringContext } from '../../VedtakEditeringContext.tsx';
 import type { ForhandsvisData } from '../forstegang/VedtakForm';
 import { LegacyOverstyrtVedtaksbrev } from './LegacyOverstyrtVedtaksbrev.tsx';
 import { OppgaveTabell } from './OppgaveTabell.tsx';
@@ -69,8 +70,6 @@ interface Props {
   tilbakekrevingtekst?: string;
   vedtakstatusTekst?: string;
   oppgaver?: Oppgave[];
-  hentBrevOverstyring: () => Promise<BrevOverstyring>;
-  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
   setHarValgtÅRedigereVedtaksbrev: (harOverstyrtVedtaksbrev: boolean) => void;
   harValgtÅRedigereVedtaksbrev: boolean;
 }
@@ -83,8 +82,6 @@ export const VedtakFellesPanel = ({
   erBehandlingEtterKlage,
   vedtakstatusTekst,
   oppgaver,
-  hentBrevOverstyring,
-  mellomlagreBrevOverstyring,
   setHarValgtÅRedigereVedtaksbrev,
   harValgtÅRedigereVedtaksbrev,
 }: Props) => {
@@ -98,7 +95,7 @@ export const VedtakFellesPanel = ({
     formState: { isSubmitting },
   } = useFormContext();
 
-  const [harRedigertBrev, setHarRedigertBrev] = useState(behandlingsresultat?.harRedigertVedtaksbrev ?? false);
+  const { harRedigertBrev } = useVedtakEditeringContext();
 
   if (!behandlingsresultat) {
     throw new Error(`behandlingsresultat finnes ikke på behandling ${uuid}`);
@@ -204,10 +201,6 @@ export const VedtakFellesPanel = ({
         {harValgtÅRedigereVedtaksbrev && (
           <OverstyringVedtaksbrev
             forhåndsvisBrev={previewCallback}
-            hentBrevOverstyring={hentBrevOverstyring}
-            setHarRedigertBrev={setHarRedigertBrev}
-            harRedigertBrev={harRedigertBrev}
-            mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
             setHarValgtÅRedigereVedtaksbrev={setHarValgtÅRedigereVedtaksbrev}
           />
         )}

--- a/packages/prosess/vedtak/src/components/forstegang/VedtakForm.tsx
+++ b/packages/prosess/vedtak/src/components/forstegang/VedtakForm.tsx
@@ -22,7 +22,6 @@ import type {
   Behandlingsresultat,
   BeregningsresultatDagytelse,
   BeregningsresultatEs,
-  BrevOverstyring,
   Oppgave,
   SimuleringResultat,
   TilbakekrevingValg,
@@ -36,6 +35,7 @@ import type {
 } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
+import { useVedtakEditeringContext } from '../../VedtakEditeringContext';
 import { VedtakFellesPanel } from '../felles/VedtakFellesPanel';
 import { getTilbakekrevingText } from '../felles/VedtakHelper';
 import { VedtakAvslagPanel } from './VedtakAvslagPanel';
@@ -177,8 +177,6 @@ interface Props {
   vilkar?: Vilkar[];
   beregningErManueltFastsatt: boolean;
   oppgaver?: Oppgave[];
-  hentBrevOverstyring: () => Promise<BrevOverstyring>;
-  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
 }
 
 export const VedtakForm = ({
@@ -189,8 +187,6 @@ export const VedtakForm = ({
   vilkar,
   beregningErManueltFastsatt,
   oppgaver,
-  hentBrevOverstyring,
-  mellomlagreBrevOverstyring,
 }: Props) => {
   const { behandling, fagsak, alleKodeverk, submitCallback, isReadOnly } =
     usePanelDataContext<VedtakAksjonspunkter[]>();
@@ -209,10 +205,10 @@ export const VedtakForm = ({
 
   const { trigger } = formMethods;
 
-  const { vedtaksbrev, harRedigertVedtaksbrev } = behandlingsresultat ?? {};
+  const { harRedigertBrev } = useVedtakEditeringContext();
 
   const [harValgtÅRedigereVedtaksbrev, setHarValgtÅRedigereVedtaksbrev] = useState(
-    harRedigertVedtaksbrev || vedtaksbrev === DokumentMalType.FRITEKST,
+    harRedigertBrev || behandlingsresultat?.vedtaksbrev === DokumentMalType.FRITEKST,
   );
 
   const erBehandlingEtterKlage = erÅrsakTypeBehandlingEtterKlage(behandling.behandlingÅrsaker);
@@ -236,8 +232,6 @@ export const VedtakForm = ({
         tilbakekrevingtekst={tilbakekrevingtekst}
         erBehandlingEtterKlage={erBehandlingEtterKlage}
         oppgaver={oppgaver}
-        hentBrevOverstyring={hentBrevOverstyring}
-        mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
         setHarValgtÅRedigereVedtaksbrev={setHarValgtÅRedigereVedtaksbrev}
         harValgtÅRedigereVedtaksbrev={harValgtÅRedigereVedtaksbrev}
         renderPanel={(skalBrukeOverstyrendeFritekstBrev, erInnvilget, erAvslatt) => {

--- a/packages/prosess/vedtak/src/components/revurdering/VedtakRevurderingForm.tsx
+++ b/packages/prosess/vedtak/src/components/revurdering/VedtakRevurderingForm.tsx
@@ -22,7 +22,6 @@ import type {
   Behandling,
   BeregningsresultatDagytelse,
   BeregningsresultatEs,
-  BrevOverstyring,
   Oppgave,
   SimuleringResultat,
   TilbakekrevingValg,
@@ -40,6 +39,7 @@ import type {
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
 import { VedtakResultType } from '../../kodeverk/vedtakResultType';
+import { useVedtakEditeringContext } from '../../VedtakEditeringContext';
 import { VedtakFellesPanel } from '../felles/VedtakFellesPanel';
 import { getTilbakekrevingText } from '../felles/VedtakHelper';
 import { buildInitialValues } from '../forstegang/VedtakForm';
@@ -227,8 +227,6 @@ interface Props {
   beregningErManueltFastsatt: boolean;
   beregningsresultatOriginalBehandling?: BeregningsresultatDagytelse | BeregningsresultatEs;
   oppgaver?: Oppgave[];
-  hentBrevOverstyring: () => Promise<BrevOverstyring>;
-  mellomlagreBrevOverstyring: (redigertInnhold: string | null) => Promise<void>;
 }
 
 export const VedtakRevurderingForm = ({
@@ -240,18 +238,16 @@ export const VedtakRevurderingForm = ({
   beregningErManueltFastsatt,
   beregningsresultatOriginalBehandling,
   oppgaver,
-  hentBrevOverstyring,
-  mellomlagreBrevOverstyring,
 }: Props) => {
   const intl = useIntl();
 
   const { behandling, fagsak, alleKodeverk, submitCallback, isReadOnly } =
     usePanelDataContext<RevurderingVedtakAksjonspunkter[]>();
 
-  const { vedtaksbrev, harRedigertVedtaksbrev } = behandling.behandlingsresultat ?? {};
+  const { harRedigertBrev } = useVedtakEditeringContext();
 
   const [harValgtÅRedigereVedtaksbrev, setHarValgtÅRedigereVedtaksbrev] = useState(
-    harRedigertVedtaksbrev || vedtaksbrev === DokumentMalType.FRITEKST,
+    harRedigertBrev || behandling.behandlingsresultat?.vedtaksbrev === DokumentMalType.FRITEKST,
   );
 
   const { behandlingsresultat, språkkode, aksjonspunkt, behandlingÅrsaker } = behandling;
@@ -317,8 +313,6 @@ export const VedtakRevurderingForm = ({
         tilbakekrevingtekst={tilbakekrevingtekst}
         erBehandlingEtterKlage={erBehandlingEtterKlage}
         oppgaver={oppgaver}
-        hentBrevOverstyring={hentBrevOverstyring}
-        mellomlagreBrevOverstyring={mellomlagreBrevOverstyring}
         setHarValgtÅRedigereVedtaksbrev={setHarValgtÅRedigereVedtaksbrev}
         harValgtÅRedigereVedtaksbrev={harValgtÅRedigereVedtaksbrev}
         renderPanel={(skalBrukeOverstyrendeFritekstBrev, erInnvilget, erAvslatt, erOpphor) => {


### PR DESCRIPTION
…av prosesspanel

Problemet her var at når ein gjorde ei editering i den nye brevredigeringa, og så bytta til anna prosesspanel og tilbake => Huksa ikkje state og det såg ut som det ikkje var gjort noko redigering

Sidan denne staten ikkje passa så godt inn i mellomlagreFormState, så laga eg ein ny Provider som vedtakspakka eksponerer. Brukar i tillegg denne til å senda med funksjonar for å mellomlagre og hente brev => slepp da propdrilling