### PR TITLE
fjern msw warning om searchparam i requestHandler path

### DIFF
--- a/apps/fp-frontend-app/src/aktoer/AktørIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/aktoer/AktørIndex.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { FagsakStatus, FagsakYtelseType } from '@navikt/fp-kodeverk';
 import { alleKodeverk, withQueryClient } from '@navikt/fp-storybook-utils';
@@ -11,12 +11,11 @@ import type { Aktor, Person } from '@navikt/fp-types';
 import { KjønnkodeEnum } from '@navikt/fp-types';
 import { notEmpty } from '@navikt/fp-utils';
 
-import { initFetchFpsak } from '../../.storybook/testdata/initFetchFpsak';
-import { initFetchFptilbake } from '../../.storybook/testdata/initFetchFptilbake';
+import { initFetchFpsak, initFetchFptilbake } from '../../.storybook/testdata';
 import { FagsakRel, FagsakUrl, initFetchOptions, useFagsakApi, wrapUrl } from '../data/fagsakApi';
 import { AktørIndex } from './AktørIndex';
 
-const getHref = (rel: string) => wrapUrl(notEmpty(initFetchFpsak.links.find(link => link.rel === rel)).href);
+const getHref = (rel: string) => cleanUrl(wrapUrl(notEmpty(initFetchFpsak.links.find(link => link.rel === rel)).href));
 
 const PERSON: Person = {
   navn: 'Espen Utvikler',

--- a/apps/fp-frontend-app/src/app/AppIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/app/AppIndex.stories.tsx
@@ -1,7 +1,7 @@
 import { MemoryRouter } from 'react-router-dom';
 
 import type { Meta, StoryObj } from '@storybook/react';
-import type { JsonBodyType } from 'msw';
+import { cleanUrl, type JsonBodyType } from 'msw';
 import { http, HttpResponse } from 'msw';
 
 import { ApiPollingStatus } from '@navikt/fp-konstanter';
@@ -66,7 +66,7 @@ const ressursMap = {
   [BehandlingRel.FAMILIEHENDELSE]: familiehendelse,
   [BehandlingRel.SAVE_AKSJONSPUNKT]: new HttpResponse(null, {
     status: 202,
-    headers: { location: 'http://www.test.com/api/result' },
+    headers: { location: 'https://www.test.com/api/result' },
   }),
 };
 
@@ -89,26 +89,22 @@ const HANDLERS = [
   http.get(FagsakUrl.INIT_FETCH_FPTILBAKE, () => HttpResponse.json(initFetchFptilbake)),
   http.post(
     BehandlingUrl.BEHANDLING,
-    () => new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/result' } }),
+    () => new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/result' } }),
   ),
-  http.get('http://www.test.com/api/status', () =>
+  http.get('https://www.test.com/api/status', () =>
     HttpResponse.json({
       status: ApiPollingStatus.PENDING,
       pollIntervalMillis: 100000000,
     }),
   ),
-  http.get('http://www.test.com/api/result', () => HttpResponse.json(behandling)),
+  http.get('https://www.test.com/api/result', () => HttpResponse.json(behandling)),
   ...[
     ...initFetchFpsak.links,
     ...initFetchFpsak.sakLinks,
     ...initFetchFptilbake.links,
     ...initFetchFptilbake.sakLinks,
     ...behandling.links,
-  ].map(link => {
-    if (link.type === 'GET') {
-      return http.get(wrapUrl(link.href), getMockResponse(link.rel));
-    } else return http.post(wrapUrl(link.href), getMockResponse(link.rel));
-  }),
+  ].map(link => http.all(cleanUrl(wrapUrl(link.href)), getMockResponse(link.rel))),
 ];
 
 const meta = {

--- a/apps/fp-frontend-app/src/app/components/Home.stories.tsx
+++ b/apps/fp-frontend-app/src/app/components/Home.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { FagsakStatus, FagsakYtelseType } from '@navikt/fp-kodeverk';
 import { alleKodeverk, getIntlDecorator, withQueryClient } from '@navikt/fp-storybook-utils';
@@ -19,7 +19,7 @@ import messages from '../../../i18n/nb_NO.json';
 
 const withIntl = getIntlDecorator(messages);
 
-const getHref = (rel: string) => wrapUrl(notEmpty(initFetchFpsak.links.find(link => link.rel === rel)).href);
+const getHref = (rel: string) => cleanUrl(wrapUrl(notEmpty(initFetchFpsak.links.find(link => link.rel === rel)).href));
 
 const PERSON: Person = {
   navn: 'Espen Utvikler',

--- a/apps/fp-frontend-app/src/behandling/felles/modaler/paVent/BehandlingPaVent.stories.tsx
+++ b/apps/fp-frontend-app/src/behandling/felles/modaler/paVent/BehandlingPaVent.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
   decorators: [withQueryClient],
   parameters: {
     msw: {
-      handlers: [http.post('http://www.test.com' + link.href, () => new HttpResponse(null, { status: 200 }))],
+      handlers: [http.post('https://www.test.com' + link.href, () => new HttpResponse(null, { status: 200 }))],
     },
   },
   args: {

--- a/apps/fp-frontend-app/src/behandlingmenu/BehandlingMenuIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/behandlingmenu/BehandlingMenuIndex.stories.tsx
@@ -2,7 +2,7 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { BehandlingStatus, BehandlingType, FagsakStatus, FagsakYtelseType } from '@navikt/fp-kodeverk';
 import {
@@ -16,8 +16,7 @@ import type { BehandlingAppKontekst, BehandlingOppretting, Fagsak } from '@navik
 import { VergeBehandlingmenyValg } from '@navikt/fp-types';
 import { notEmpty } from '@navikt/fp-utils';
 
-import { initFetchFpsak } from '../../.storybook/testdata/initFetchFpsak';
-import { initFetchFptilbake } from '../../.storybook/testdata/initFetchFptilbake';
+import { initFetchFpsak, initFetchFptilbake } from '../../.storybook/testdata';
 import { FagsakRel, FagsakUrl, initFetchOptions, useFagsakApi, wrapUrl } from '../data/fagsakApi';
 import { FagsakData } from '../fagsak/FagsakData';
 import { BehandlingMenuIndex } from './BehandlingMenuIndex';
@@ -27,13 +26,15 @@ import messages from '../../i18n/nb_NO.json';
 const withIntl = getIntlDecorator(messages);
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ??
-        initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
-        initFetchFptilbake.links.find(link => link.rel === rel) ??
-        initFetchFptilbake.sakLinks.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ??
+          initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
+          initFetchFptilbake.links.find(link => link.rel === rel) ??
+          initFetchFptilbake.sakLinks.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const BEHANDLING_TILLATTE_OPERASJONER = {

--- a/apps/fp-frontend-app/src/behandlingsupport/BehandlingSupportIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/BehandlingSupportIndex.stories.tsx
@@ -2,7 +2,7 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { BehandlingStatus, BehandlingType, FagsakStatus, FagsakYtelseType } from '@navikt/fp-kodeverk';
 import {
@@ -26,13 +26,15 @@ import messages from '../../i18n/nb_NO.json';
 const withIntl = getIntlDecorator(messages);
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ??
-        initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
-        initFetchFptilbake.links.find(link => link.rel === rel) ??
-        initFetchFptilbake.sakLinks.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ??
+          initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
+          initFetchFptilbake.links.find(link => link.rel === rel) ??
+          initFetchFptilbake.sakLinks.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const BEHANDLING_TILLATTE_OPERASJONER = {

--- a/apps/fp-frontend-app/src/behandlingsupport/dokument/DokumentIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/dokument/DokumentIndex.stories.tsx
@@ -2,13 +2,13 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { Kommunikasjonsretning } from '@navikt/fp-kodeverk';
 import { getIntlDecorator, withQueryClient } from '@navikt/fp-storybook-utils';
 import { notEmpty } from '@navikt/fp-utils';
 
-import { initFetchFpsak } from '../../../.storybook/testdata/initFetchFpsak';
+import { initFetchFpsak } from '../../../.storybook/testdata';
 import { FagsakRel, FagsakUrl, initFetchOptions, wrapUrl } from '../../data/fagsakApi';
 import { UtvidEllerMinskKnapp } from '../UtvidEllerMinskKnapp.tsx';
 import { DokumentIndex } from './DokumentIndex';
@@ -17,7 +17,8 @@ import messages from '../../../i18n/nb_NO.json';
 
 const withIntl = getIntlDecorator(messages);
 
-const getHref = (rel: string) => wrapUrl(notEmpty(initFetchFpsak.sakLinks.find(link => link.rel === rel)).href);
+const getHref = (rel: string) =>
+  cleanUrl(wrapUrl(notEmpty(initFetchFpsak.sakLinks.find(link => link.rel === rel)).href));
 
 const meta = {
   title: 'fagsak/DokumentIndex',

--- a/apps/fp-frontend-app/src/behandlingsupport/historikk/HistorikkIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/historikk/HistorikkIndex.stories.tsx
@@ -2,7 +2,7 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import {
   alleKodeverk,
@@ -15,7 +15,7 @@ import { notEmpty } from '@navikt/fp-utils';
 
 import { initFetchFpsak, initFetchFptilbake } from '../../../.storybook/testdata';
 import { FagsakRel, FagsakUrl, initFetchOptions, useFagsakApi, wrapUrl } from '../../data/fagsakApi';
-import { UtvidEllerMinskKnapp } from '../UtvidEllerMinskKnapp.tsx';
+import { UtvidEllerMinskKnapp } from '../UtvidEllerMinskKnapp';
 import { HistorikkIndex } from './HistorikkIndex';
 
 import messages from '../../../i18n/nb_NO.json';
@@ -23,10 +23,12 @@ import messages from '../../../i18n/nb_NO.json';
 const withIntl = getIntlDecorator(messages);
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ?? initFetchFptilbake.links.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ?? initFetchFptilbake.links.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const meta = {

--- a/apps/fp-frontend-app/src/behandlingsupport/melding/MeldingIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/melding/MeldingIndex.stories.tsx
@@ -2,7 +2,7 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { BehandlingStatus, BehandlingType, DokumentMalType, FagsakStatus, FagsakYtelseType } from '@navikt/fp-kodeverk';
 import {
@@ -27,10 +27,12 @@ import messages from '../../../i18n/nb_NO.json';
 const withIntl = getIntlDecorator(messages);
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ?? initFetchFptilbake.links.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ?? initFetchFptilbake.links.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const MALER = [

--- a/apps/fp-frontend-app/src/behandlingsupport/totrinnskontroll/TotrinnskontrollIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/behandlingsupport/totrinnskontroll/TotrinnskontrollIndex.stories.tsx
@@ -2,7 +2,7 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import {
   AksjonspunktKode,
@@ -38,12 +38,14 @@ import messages from '../../../i18n/nb_NO.json';
 const withIntl = getIntlDecorator(messages);
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ??
-        initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
-        initFetchFptilbake.links.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ??
+          initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
+          initFetchFptilbake.links.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const createAksjonspunkt = (aksjonspunktKode: string) =>

--- a/apps/fp-frontend-app/src/data/behandlingApi.ts
+++ b/apps/fp-frontend-app/src/data/behandlingApi.ts
@@ -106,7 +106,7 @@ const kyExtended = ky.extend({
 
 //MÅ være en gyldig URL for at KY skal fungere i test
 const isTest = import.meta.env.MODE === 'test';
-export const wrapUrl = (url: string) => (isTest ? `http://www.test.com${url}` : url);
+export const wrapUrl = (url: string) => (isTest ? `https://www.test.com${url}` : url);
 
 const getUrlFromRel = (rel: keyof typeof BehandlingRel, links: ApiLink[]): string => {
   const link = links.find(l => l.rel === BehandlingRel[rel]);

--- a/apps/fp-frontend-app/src/data/fagsakApi.ts
+++ b/apps/fp-frontend-app/src/data/fagsakApi.ts
@@ -72,7 +72,7 @@ const kyExtended = ky.extend({
 
 //MÅ være en gyldig URL for at KY skal fungere i test
 const isTest = import.meta.env.MODE === 'test';
-export const wrapUrl = (url: string): string => (isTest ? `http://www.test.com${url}` : url);
+export const wrapUrl = (url: string): string => (isTest ? `https://www.test.com${url}` : url);
 
 const getUrlFromRel = (rel: keyof typeof FagsakRel, links: ApiLink[] = []): string => {
   const link = links.find(l => l.rel === FagsakRel[rel]);

--- a/apps/fp-frontend-app/src/fagsak/FagsakIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/fagsak/FagsakIndex.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 import type { DecoratorFunction } from 'storybook/internal/types';
 
 import { BehandlingStatus, BehandlingType, FagsakStatus, FagsakYtelseType } from '@navikt/fp-kodeverk';
@@ -36,13 +36,15 @@ const withRequestPendingProvider: DecoratorFunction<ReactRenderer> = Story => {
 };
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ??
-        initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
-        initFetchFptilbake.links.find(link => link.rel === rel) ??
-        initFetchFptilbake.sakLinks.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ??
+          initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
+          initFetchFptilbake.links.find(link => link.rel === rel) ??
+          initFetchFptilbake.sakLinks.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const BEHANDLING_TILLATTE_OPERASJONER = {

--- a/apps/fp-frontend-app/src/fagsakSearch/FagsakSearchIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/fagsakSearch/FagsakSearchIndex.stories.tsx
@@ -1,18 +1,18 @@
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import { alleKodeverk, withQueryClient, withRouter } from '@navikt/fp-storybook-utils';
 import type { FagsakEnkel } from '@navikt/fp-types';
 import { KjønnkodeEnum } from '@navikt/fp-types';
 import { notEmpty } from '@navikt/fp-utils';
 
-import { initFetchFpsak } from '../../.storybook/testdata/initFetchFpsak';
+import { initFetchFpsak } from '../../.storybook/testdata';
 import { FagsakRel, FagsakUrl, initFetchOptions, useFagsakApi, wrapUrl } from '../data/fagsakApi';
 import { FagsakSearchIndex } from './FagsakSearchIndex';
 
-const getHref = (rel: string) => wrapUrl(notEmpty(initFetchFpsak.links.find(link => link.rel === rel)).href);
+const getHref = (rel: string) => cleanUrl(wrapUrl(notEmpty(initFetchFpsak.links.find(link => link.rel === rel)).href));
 
 const FAGSAK_1 = {
   saksnummer: '12345',

--- a/apps/fp-frontend-app/src/fagsakprofile/FagsakProfileIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/fagsakprofile/FagsakProfileIndex.stories.tsx
@@ -2,7 +2,7 @@ import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import {
   AksjonspunktKode,
@@ -34,13 +34,15 @@ import messages from '../../i18n/nb_NO.json';
 const withIntl = getIntlDecorator(messages);
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ??
-        initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
-        initFetchFptilbake.links.find(link => link.rel === rel) ??
-        initFetchFptilbake.sakLinks.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ??
+          initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
+          initFetchFptilbake.links.find(link => link.rel === rel) ??
+          initFetchFptilbake.sakLinks.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const BEHANDLING_TILLATTE_OPERASJONER = {

--- a/apps/fp-frontend-app/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react';
 import type { DecoratorFunction } from '@storybook/types';
 import { useQuery } from '@tanstack/react-query';
-import { http, HttpResponse } from 'msw';
+import { cleanUrl, http, HttpResponse } from 'msw';
 
 import {
   AksjonspunktKode,
@@ -44,13 +44,15 @@ const withRequestPendingProvider: DecoratorFunction<ReactRenderer> = Story => {
 };
 
 const getHref = (rel: string) =>
-  wrapUrl(
-    notEmpty(
-      initFetchFpsak.links.find(link => link.rel === rel) ??
-        initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
-        initFetchFptilbake.links.find(link => link.rel === rel) ??
-        initFetchFptilbake.sakLinks.find(link => link.rel === rel),
-    ).href,
+  cleanUrl(
+    wrapUrl(
+      notEmpty(
+        initFetchFpsak.links.find(link => link.rel === rel) ??
+          initFetchFpsak.sakLinks.find(link => link.rel === rel) ??
+          initFetchFptilbake.links.find(link => link.rel === rel) ??
+          initFetchFptilbake.sakLinks.find(link => link.rel === rel),
+      ).href,
+    ),
   );
 
 const BEHANDLING_TILLATTE_OPERASJONER = {

--- a/packages/journalforing/src/data/fpFordelApi.ts
+++ b/packages/journalforing/src/data/fpFordelApi.ts
@@ -24,7 +24,7 @@ const kyExtended = ky.extend({
 
 //MÅ være en gyldig URL for at KY skal fungere i test
 const isTest = import.meta.env.MODE === 'test';
-const wrapUrl = (url: string) => (isTest ? `http://www.test.com${url}` : url);
+const wrapUrl = (url: string) => (isTest ? `https://www.test.com${url}` : url);
 
 export const FpFordelUrl = {
   ALLE_JOURNAL_OPPGAVER: wrapUrl('/fpfordel/api/journalfoering/oppgaver'),

--- a/packages/los/avdelingsleder/src/data/fplosAvdelingslederApi.ts
+++ b/packages/los/avdelingsleder/src/data/fplosAvdelingslederApi.ts
@@ -29,7 +29,7 @@ const kyExtended = ky.extend({
 
 //MÅ være en gyldig URL for at KY skal fungere i test
 const isTest = import.meta.env.MODE === 'test';
-const wrapUrl = (url: string) => (isTest ? `http://www.test.com${url}` : url);
+const wrapUrl = (url: string) => (isTest ? `https://www.test.com${url}` : url);
 
 export const LosUrl = {
   KODEVERK_LOS: wrapUrl('/fplos/api/kodeverk'),

--- a/packages/los/saksbehandler/src/SaksbehandlerIndex.stories.tsx
+++ b/packages/los/saksbehandler/src/SaksbehandlerIndex.stories.tsx
@@ -229,16 +229,16 @@ const meta = {
         http.get(LosUrl.OPPGAVER_TIL_BEHANDLING, t => {
           const doPolling = t.request.url.includes('oppgaveIder');
           return doPolling
-            ? new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/status' } })
-            : new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/result' } });
+            ? new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/status' } })
+            : new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/result' } });
         }),
-        http.get('http://www.test.com/api/status', () =>
+        http.get('https://www.test.com/api/status', () =>
           HttpResponse.json({
             status: ApiPollingStatus.PENDING,
             pollIntervalMillis: 100000000,
           }),
         ),
-        http.get('http://www.test.com/api/result', () => HttpResponse.json(OPPGAVER_TIL_BEHANDLING)),
+        http.get('https://www.test.com/api/result', () => HttpResponse.json(OPPGAVER_TIL_BEHANDLING)),
         http.get(LosUrl.HENT_RESERVASJONSSTATUS, () => new HttpResponse(null, { status: 200 })),
         http.get(LosUrl.BEHANDLEDE_OPPGAVER, () => HttpResponse.json(BEHANDLEDE_OPPGAVER)),
         http.get(LosUrl.HENT_NYE_OG_FERDIGSTILTE_OPPGAVER, () => HttpResponse.json(NYE_OG_FERDIGSTILTE_OPPGAVER)),

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabell/OppgaverTabell.spec.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabell/OppgaverTabell.spec.tsx
@@ -6,7 +6,7 @@ import * as stories from './OppgaverTabell.stories';
 
 const { Default, TomOppgaveTabell } = composeStories(stories);
 
-describe('<OppgaverTabell>', () => {
+describe('OppgaverTabell', () => {
   it('skal vise tabell med behandlinger', async () => {
     await applyRequestHandlers(Default.parameters['msw']);
     await Default.run();

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabell/OppgaverTabell.stories.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabell/OppgaverTabell.stories.tsx
@@ -141,16 +141,16 @@ export const Default: Story = {
         http.get(LosUrl.OPPGAVER_TIL_BEHANDLING, t => {
           const doPolling = t.request.url.includes('oppgaveIder');
           return doPolling
-            ? new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/status' } })
-            : new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/result' } });
+            ? new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/status' } })
+            : new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/result' } });
         }),
-        http.get('http://www.test.com/api/status', () =>
+        http.get('https://www.test.com/api/status', () =>
           HttpResponse.json({
             status: ApiPollingStatus.PENDING,
             pollIntervalMillis: 100000000,
           }),
         ),
-        http.get('http://www.test.com/api/result', () => HttpResponse.json(OPPGAVER_TIL_BEHANDLING)),
+        http.get('https://www.test.com/api/result', () => HttpResponse.json(OPPGAVER_TIL_BEHANDLING)),
       ],
     },
   },
@@ -169,16 +169,16 @@ export const TomOppgaveTabell: Story = {
         http.get(LosUrl.OPPGAVER_TIL_BEHANDLING, t => {
           const doPolling = t.request.url.includes('oppgaveIder');
           return doPolling
-            ? new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/status' } })
-            : new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/result' } });
+            ? new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/status' } })
+            : new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/result' } });
         }),
-        http.get('http://www.test.com/api/status', () =>
+        http.get('https://www.test.com/api/status', () =>
           HttpResponse.json({
             status: ApiPollingStatus.PENDING,
             pollIntervalMillis: 100000000,
           }),
         ),
-        http.get('http://www.test.com/api/result', () => HttpResponse.json([])),
+        http.get('https://www.test.com/api/result', () => HttpResponse.json([])),
       ],
     },
   },
@@ -212,16 +212,16 @@ export const VisPagineringNårMerEnn15Oppgaver: Story = {
         http.get(LosUrl.OPPGAVER_TIL_BEHANDLING, t => {
           const doPolling = t.request.url.includes('oppgaveIder');
           return doPolling
-            ? new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/status' } })
-            : new HttpResponse(null, { status: 202, headers: { location: 'http://www.test.com/api/result' } });
+            ? new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/status' } })
+            : new HttpResponse(null, { status: 202, headers: { location: 'https://www.test.com/api/result' } });
         }),
-        http.get('http://www.test.com/api/status', () =>
+        http.get('https://www.test.com/api/status', () =>
           HttpResponse.json({
             status: ApiPollingStatus.PENDING,
             pollIntervalMillis: 100000000,
           }),
         ),
-        http.get('http://www.test.com/api/result', () => HttpResponse.json(OPPGAVER_TIL_BEHANDLING)),
+        http.get('https://www.test.com/api/result', () => HttpResponse.json(OPPGAVER_TIL_BEHANDLING)),
       ],
     },
   },

--- a/packages/los/saksbehandler/src/data/fplosSaksbehandlerApi.ts
+++ b/packages/los/saksbehandler/src/data/fplosSaksbehandlerApi.ts
@@ -24,7 +24,7 @@ const kyExtended = ky.extend({
 
 //MÅ være en gyldig URL for at KY skal fungere i test
 const isTest = import.meta.env.MODE === 'test';
-const wrapUrl = (url: string) => (isTest ? `http://www.test.com${url}` : url);
+const wrapUrl = (url: string) => (isTest ? `https://www.test.com${url}` : url);
 
 export const LosUrl = {
   KODEVERK_LOS: wrapUrl('fplos/api/kodeverk'),


### PR DESCRIPTION
* `cleanUrl` fjerner search params fra en lenke. for å fjerne warning output fra tester
* `lagt til https i test urler pga. feil i storybook på github pages:
```
Mixed Content: The page at 'https://navikt.github.io/fp-frontend/@navikt/fp-frontend-app/index.html?path=/story/appindex--default' was loaded over HTTPS, but requested an insecure resource 'http://www.test.com/api/result'. This request has been blocked; the content must be served over HTTPS.
```