### PR TITLE
fiks feil hvor noen av apps-testene ikke kjører i node v22.12.0

### DIFF
--- a/apps/fp-frontend-app/package.json
+++ b/apps/fp-frontend-app/package.json
@@ -128,7 +128,6 @@
     "react-intl": "7.1.11",
     "react-modal": "3.16.3",
     "react-responsive": "10.0.1",
-    "react-router": "7.7.1",
     "react-router-dom": "7.7.1"
   },
   "devDependencies": {

--- a/apps/fp-frontend-app/src/aktoer/AktørIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/aktoer/AktørIndex.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';

--- a/apps/fp-frontend-app/src/app/components/Home.stories.tsx
+++ b/apps/fp-frontend-app/src/app/components/Home.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';

--- a/apps/fp-frontend-app/src/behandling/BehandlingIndex.tsx
+++ b/apps/fp-frontend-app/src/behandling/BehandlingIndex.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useState } from 'react';
-import { type NavigateFunction, useLocation, useNavigate } from 'react-router';
+import { type NavigateFunction, useLocation, useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { replaceNorwegianCharacters } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/BehandlingPanelerIndex.tsx
+++ b/apps/fp-frontend-app/src/behandling/BehandlingPanelerIndex.tsx
@@ -1,5 +1,5 @@
 import { Suspense, use } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { parseQueryString } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/VarselProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/VarselProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { use } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/VedtakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/fellesPaneler/prosess/VedtakProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { use, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/innsyn/prosessPaneler/InnsynVedtakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/innsyn/prosessPaneler/InnsynVedtakProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { use, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/klage/prosessPaneler/KlageresultatProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/klage/prosessPaneler/KlageresultatProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { use, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/klage/prosessPaneler/VurderingFellesProsessStegInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/klage/prosessPaneler/VurderingFellesProsessStegInitPanel.tsx
@@ -1,5 +1,5 @@
 import { use, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/TilbakekrevingPaneler.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/TilbakekrevingPaneler.tsx
@@ -1,5 +1,5 @@
 import { use } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
+++ b/apps/fp-frontend-app/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
@@ -1,6 +1,6 @@
 import { type ComponentProps, use, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 import {
   type ForhandsvisData,

--- a/apps/fp-frontend-app/src/fagsak/FagsakIndex.stories.tsx
+++ b/apps/fp-frontend-app/src/fagsak/FagsakIndex.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,7 +2423,6 @@ __metadata:
     react-intl: 7.1.11
     react-modal: 3.16.3
     react-responsive: 10.0.1
-    react-router: 7.7.1
     react-router-dom: 7.7.1
     storybook: 9.0.18
     stylelint: 16.22.0


### PR DESCRIPTION
'Node.js 22.12 introduced changes related to ESM resolution and stricter package loading. If you're loading react-router-dom or parts of your app incorrectly — especially in test or SSR environments — it could behave inconsistently.'