### PR TITLE
TFP-6401 fjerne ankomstdato fra papirsøknad

### DIFF
--- a/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
+++ b/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
@@ -72,7 +72,6 @@
   "Registrering.Adopsjon.Nei": "Nei",
   "Registrering.Adopsjon.DatoForOvertakelsenStebarn": "Dato for omsorgsovertakelse/stebarnsadopsjon",
   "Registrering.Adopsjon.DatoForOvertakelsen": "Dato for omsorgsovertakelsen",
-  "Registrering.Adopsjon.Ankomstdato": "Ankomstdato",
   "Registrering.Adopsjon.AntallBarn": "Antall barn",
 
   "Registrering.RegistreringOpphold.AngiOpphold": "Oppgi hvilket land og i hvilken periode",

--- a/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/OmsorgOgAdopsjonPapirsoknadIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/OmsorgOgAdopsjonPapirsoknadIndex.spec.tsx
@@ -106,10 +106,6 @@ describe('OmsorgOgAdopsjonPapirsoknadIndex', () => {
     await userEvent.type(datoInput, '30.05.2022');
     fireEvent.blur(datoInput);
 
-    const ankomstdatoInput = screen.getByLabelText('Ankomstdato');
-    await userEvent.type(ankomstdatoInput, '22.05.2022');
-    fireEvent.blur(ankomstdatoInput);
-
     const antallBarnInput = screen.getByLabelText('Antall barn');
     await userEvent.type(antallBarnInput, '2');
 
@@ -130,7 +126,6 @@ describe('OmsorgOgAdopsjonPapirsoknadIndex', () => {
     await waitFor(() => expect(lagre).toHaveBeenCalledOnce());
     expect(lagre).toHaveBeenCalledWith({
       omsorg: {
-        ankomstdato: '2022-05-22',
         antallBarn: 2,
         foedselsDato: ['2022-05-27', '2022-05-26'],
         omsorgsovertakelsesdato: '2022-05-30',

--- a/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
@@ -121,16 +121,6 @@ export const OmsorgOgAdopsjonPanel = ({
           validate={familieHendelseType === FamilieHendelseType.ADOPSJON ? [required, hasValidDate] : [hasValidDate]}
         />
         <HStack gap="space-16">
-          {familieHendelseType === FamilieHendelseType.ADOPSJON && (
-            <RhfDatepicker
-              //@ts-expect-error Her er det noko rart med typane
-              name={`${OMSORG_NAME_PREFIX}.ankomstdato`}
-              control={control}
-              label={formatMessage({ id: 'Registrering.Adopsjon.Ankomstdato' })}
-              isReadOnly={readOnly}
-              validate={[hasValidDate]}
-            />
-          )}
           <RhfTextField
             name={`${OMSORG_NAME_PREFIX}.antallBarn`}
             control={control}


### PR DESCRIPTION
Ankomstdato trengs ikke lenger.  Det så ikke ut som ankomstdato ble mappet til det som lagres til backend.
