### PR TITLE
fiks flexgrow på FaktaBox slik at det blir lik bredde på hvert element

### DIFF
--- a/packages/fakta/felles/src/components/FaktaBox.tsx
+++ b/packages/fakta/felles/src/components/FaktaBox.tsx
@@ -18,8 +18,16 @@ interface FaktaBoxProps {
 
 export const FaktaBox = ({ label, value, kilde }: FaktaBoxProps) => {
   return (
-    <Box background="bg-subtle" flexGrow="1" paddingBlock="2" paddingInline="4" borderRadius="medium">
-      <VStack gap="6">
+    <Box
+      background="bg-subtle"
+      flexBasis="0%"
+      flexGrow="1"
+      borderRadius="medium"
+      paddingBlock="2"
+      paddingInline="4"
+      aria-label={typeof label === 'string' ? label : undefined}
+    >
+      <VStack gap="6" flexGrow="1" height="100%" justify="space-between">
         <div>
           <Label size="small">{label}</Label>
           <BodyShort size="large">{value}</BodyShort>


### PR DESCRIPTION
Løser problem med at flexgrow kun skalerer i forhold til grunnstørrelsen til elementet.  `flexBasis:0%` gjør at den initielle størrelsen er 0 før flex grow gjør at den vokser.

På bilde under ser man at de to boksene på første rad ikke er nøyaktig 50/50 slik de skal være.
![Screenshot 2025-06-04 at 15 17 59](https://github.com/user-attachments/assets/f6eedb75-f3c4-41b7-8432-6378029f789c)

jeg la også til aria label for at vi kan bruke den til testing
