### PR TITLE
erstatt bruk av utils fra render med screen

### DIFF
--- a/apps/fp-avdelingsleder/src/saksbehandlere/LeggTilSaksbehandlerForm.spec.tsx
+++ b/apps/fp-avdelingsleder/src/saksbehandlere/LeggTilSaksbehandlerForm.spec.tsx
@@ -10,11 +10,11 @@ const { Default, SaksbehandlerFinnesIkke } = composeStories(stories);
 describe('LeggTilSaksbehandlerForm', () => {
   it('skal vise at oppgitt brukerident ikke finnes', async () => {
     applyRequestHandlers(SaksbehandlerFinnesIkke.parameters['msw'] as MswParameters['msw']);
-    const utils = render(<SaksbehandlerFinnesIkke />);
+    render(<SaksbehandlerFinnesIkke />);
 
     expect(await screen.findByText('Legg til saksbehandler')).toBeInTheDocument();
 
-    const brukerIdentInput = utils.getByLabelText('Brukerident');
+    const brukerIdentInput = screen.getByLabelText('Brukerident');
     await userEvent.type(brukerIdentInput, 'TESTIDENT');
 
     expect(await screen.findByText('Søk')).toBeInTheDocument();
@@ -28,11 +28,11 @@ describe('LeggTilSaksbehandlerForm', () => {
 
   it('skal finne brukerident og så legge saksbehandler til listen', async () => {
     applyRequestHandlers(Default.parameters['msw'] as MswParameters['msw']);
-    const utils = render(<Default />);
+    render(<Default />);
 
     expect(await screen.findByText('Legg til saksbehandler')).toBeInTheDocument();
 
-    const brukerIdentInput = utils.getByLabelText('Brukerident');
+    const brukerIdentInput = screen.getByLabelText('Brukerident');
     await userEvent.type(brukerIdentInput, 'TESTIDENT');
 
     expect(await screen.findByText('Søk')).toBeInTheDocument();

--- a/apps/fp-frontend/src/fagsakSearch/FagsakSearchIndex.spec.tsx
+++ b/apps/fp-frontend/src/fagsakSearch/FagsakSearchIndex.spec.tsx
@@ -10,11 +10,11 @@ const { Default } = composeStories(stories);
 describe('FagsakSearchIndex', () => {
   it('skal søke med saksnummer og få opp treff i liste', async () => {
     applyRequestHandlers(Default.parameters['msw'] as MswParameters['msw']);
-    const utils = render(<Default />);
+    render(<Default />);
 
     expect(await screen.findByText('Søk på sak eller person')).toBeInTheDocument();
 
-    const nrInput = utils.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
+    const nrInput = screen.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
     await userEvent.type(nrInput, '123');
 
     expect(await screen.findByText('Søk')).toBeEnabled();

--- a/packages/fakta/adopsjon/src/AdopsjonFaktaIndex.spec.tsx
+++ b/packages/fakta/adopsjon/src/AdopsjonFaktaIndex.spec.tsx
@@ -15,7 +15,7 @@ describe('AdopsjonFaktaIndex', () => {
   it('skal kontrollere opplysninger fra adopsjonsdokumentasjonen og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktForAdopsjonsvilkåret submitCallback={lagre} />);
+    render(<AksjonspunktForAdopsjonsvilkåret submitCallback={lagre} />);
 
     expect(await screen.findByText('Kontroller mot opplysningene fra adopsjonsdokumentasjonen')).toBeInTheDocument();
     expect(screen.getByText('Adopsjonsopplysninger fra søknad')).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe('AdopsjonFaktaIndex', () => {
 
     expect(screen.getByText('Antall barn som fyller vilkåret')).toBeInTheDocument();
 
-    const begrunnValgInput = utils.getByLabelText('Begrunn endringene');
+    const begrunnValgInput = screen.getByLabelText('Begrunn endringene');
     await userEvent.type(begrunnValgInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -51,7 +51,7 @@ describe('AdopsjonFaktaIndex', () => {
   it('skal kontrollere opplysninger fra adopsjonsdokumentasjonen og mann adopterer og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktForOmSøkerErMannSomAdoptererAlene submitCallback={lagre} />);
+    render(<AksjonspunktForOmSøkerErMannSomAdoptererAlene submitCallback={lagre} />);
 
     expect(await screen.findByText('Kontroller mot opplysningene fra adopsjonsdokumentasjonen')).toBeInTheDocument();
     expect(screen.getByText('Vurder om mann adopterer alene')).toBeInTheDocument();
@@ -62,7 +62,7 @@ describe('AdopsjonFaktaIndex', () => {
     expect(screen.getByText('Mann adopterer')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Ja, adopterer alene'));
 
-    const begrunnValgInput = utils.getByLabelText('Begrunn endringene');
+    const begrunnValgInput = screen.getByLabelText('Begrunn endringene');
     await userEvent.type(begrunnValgInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -89,7 +89,7 @@ describe('AdopsjonFaktaIndex', () => {
   it('skal kontrollere opplysninger fra adopsjonsdokumentasjonen og ektefelles barn og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktForOmAdopsjonGjelderEktefellesBarn submitCallback={lagre} />);
+    render(<AksjonspunktForOmAdopsjonGjelderEktefellesBarn submitCallback={lagre} />);
 
     expect(await screen.findByText('Kontroller mot opplysningene fra adopsjonsdokumentasjonen')).toBeInTheDocument();
     expect(screen.getByText('Vurder om det er ektefelles/samboers barn som adopteres')).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe('AdopsjonFaktaIndex', () => {
     expect(screen.getByText('Er det ektefelles/samboers barn som adopteres?')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Nei, det er ikke ektefelles/samboers barn'));
 
-    const begrunnValgInput = utils.getByLabelText('Begrunn endringene');
+    const begrunnValgInput = screen.getByLabelText('Begrunn endringene');
     await userEvent.type(begrunnValgInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.spec.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.spec.tsx
@@ -36,9 +36,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const settPåVent = vi.fn(() => Promise.resolve());
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(
-      <InnhentInntektsmelding settBehandlingPåVentCallback={settPåVent} lagreVurdering={lagreVurdering} />,
-    );
+    render(<InnhentInntektsmelding settBehandlingPåVentCallback={settPåVent} lagreVurdering={lagreVurdering} />);
 
     expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
     expect(screen.getByText('Skjæringstidspunkt for opptjening: 10.11.2021')).toBeInTheDocument();
@@ -58,7 +56,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
       screen.getByText('Jeg tar kontakt med søker eller arbeidsgiver for å innhente inntektsmelding'),
     );
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -86,15 +84,13 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const bekrefteAksjonspunkt = vi.fn(() => Promise.resolve());
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(
-      <InnhentInntektsmelding submitCallback={bekrefteAksjonspunkt} lagreVurdering={lagreVurdering} />,
-    );
+    render(<InnhentInntektsmelding submitCallback={bekrefteAksjonspunkt} lagreVurdering={lagreVurdering} />);
 
     expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Gå videre uten inntektsmelding'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -143,9 +139,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const settPåVent = vi.fn(() => Promise.resolve());
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(
-      <AvklarManglendeArbeidsforhold settBehandlingPåVentCallback={settPåVent} lagreVurdering={lagreVurdering} />,
-    );
+    render(<AvklarManglendeArbeidsforhold settBehandlingPåVentCallback={settPåVent} lagreVurdering={lagreVurdering} />);
 
     expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
     expect(screen.getByText('Skjæringstidspunkt for opptjening: 10.11.2021')).toBeInTheDocument();
@@ -168,7 +162,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Jeg kontakter arbeidsgiver'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -197,7 +191,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
     const settPåVent = vi.fn(() => Promise.resolve());
 
-    const utils = render(
+    render(
       <InnhentInntektsmelding
         submitCallback={bekrefteAksjonspunkt}
         lagreVurdering={lagreVurdering}
@@ -209,7 +203,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Send påminnelse via Min side - arbeidsgiver på nav.no'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -228,15 +222,13 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const bekrefteAksjonspunkt = vi.fn(() => Promise.resolve());
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(
-      <AvklarManglendeArbeidsforhold submitCallback={bekrefteAksjonspunkt} lagreVurdering={lagreVurdering} />,
-    );
+    render(<AvklarManglendeArbeidsforhold submitCallback={bekrefteAksjonspunkt} lagreVurdering={lagreVurdering} />);
 
     expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Se bort fra inntektsmeldingen'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -262,7 +254,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const bekrefteAksjonspunkt = vi.fn(() => Promise.resolve());
     const registrerArbeidsforhold = vi.fn(() => Promise.resolve());
 
-    const utils = render(
+    render(
       <AvklarManglendeArbeidsforhold
         submitCallback={bekrefteAksjonspunkt}
         registrerArbeidsforhold={registrerArbeidsforhold}
@@ -281,8 +273,8 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     await userEvent.type(periodeTil, '01.02.2022');
     fireEvent.blur(periodeTil);
 
-    await userEvent.type(utils.getByLabelText('Stillingsprosent'), '100');
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Stillingsprosent'), '100');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -370,7 +362,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const bekrefteAksjonspunkt = vi.fn(() => Promise.resolve());
     const registrerArbeidsforhold = vi.fn(() => Promise.resolve());
 
-    const utils = render(
+    render(
       <SkalKunneLeggeTilNyttArbeidsforholdNårIngenArbeidsforholdEllerInntektsmeldingerFinnesOgEnHarReåpnetOgEnErOverstyrer
         submitCallback={bekrefteAksjonspunkt}
         registrerArbeidsforhold={registrerArbeidsforhold}
@@ -391,7 +383,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Legg til arbeidsforhold'));
 
-    await userEvent.type(utils.getByLabelText('Navn på arbeidsgiver'), 'Telenor');
+    await userEvent.type(screen.getByLabelText('Navn på arbeidsgiver'), 'Telenor');
 
     const periodeFra = screen.getByText('Periode fra');
     await userEvent.type(periodeFra, '01.02.2020');
@@ -401,8 +393,8 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     await userEvent.type(periodeTil, '01.02.2022');
     fireEvent.blur(periodeTil);
 
-    await userEvent.type(utils.getByLabelText('Stillingsprosent'), '100');
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Stillingsprosent'), '100');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Lagre'));
 
@@ -569,7 +561,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const settPåVent = vi.fn(() => Promise.resolve());
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(
+    render(
       <FlereArbeidsforholdOgInntekstemeldinger
         settBehandlingPåVentCallback={settPåVent}
         lagreVurdering={lagreVurdering}
@@ -582,7 +574,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
       screen.getByText('Jeg tar kontakt med søker eller arbeidsgiver for å innhente inntektsmelding'),
     );
 
-    await userEvent.type(utils.getAllByLabelText('Begrunn valget')[0]!, 'Dette er en begrunnelse');
+    await userEvent.type(screen.getAllByLabelText('Begrunn valget')[0]!, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getAllByText('Lagre')[0]!);
 
@@ -598,7 +590,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Jeg kontakter arbeidsgiver'));
 
-    await userEvent.type(utils.getAllByLabelText('Begrunn valget')[1]!, 'Dette er begrunnelse nr 2');
+    await userEvent.type(screen.getAllByLabelText('Begrunn valget')[1]!, 'Dette er begrunnelse nr 2');
 
     await userEvent.click(screen.getAllByText('Lagre')[1]!);
 
@@ -626,7 +618,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     const settPåVent = vi.fn(() => Promise.resolve());
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(
+    render(
       <ArbeidsforholdMedSammeOrgNrDerEnManglerInntektsmeldingMenIkkeDetAndre
         settBehandlingPåVentCallback={settPåVent}
         lagreVurdering={lagreVurdering}
@@ -658,7 +650,7 @@ describe('ArbeidOgInntektFaktaIndex', () => {
       screen.getByText('Jeg tar kontakt med søker eller arbeidsgiver for å innhente inntektsmelding'),
     );
 
-    await userEvent.type(utils.getByLabelText('Kommentar'), 'Dette er en kommentar');
+    await userEvent.type(screen.getByLabelText('Kommentar'), 'Dette er en kommentar');
 
     await userEvent.click(screen.getByText('Lagre'));
 

--- a/packages/fakta/arbeid-og-inntekt/src/components/felles/InntektsmeldingerPanel.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/felles/InntektsmeldingerPanel.tsx
@@ -148,7 +148,7 @@ export const InntektsmeldingerPanel = ({ saksnummer, alleKodeverk, radData }: Pr
                             const status = info[a.internArbeidsforholdId];
                             return {
                               ...info,
-                               
+
                               [a.internArbeidsforholdId]: status === undefined || status === false,
                             };
                           });

--- a/packages/fakta/besteberegning/src/BesteberegningFaktaIndex.spec.tsx
+++ b/packages/fakta/besteberegning/src/BesteberegningFaktaIndex.spec.tsx
@@ -30,7 +30,7 @@ describe('BesteberegningFaktaIndex', () => {
   it('skal bekrefte aksjonspunkt for vurder besteberegning', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<BesteberegningMedAvvik submitCallback={lagre} />);
+    render(<BesteberegningMedAvvik submitCallback={lagre} />);
 
     expect(await screen.findByText('Bekreft og fortsett')).toBeInTheDocument();
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
@@ -43,7 +43,7 @@ describe('BesteberegningFaktaIndex', () => {
 
     expect(screen.getByText('Beregningen er riktig, fortsett behandlingen.')).toBeEnabled();
     await userEvent.click(screen.getByRole('checkbox'));
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Min begrunnelse for vurdering av besteberegning');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Min begrunnelse for vurdering av besteberegning');
 
     expect(screen.getByText('Bekreft og fortsett')).toBeEnabled();
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
+++ b/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
@@ -6,7 +6,7 @@ import * as stories from './InntektsmeldingFaktaIndex.stories';
 
 const { InntektsmeldingDefault } = composeStories(stories);
 
-describe('InntektsmeldingDefault', () => {
+describe('InntektsmeldingFaktaIndex', () => {
   // eslint-disable-next-line vitest/expect-expect -- assertes i hjelpefunksjon
   it('Skal kunne sortere tabellen', async () => {
     render(<InntektsmeldingDefault />);

--- a/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
@@ -18,7 +18,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   it('skal velge å ha aleneomsorg for barnet', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<HarAksjonspunktForAvklarAleneomsorg submitCallback={lagreVurdering} />);
+    render(<HarAksjonspunktForAvklarAleneomsorg submitCallback={lagreVurdering} />);
 
     expect(screen.queryByText('Rettighetstype')).not.toBeInTheDocument();
     expect(await screen.findByText('Vurder om søker har aleneomsorg for barnet.')).toBeInTheDocument();
@@ -37,7 +37,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
 
     await userEvent.click(screen.getByLabelText('Søker har aleneomsorg for barnet'));
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -54,7 +54,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   it('skal velge å ikke ha aleneomsorg for barnet', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<HarAksjonspunktForAvklarAleneomsorg submitCallback={lagreVurdering} />);
+    render(<HarAksjonspunktForAvklarAleneomsorg submitCallback={lagreVurdering} />);
 
     expect(screen.queryByText('Rettighetstype')).not.toBeInTheDocument();
 
@@ -67,7 +67,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
     const jaElements = screen.getAllByText('Ja');
     await userEvent.click(jaElements.at(-1)!);
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -93,7 +93,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   it('skal vurdere at den andre forelderen har rett til foreldrepenger', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<HarAksjonspunktForAvklarAnnenForelderRett submitCallback={lagreVurdering} />);
+    render(<HarAksjonspunktForAvklarAnnenForelderRett submitCallback={lagreVurdering} />);
 
     expect(await screen.findByText('Vurder om den andre forelderen har rett til foreldrepenger.')).toBeInTheDocument();
     expect(screen.queryByText('Rettighetstype')).not.toBeInTheDocument();
@@ -102,7 +102,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
     const jaElements = screen.getAllByText('Ja');
     await userEvent.click(jaElements.at(-1)!);
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -118,7 +118,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   it('skal vurdere at den andre forelderen ikke har rett til foreldrepenger', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<HarAksjonspunktForAvklarAnnenForelderRett submitCallback={lagreVurdering} />);
+    render(<HarAksjonspunktForAvklarAnnenForelderRett submitCallback={lagreVurdering} />);
 
     expect(await screen.findByText('Vurder om den andre forelderen har rett til foreldrepenger.')).toBeInTheDocument();
     expect(screen.queryByText('Rettighetstype')).not.toBeInTheDocument();
@@ -134,7 +134,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
     expect(await screen.findByText('Mottar annen forelder uføretrygd, jf. § 14-14 tredje ledd?')).toBeInTheDocument();
     await userEvent.click(screen.getAllByText('Ja').at(-1)!);
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -219,12 +219,12 @@ describe('OmsorgOgRettFaktaIndex', () => {
   it('skal kunne ovestyre', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<KanOverstyreMor submitCallback={lagreVurdering} />);
+    render(<KanOverstyreMor submitCallback={lagreVurdering} />);
 
     await userEvent.click(screen.getByTitle('Overstyr'));
-    await userEvent.selectOptions(utils.getByLabelText('Rettighetstype'), 'BEGGE_RETT');
+    await userEvent.selectOptions(screen.getByLabelText('Rettighetstype'), 'BEGGE_RETT');
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/fakta/omsorg/src/OmsorgFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorg/src/OmsorgFaktaIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('OmsorgFaktaIndex', () => {
   it('skal velge at søker har omsorg for barnet', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<ÅpentAksjonspunktForKontrollAvOmBrukerHarOmsorg submitCallback={lagreVurdering} />);
+    render(<ÅpentAksjonspunktForKontrollAvOmBrukerHarOmsorg submitCallback={lagreVurdering} />);
 
     expect(await screen.findByText('Vurder om søker har omsorg for barnet i søknadsperioden')).toBeInTheDocument();
 
@@ -24,7 +24,7 @@ describe('OmsorgFaktaIndex', () => {
 
     await userEvent.click(screen.getAllByText('Søker har omsorg for barnet')[0]!);
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -39,7 +39,7 @@ describe('OmsorgFaktaIndex', () => {
   it('skal velge at søker ikke har omsorg for barnet', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<ÅpentAksjonspunktForKontrollAvOmBrukerHarOmsorg submitCallback={lagreVurdering} />);
+    render(<ÅpentAksjonspunktForKontrollAvOmBrukerHarOmsorg submitCallback={lagreVurdering} />);
 
     expect(await screen.findByText('Vurder om søker har omsorg for barnet i søknadsperioden')).toBeInTheDocument();
 
@@ -49,7 +49,7 @@ describe('OmsorgFaktaIndex', () => {
 
     await userEvent.click(screen.getAllByText('Søker har omsorg for barnet')[1]!);
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
+++ b/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
@@ -9,7 +9,7 @@ const { MedAksjonspunkt, UtenAksjonspunkt } = composeStories(stories);
 describe('OpptjeningFaktaIndex', () => {
   it('skal åpne aktivitet automatisk når det har åpent aksjonspunkt og så godkjenne det', async () => {
     const lagre = vi.fn(() => Promise.resolve());
-    const utils = render(<MedAksjonspunkt submitCallback={lagre} />);
+    render(<MedAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Vurder om aktivitetene kan godkjennes')).toBeInTheDocument();
     expect(screen.getByText('Skjæringstidspunkt for opptjening')).toBeInTheDocument();
@@ -23,7 +23,7 @@ describe('OpptjeningFaktaIndex', () => {
     expect(screen.getByText('Avbryt')).toBeEnabled();
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'D');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'D');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
@@ -34,8 +34,8 @@ describe('OpptjeningFaktaIndex', () => {
 
     await waitFor(() => expect(screen.queryByText('Feltet må fylles ut')).not.toBeInTheDocument());
 
-    await userEvent.clear(utils.getByLabelText('Begrunn endringene'));
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.clear(screen.getByLabelText('Begrunn endringene'));
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await waitFor(() => expect(screen.queryByText('Du må skrive minst 3 tegn')).not.toBeInTheDocument());
 
@@ -44,7 +44,7 @@ describe('OpptjeningFaktaIndex', () => {
     expect(await screen.findAllByText('Sykepenger')).toHaveLength(2);
 
     await userEvent.click(screen.getAllByRole('radio')[1]!);
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse 2');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse 2');
 
     await userEvent.click(screen.getByText('Oppdater'));
 

--- a/packages/fakta/permisjon/src/PermisjonFaktaIndex.spec.tsx
+++ b/packages/fakta/permisjon/src/PermisjonFaktaIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('PermisjonFaktaIndex', () => {
   it('skal velge å ta med arbeidsforholdet og så bekrefte', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<EttArbeidsforholdUtenSluttdatoForPermisjon submitCallback={lagreVurdering} />);
+    render(<EttArbeidsforholdUtenSluttdatoForPermisjon submitCallback={lagreVurdering} />);
 
     expect(await screen.findByText('Fakta om permisjon')).toBeInTheDocument();
     expect(
@@ -30,7 +30,7 @@ describe('PermisjonFaktaIndex', () => {
       screen.getByText('Fjern permisjonen og ta med arbeidsforholdet. Vurder om inntektsmelding må innhentes'),
     );
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -51,7 +51,7 @@ describe('PermisjonFaktaIndex', () => {
   it('skal ta med ett av to arbeidsforhold og så bekrefte', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 
-    const utils = render(<FlereArbeidsforhold submitCallback={lagreVurdering} />);
+    render(<FlereArbeidsforhold submitCallback={lagreVurdering} />);
 
     expect(await screen.findByText('Fakta om permisjon')).toBeInTheDocument();
     expect(
@@ -64,11 +64,11 @@ describe('PermisjonFaktaIndex', () => {
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
 
     await userEvent.click(
-      utils.getByLabelText('Fjern permisjonen og ta med arbeidsforholdet. Vurder om inntektsmelding må innhentes'),
+      screen.getByLabelText('Fjern permisjonen og ta med arbeidsforholdet. Vurder om inntektsmelding må innhentes'),
     );
-    await userEvent.click(utils.getAllByLabelText('Ikke ta med arbeidsforholdet')[1]!);
+    await userEvent.click(screen.getAllByLabelText('Ikke ta med arbeidsforholdet')[1]!);
 
-    await userEvent.type(utils.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/fakta/saken/src/SakenFaktaIndex.spec.tsx
+++ b/packages/fakta/saken/src/SakenFaktaIndex.spec.tsx
@@ -17,7 +17,7 @@ describe('SakenFaktaIndex', () => {
   it('skal få aksjonspunkt om innehenting av dokumentasjon, svar at vil bli innhentet og bekreft', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ApentAksjonspunktForInnhentingAvDokumentasjon submitCallback={lagre} />);
+    render(<ApentAksjonspunktForInnhentingAvDokumentasjon submitCallback={lagre} />);
 
     expect(
       await screen.findByText(
@@ -28,7 +28,7 @@ describe('SakenFaktaIndex', () => {
 
     await userEvent.click(screen.getAllByText('Dokumentasjon vil bli innhentet')[0]!);
 
-    const begrunnelseInput = utils.getByLabelText('Begrunnelse');
+    const begrunnelseInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -44,7 +44,7 @@ describe('SakenFaktaIndex', () => {
   it('skal få feilmelding når en ikke har fylt ut alle feltene under Opptjening utland', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ApentAksjonspunktForInnhentingAvDokumentasjon submitCallback={lagre} />);
+    render(<ApentAksjonspunktForInnhentingAvDokumentasjon submitCallback={lagre} />);
 
     expect(
       await screen.findByText(
@@ -52,7 +52,7 @@ describe('SakenFaktaIndex', () => {
       ),
     ).toBeInTheDocument();
 
-    const begrunnelseInput = utils.getByLabelText('Begrunnelse');
+    const begrunnelseInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -20,11 +20,11 @@ const lagNyDato = (nyDato: string) => {
   return backspace + nyDato;
 };
 
-describe('FodselOgTilretteleggingFaktaIndex', () => {
+describe('TilretteleggingFaktaIndex', () => {
   it('skal vurdere velferdspermisjon og så bekrefte aksjonspunkt', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<TilretteleggingMedVelferdspermisjon submitCallback={lagre} />);
+    render(<TilretteleggingMedVelferdspermisjon submitCallback={lagre} />);
 
     expect(
       await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer'),
@@ -45,7 +45,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
     expect(screen.getByText('17.03.2020 - 14.08.2020')).toBeInTheDocument();
     expect(screen.getByText('15.08.2020 - 15.10.2020')).toBeInTheDocument();
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -117,7 +117,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
   });
 
   it('skal validere at en må velge minst ett arbeidsforhold og at alle velferdspermisjoner er vurdert', async () => {
-    const utils = render(<TilretteleggingMedVelferdspermisjon />);
+    render(<TilretteleggingMedVelferdspermisjon />);
 
     expect(
       await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer'),
@@ -125,7 +125,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Skal ha svangerskapspenger for arbeidsforholdet'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -134,13 +134,13 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
   });
 
   it('skal validere at en må ferdigstille tilretteleggingsperiode som er lagt til', async () => {
-    const utils = render(<HarOpphold />);
+    render(<HarOpphold />);
 
     expect(await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Periode med svangerskapspenger'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -148,13 +148,13 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
   });
 
   it('skal validere at en må ferdigstille oppholdsperiode som er lagt til', async () => {
-    const utils = render(<HarOpphold />);
+    render(<HarOpphold />);
 
     expect(await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Opphold'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -162,7 +162,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
   });
 
   it('skal validere at dato for tilrettelegging fra lege eller jordmor må være før termindato', async () => {
-    const utils = render(<TilretteleggingMedVelferdspermisjon />);
+    render(<TilretteleggingMedVelferdspermisjon />);
 
     expect(
       await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer'),
@@ -172,7 +172,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
     await userEvent.type(dato, '{backspace}1');
     fireEvent.blur(dato);
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -239,7 +239,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
   });
 
   it('skal legge til ny tilretteleggingsperiode', async () => {
-    const utils = render(<TilretteleggingMedVelferdspermisjon />);
+    render(<TilretteleggingMedVelferdspermisjon />);
 
     expect(
       await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer'),
@@ -266,7 +266,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
     await userEvent.type(dato, lagNyDato('15.09.2020'));
     fireEvent.blur(dato);
 
-    await userEvent.type(utils.getByLabelText('Arbeidsprosent'), '40');
+    await userEvent.type(screen.getByLabelText('Arbeidsprosent'), '40');
 
     await userEvent.click(screen.getByText('Legg til ny periode'));
 
@@ -292,7 +292,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
   it('skal legge til ny oppholdsperiode', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<TilretteleggingMedVelferdspermisjon submitCallback={lagre} />);
+    render(<TilretteleggingMedVelferdspermisjon submitCallback={lagre} />);
 
     expect(
       await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer'),
@@ -331,7 +331,7 @@ describe('FodselOgTilretteleggingFaktaIndex', () => {
 
     await userEvent.click(screen.getAllByText('Oppdater')[0]!);
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.spec.tsx
+++ b/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.spec.tsx
@@ -14,11 +14,12 @@ const {
 describe('UttakFaktaEøsIndex', () => {
   it('skal få aksjonspunkt uten eksisterende perioder og kan bekrefte AP uten å legge til noen perioder', async () => {
     const lagre = vi.fn(() => Promise.resolve());
-    const utils = render(<AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg submitCallback={lagre} />);
+
+    render(<AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak til annen forelder i EØS')).toBeInTheDocument();
     expect(await screen.findByText('Ingen perioder lagt til.')).toBeInTheDocument();
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(lagre).toHaveBeenNthCalledWith(1, {
@@ -30,7 +31,8 @@ describe('UttakFaktaEøsIndex', () => {
 
   it('aksjonspunkt skal initielt ikke ha perioder registrert og saksbehandler kan bekrefte AP uten å legge til noen perioder', async () => {
     const lagre = vi.fn(() => Promise.resolve());
-    const utils = render(<AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg submitCallback={lagre} />);
+
+    render(<AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak til annen forelder i EØS')).toBeInTheDocument();
     expect(await screen.findByText('Ingen perioder lagt til.')).toBeInTheDocument();
@@ -51,7 +53,7 @@ describe('UttakFaktaEøsIndex', () => {
 
     expect(screen.queryByText('Ingen perioder lagt til.')).not.toBeInTheDocument();
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(lagre).toHaveBeenNthCalledWith(1, {
@@ -70,7 +72,7 @@ describe('UttakFaktaEøsIndex', () => {
 
   it('skal vise eksisterende perioder og kunne slette periode', async () => {
     const lagre = vi.fn(() => Promise.resolve());
-    const utils = render(<ÅpentAksjonspunktMedPerioder submitCallback={lagre} />);
+    render(<ÅpentAksjonspunktMedPerioder submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak til annen forelder i EØS')).toBeInTheDocument();
     expect(screen.queryByText('Ingen perioder lagt til.')).not.toBeInTheDocument();
@@ -80,7 +82,7 @@ describe('UttakFaktaEøsIndex', () => {
     expect(screen.getByText('Vil du slette denne perioden?')).toBeInTheDocument();
     await userEvent.click(screen.getByText('OK'));
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(lagre).toHaveBeenNthCalledWith(1, {
@@ -105,7 +107,8 @@ describe('UttakFaktaEøsIndex', () => {
 
   it('skal få feilmelding hvis en legger til overlappende perioder, rydder opp i overlapper og sender inn', async () => {
     const lagre = vi.fn(() => Promise.resolve());
-    const utils = render(<AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg submitCallback={lagre} />);
+
+    render(<AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak til annen forelder i EØS')).toBeInTheDocument();
     expect(await screen.findByText('Ingen perioder lagt til.')).toBeInTheDocument();
@@ -136,7 +139,7 @@ describe('UttakFaktaEøsIndex', () => {
 
     expect(screen.queryByText('Ingen perioder lagt til.')).not.toBeInTheDocument();
 
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
 
     expect(screen.getByText('Du må rette disse feilene før du kan fortsette:')).toBeInTheDocument();
@@ -181,7 +184,8 @@ describe('UttakFaktaEøsIndex', () => {
 
   it('skal kunne overstyre og vil da sende inn med annen aksjonspunktkode enn ordinært aksjonspunkt', async () => {
     const lagre = vi.fn(() => Promise.resolve());
-    const utils = render(
+
+    render(
       <OverstyringSkalVæreMuligHvisDetForeliggerEnTidligereVurderingMedRegistrertePerioder submitCallback={lagre} />,
     );
 
@@ -192,7 +196,7 @@ describe('UttakFaktaEøsIndex', () => {
     await userEvent.click(screen.getByTitle('Overstyr'));
 
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
-    await userEvent.type(utils.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(lagre).toHaveBeenNthCalledWith(1, {

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -28,7 +28,7 @@ describe('UttakFaktaIndex', () => {
   it('skal kunne overstyre når det ikke er aksjonspunkter og en er overstyrer', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<VisUttaksperiodeUtenAksjonspunktKanOverstyre submitCallback={lagre} />);
+    render(<VisUttaksperiodeUtenAksjonspunktKanOverstyre submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak')).toBeInTheDocument();
 
@@ -42,18 +42,18 @@ describe('UttakFaktaIndex', () => {
 
     await userEvent.click(screen.getByTitle('Vis mer'));
 
-    const periodeFra = utils.getByLabelText('Periode fra');
+    const periodeFra = screen.getByLabelText('Periode fra');
     await userEvent.clear(periodeFra);
     await userEvent.type(periodeFra, '31.01.2022');
     fireEvent.blur(periodeFra);
 
     await userEvent.click(screen.getByText('Samtidig uttaksprosent'));
 
-    await userEvent.type(utils.getAllByLabelText('Samtidig uttaksprosent')[1]!, '10');
+    await userEvent.type(screen.getAllByLabelText('Samtidig uttaksprosent')[1]!, '10');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -84,7 +84,7 @@ describe('UttakFaktaIndex', () => {
   it('skal få aksjonspunkt der en må justere fom dato til avklart startdato', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<VisUttaksperiodeMedAksjonspunkt submitCallback={lagre} />);
+    render(<VisUttaksperiodeMedAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak')).toBeInTheDocument();
 
@@ -96,14 +96,14 @@ describe('UttakFaktaIndex', () => {
 
     expect(await screen.findByText('Periode til')).toBeInTheDocument();
 
-    const periodeFra = utils.getByLabelText('Periode fra');
+    const periodeFra = screen.getByLabelText('Periode fra');
     await userEvent.clear(periodeFra);
     await userEvent.type(periodeFra, '31.01.2022');
     fireEvent.blur(periodeFra);
 
     await userEvent.click(screen.getByText('Oppdater'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -162,7 +162,7 @@ describe('UttakFaktaIndex', () => {
   it('skal vise aksjonspunkt når det ikke finnes perioder og så legge til en periode', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<VisAksjonspunktDerIngenPerioderFinnes submitCallback={lagre} />);
+    render(<VisAksjonspunktDerIngenPerioderFinnes submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak')).toBeInTheDocument();
 
@@ -174,21 +174,21 @@ describe('UttakFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Legg til periode'));
 
-    const periodeFra = utils.getByLabelText('Periode fra');
+    const periodeFra = screen.getByLabelText('Periode fra');
     await userEvent.type(periodeFra, '31.01.2022');
     fireEvent.blur(periodeFra);
 
-    const periodeTil = utils.getByLabelText('Periode til');
+    const periodeTil = screen.getByLabelText('Periode til');
     await userEvent.type(periodeTil, '14.12.2022');
     fireEvent.blur(periodeTil);
 
     await userEvent.click(screen.getByText('Opphold'));
 
-    await userEvent.selectOptions(utils.getByLabelText('Årsak'), 'UTTAK_FEDREKVOTE_ANNEN_FORELDER');
+    await userEvent.selectOptions(screen.getByLabelText('Årsak'), 'UTTAK_FEDREKVOTE_ANNEN_FORELDER');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -215,7 +215,7 @@ describe('UttakFaktaIndex', () => {
   it('skal få aksjonspunkt der arbeidsforholdet i periode er ukjent', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<VisAksjonspunktDerArbeidsfoholdErUkjentVedGradering submitCallback={lagre} />);
+    render(<VisAksjonspunktDerArbeidsfoholdErUkjentVedGradering submitCallback={lagre} />);
 
     expect(await screen.findByText('Fakta om uttak')).toBeInTheDocument();
 
@@ -227,16 +227,16 @@ describe('UttakFaktaIndex', () => {
       await screen.findByText('Arbeidsgiver oppgitt for perioden er ukjent. Referanse: 91090823'),
     ).toBeInTheDocument();
 
-    const periodeFra = utils.getByLabelText('Periode fra');
+    const periodeFra = screen.getByLabelText('Periode fra');
     await userEvent.clear(periodeFra);
     await userEvent.type(periodeFra, '31.01.2022');
     fireEvent.blur(periodeFra);
 
-    await userEvent.selectOptions(utils.getByLabelText('Arbeidsgiver'), '910909088-ORDINÆRT_ARBEID');
+    await userEvent.selectOptions(screen.getByLabelText('Arbeidsgiver'), '910909088-ORDINÆRT_ARBEID');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
-    await userEvent.type(utils.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -267,7 +267,7 @@ describe('UttakFaktaIndex', () => {
   });
 
   it('skal vise ulike felter for ulike periodetyper', async () => {
-    const utils = render(<VisUtsettelseperiodeMedAksjonspunkt />);
+    render(<VisUtsettelseperiodeMedAksjonspunkt />);
 
     expect(await screen.findByText('Fakta om uttak')).toBeInTheDocument();
 
@@ -276,50 +276,50 @@ describe('UttakFaktaIndex', () => {
     expect(await screen.findByText('Periodetype')).toBeInTheDocument();
 
     // For periodetype = Utsettelse
-    expect(utils.getByLabelText('Årsak')).toBeInTheDocument();
-    expect(utils.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Stønadskonto')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Gradering %')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Arbeidsgiver')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Samtidig uttaksprosent')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Flerbarnsdager')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Årsak')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Stønadskonto')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Gradering %')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Arbeidsgiver')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Samtidig uttaksprosent')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Flerbarnsdager')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Overføring'));
 
-    expect(await utils.findByLabelText('Stønadskonto')).toBeInTheDocument();
-    expect(utils.getByLabelText('Årsak')).toBeInTheDocument();
-    expect(utils.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Gradering %')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Arbeidsgiver')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Samtidig uttaksprosent')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Flerbarnsdager')).not.toBeInTheDocument();
+    expect(await screen.findByLabelText('Stønadskonto')).toBeInTheDocument();
+    expect(screen.getByLabelText('Årsak')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Gradering %')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Arbeidsgiver')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Samtidig uttaksprosent')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Flerbarnsdager')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Uttak'));
 
-    expect(await utils.findByLabelText('Gradering')).toBeInTheDocument();
-    expect(utils.getByLabelText('Samtidig uttaksprosent')).toBeInTheDocument();
-    expect(utils.getByLabelText('Stønadskonto')).toBeInTheDocument();
-    expect(utils.queryByLabelText('Gradering %')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
-    expect(utils.getByLabelText('Flerbarnsdager')).toBeInTheDocument();
-    expect(utils.queryByLabelText('Årsak')).not.toBeInTheDocument();
+    expect(await screen.findByLabelText('Gradering')).toBeInTheDocument();
+    expect(screen.getByLabelText('Samtidig uttaksprosent')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stønadskonto')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Gradering %')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Flerbarnsdager')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Årsak')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Gradering'));
-    expect(await utils.findByLabelText('Gradering %')).toBeInTheDocument();
-    expect(utils.getByLabelText('Arbeidsgiver')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Gradering %')).toBeInTheDocument();
+    expect(screen.getByLabelText('Arbeidsgiver')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Samtidig uttaksprosent'));
-    expect(await utils.findAllByLabelText('Samtidig uttaksprosent')).toHaveLength(2);
+    expect(await screen.findAllByLabelText('Samtidig uttaksprosent')).toHaveLength(2);
 
     await userEvent.click(screen.getByText('Opphold'));
 
-    expect(utils.getByLabelText('Årsak')).toBeInTheDocument();
-    expect(utils.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Stønadskonto')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Gradering %')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Arbeidsgiver')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Samtidig uttaksprosent')).not.toBeInTheDocument();
-    expect(utils.queryByLabelText('Flerbarnsdager')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Årsak')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Mors aktivitet')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Stønadskonto')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Gradering %')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Arbeidsgiver')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Samtidig uttaksprosent')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Flerbarnsdager')).not.toBeInTheDocument();
   });
 
   it('skal vise periode der aksjonspunkt er løst og behandlingen er avsluttet', async () => {

--- a/packages/fakta/uttaksdokumentasjon/src/UttakDokumentasjonFaktaIndex.spec.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/UttakDokumentasjonFaktaIndex.spec.tsx
@@ -16,7 +16,7 @@ describe('UttakDokumentasjonFaktaIndex', () => {
   it('skal avklare perioder og så bekrefte aksjonspunkt', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
-    const utils = render(<AksjonspunktMedUavklartePerioder submitCallback={lagre} />);
+    render(<AksjonspunktMedUavklartePerioder submitCallback={lagre} />);
 
     expect(screen.getByText('Kontroller dokumentasjon')).toBeInTheDocument();
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
@@ -48,7 +48,7 @@ describe('UttakDokumentasjonFaktaIndex', () => {
     await userEvent.type(screen.getByLabelText('Hvor mange prosent jobber mor?'), '60');
     await userEvent.click(screen.getByText('Oppdater'));
 
-    await userEvent.type(utils.getByLabelText('Begrunnelse'), 'Dette er en begrunnelse');
+    await userEvent.type(screen.getByLabelText('Begrunnelse'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -12,28 +12,28 @@ describe('VergeFaktaIndex', () => {
   it('skal velge vergetype og bekrefte aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<Default submitCallback={lagre} />);
+    render(<Default submitCallback={lagre} />);
 
     expect(await screen.findByText('Fyll ut og kontroller vergeopplysninger')).toBeInTheDocument();
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
 
-    await userEvent.selectOptions(utils.getByLabelText('Type verge'), 'ADVOKAT');
+    await userEvent.selectOptions(screen.getByLabelText('Type verge'), 'ADVOKAT');
 
-    const navnInput = utils.getByLabelText('Navn');
+    const navnInput = screen.getByLabelText('Navn');
     await userEvent.type(navnInput, 'Espen Utvikler');
 
-    const organisasjonsnummerInput = utils.getByLabelText('Organisasjonsnummer');
+    const organisasjonsnummerInput = screen.getByLabelText('Organisasjonsnummer');
     await userEvent.type(organisasjonsnummerInput, '232232323');
 
-    const fomInput = utils.getByLabelText('Fra og med');
+    const fomInput = screen.getByLabelText('Fra og med');
     await userEvent.type(fomInput, '14.09.2022');
     fireEvent.blur(fomInput);
 
-    const tomInput = utils.getByLabelText('Til og med');
+    const tomInput = screen.getByLabelText('Til og med');
     await userEvent.type(tomInput, '24.09.2022');
     fireEvent.blur(tomInput);
 
-    const begrunnelseInput = utils.getByLabelText('Begrunn endringene');
+    const begrunnelseInput = screen.getByLabelText('Begrunn endringene');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/los/felles/src/flyttReservasjon/FlyttReservasjonModal.spec.tsx
+++ b/packages/los/felles/src/flyttReservasjon/FlyttReservasjonModal.spec.tsx
@@ -17,11 +17,11 @@ describe('FlyttReservasjonModal', () => {
   });
 
   it('skal vise at oppgitt brukerident ikke finnes', async () => {
-    const utils = render(<Default />);
+    render(<Default />);
 
     expect(await screen.findByText('Flytt reservasjonen til annen saksbehandler')).toBeInTheDocument();
 
-    const brukerIdentInput = utils.getByLabelText('Brukerident');
+    const brukerIdentInput = screen.getByLabelText('Brukerident');
     await userEvent.type(brukerIdentInput, 'TESTTES');
 
     expect(await screen.findByText('Søk')).toBeInTheDocument();
@@ -35,11 +35,11 @@ describe('FlyttReservasjonModal', () => {
 
   it('skal vise finne brukerident og så lagre begrunnelse for flytting', async () => {
     const flyttOppgavereservasjon = vi.fn();
-    const utils = render(<MedTreffPåSøk flyttOppgavereservasjon={flyttOppgavereservasjon} />);
+    render(<MedTreffPåSøk flyttOppgavereservasjon={flyttOppgavereservasjon} />);
 
     expect(await screen.findByText('Flytt reservasjonen til annen saksbehandler')).toBeInTheDocument();
 
-    const brukerIdentInput = utils.getByLabelText('Brukerident');
+    const brukerIdentInput = screen.getByLabelText('Brukerident');
     await userEvent.type(brukerIdentInput, 'TESTTES');
 
     expect(await screen.findByText('Søk')).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe('FlyttReservasjonModal', () => {
     expect(await screen.findByText('Espen Utvikler')).toBeInTheDocument();
     expect(screen.getByText('OK').closest('button')).toBeDisabled();
 
-    const begrunnelseInput = utils.getByLabelText('Begrunn flytting av reservasjonen');
+    const begrunnelseInput = screen.getByLabelText('Begrunn flytting av reservasjonen');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await waitFor(() => expect(screen.getByText('OK')).toBeEnabled());

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/LedigOppgaveTabell.spec.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/LedigOppgaveTabell.spec.tsx
@@ -6,7 +6,7 @@ import * as stories from './LedigOppgaveTabell.stories';
 
 const { Default, TomOppgaveTabell } = composeStories(stories);
 
-describe('OppgaverTabell', () => {
+describe('LedigOppgaveTabell', () => {
   it('skal vise tabell med behandlinger', async () => {
     applyRequestHandlers(Default.parameters['msw'] as MswParameters['msw']);
     await Default.run();

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/reservertOppgaveTabell/ReservertOppgaveTabell.spec.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/reservertOppgaveTabell/ReservertOppgaveTabell.spec.tsx
@@ -6,7 +6,7 @@ import * as stories from './ReservertOppgaveTabell.stories';
 
 const { Default, TomOppgaveTabell } = composeStories(stories);
 
-describe('OppgaverTabell', () => {
+describe('ReservertOppgaveTabell', () => {
   it('skal vise tabell med behandlinger', async () => {
     applyRequestHandlers(Default.parameters['msw'] as MswParameters['msw']);
     await Default.run();

--- a/packages/papirsoknad-ui-komponenter/src/dekningsgradFp/DekningsgradIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/dekningsgradFp/DekningsgradIndex.spec.tsx
@@ -6,7 +6,7 @@ import * as stories from './DekningsgradIndex.stories';
 
 const { Default } = composeStories(stories);
 
-describe('BekreftelsePanel', () => {
+describe('DekningsgradIndex', () => {
   it('skal måtte velge dekningsgrad', async () => {
     const lagre = vi.fn();
 

--- a/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminFodselSvpPanel.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminFodselSvpPanel.spec.tsx
@@ -9,7 +9,7 @@ import * as stories from './TerminFodselSvpPanel.stories';
 
 const { Default } = composeStories(stories);
 
-describe('TerminOgFodselPanelSvp', () => {
+describe('TerminFodselSvpPanel', () => {
   it('skal velge termindato og fødselsdato', async () => {
     const lagre = vi.fn();
     const foedselsDato = dayjs().subtract(1, 'day');

--- a/packages/prosess/formkrav/src/FormkravProsessIndex.spec.tsx
+++ b/packages/prosess/formkrav/src/FormkravProsessIndex.spec.tsx
@@ -14,16 +14,16 @@ describe('FormkravProsessIndex', () => {
   it('skal fylle ut og bekrefte skjema for NFP', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<FormkravPanelForAksjonspunktNfp submitCallback={lagre} />);
+    render(<FormkravPanelForAksjonspunktNfp submitCallback={lagre} />);
 
     expect(await screen.findByText('Vurder formkrav')).toBeInTheDocument();
     expect(screen.getByText('Fvl §§ 28, 31, 32, 33 og ftrl § 21-12')).toBeInTheDocument();
     expect(screen.getByText('Vurder om klagen oppfyller formkravene')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
-    await userEvent.selectOptions(utils.getByLabelText('Vedtaket som er påklagd'), '1');
+    await userEvent.selectOptions(screen.getByLabelText('Vedtaket som er påklagd'), '1');
 
     await userEvent.click(screen.getAllByText('Ja')[0]!);
     await userEvent.click(screen.getAllByText('Ja')[1]!);
@@ -53,21 +53,21 @@ describe('FormkravProsessIndex', () => {
   it('skal kunne fylle ut fritekst og mellomlagre når en velger nei på et spørsmål', async () => {
     const mellomlagre = vi.fn();
 
-    const utils = render(<FormkravPanelForAksjonspunktNfp lagreFormkravVurdering={mellomlagre} />);
+    render(<FormkravPanelForAksjonspunktNfp lagreFormkravVurdering={mellomlagre} />);
 
     expect(await screen.findByText('Vurder formkrav')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Vedtaket som er påklagd'), '1');
+    await userEvent.selectOptions(screen.getByLabelText('Vedtaket som er påklagd'), '1');
 
     await userEvent.click(screen.getAllByText('Nei')[0]!);
     await userEvent.click(screen.getAllByText('Ja')[1]!);
     await userEvent.click(screen.getAllByText('Ja')[2]!);
     await userEvent.click(screen.getAllByText('Ja')[3]!);
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
-    const fritekstInput = utils.getByLabelText('Fritekst');
+    const fritekstInput = screen.getByLabelText('Fritekst');
     await userEvent.type(fritekstInput, 'Dette er en fritekst');
 
     await userEvent.click(screen.getByText('Lagre'));

--- a/packages/prosess/innsyn/src/InnsynProsessIndex.spec.tsx
+++ b/packages/prosess/innsyn/src/InnsynProsessIndex.spec.tsx
@@ -12,19 +12,19 @@ describe('InnsynProsessIndex', () => {
   it('skal fylle ut og så bekrefte avslått innsyn', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<PanelForVurderingAvInnsyn submitCallback={lagre} />);
+    render(<PanelForVurderingAvInnsyn submitCallback={lagre} />);
 
     expect(await screen.findByText('Innsynsbehandling')).toBeInTheDocument();
     expect(screen.getByText('Følg manuelle rutiner for innsynsbehandling')).toBeInTheDocument();
 
-    const datoMottattKravInput = utils.getByLabelText('Dato for mottatt krav om innsyn');
+    const datoMottattKravInput = screen.getByLabelText('Dato for mottatt krav om innsyn');
     await userEvent.type(datoMottattKravInput, '23.12.2021');
     fireEvent.blur(datoMottattKravInput);
 
     expect(screen.getByText('Velg innsynsdokumentasjon til søker')).toBeInTheDocument();
     expect(screen.getByText('Dette er et dokument')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -68,24 +68,24 @@ describe('InnsynProsessIndex', () => {
   it('skal fylle ut og så bekrefte innvilget innsyn', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<PanelForVurderingAvInnsyn submitCallback={lagre} />);
+    render(<PanelForVurderingAvInnsyn submitCallback={lagre} />);
 
     expect(await screen.findByText('Innsynsbehandling')).toBeInTheDocument();
 
-    const datoMottattKravInput = utils.getByLabelText('Dato for mottatt krav om innsyn');
+    const datoMottattKravInput = screen.getByLabelText('Dato for mottatt krav om innsyn');
     await userEvent.type(datoMottattKravInput, '23.12.2021');
     fireEvent.blur(datoMottattKravInput);
 
     await userEvent.click(screen.getByRole('checkbox'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Innvilget innsyn'));
 
     await userEvent.click(screen.getByText('Sett behandling på vent i påvente av skanning'));
 
-    const sattPaVentFristInput = utils.getByLabelText('Behandling blir satt på vent med frist');
+    const sattPaVentFristInput = screen.getByLabelText('Behandling blir satt på vent med frist');
     await userEvent.clear(sattPaVentFristInput);
     await userEvent.type(sattPaVentFristInput, '29.12.2021');
     fireEvent.blur(sattPaVentFristInput);

--- a/packages/prosess/klagevurdering/src/KlagevurderingProsessIndex.spec.tsx
+++ b/packages/prosess/klagevurdering/src/KlagevurderingProsessIndex.spec.tsx
@@ -13,7 +13,7 @@ describe('KlagevurderingProsessIndex', () => {
     const mellomlagre = vi.fn();
     const forhåndsvise = vi.fn();
 
-    const utils = render(
+    render(
       <KlagevurderingMedAksjonspunktNfp
         submitCallback={lagre}
         saveKlage={mellomlagre}
@@ -26,16 +26,16 @@ describe('KlagevurderingProsessIndex', () => {
 
     await userEvent.click(screen.getByText('Omgjør vedtaket'));
 
-    await userEvent.selectOptions(utils.getByLabelText('Årsak'), 'ULIK_VURDERING');
+    await userEvent.selectOptions(screen.getByLabelText('Årsak'), 'ULIK_VURDERING');
 
     await userEvent.click(screen.getByText('Til gunst'));
 
-    await userEvent.selectOptions(utils.getByLabelText('Hjemmel'), '14-17');
+    await userEvent.selectOptions(screen.getByLabelText('Hjemmel'), '14-17');
 
-    const vurderingInput = utils.getByLabelText('Begrunnelse');
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
-    const fritekstInput = utils.getByLabelText('Fritekst til brev');
+    const fritekstInput = screen.getByLabelText('Fritekst til brev');
     await userEvent.type(fritekstInput, 'Dette er en fritekst');
 
     await userEvent.click(screen.getByText('Lagre'));

--- a/packages/prosess/simulering/src/SimuleringProsessIndex.spec.tsx
+++ b/packages/prosess/simulering/src/SimuleringProsessIndex.spec.tsx
@@ -11,7 +11,7 @@ describe('SimuleringProsessIndex', () => {
   it('skal velge ingen tilbakebetaling og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktVurderFeilutbetaling submitCallback={lagre} />);
+    render(<AksjonspunktVurderFeilutbetaling submitCallback={lagre} />);
 
     expect(await screen.findByText('Simulering')).toBeInTheDocument();
     expect(screen.getByText('Vurder videre behandling av tilbakekreving')).toBeInTheDocument();
@@ -22,7 +22,7 @@ describe('SimuleringProsessIndex', () => {
     expect(screen.getByText('Resultat')).toBeInTheDocument();
     expect(screen.getByText('−26 486')).toBeInTheDocument();
 
-    const begrunnelseInput = utils.getByLabelText(
+    const begrunnelseInput = screen.getByLabelText(
       'Beskriv hvorfor det har oppstått en feilutbetaling og hvordan den skal behandles videre',
     );
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
@@ -45,11 +45,11 @@ describe('SimuleringProsessIndex', () => {
   it('skal velge å opprett tilbakekreving, sende varsel og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktVurderFeilutbetaling submitCallback={lagre} />);
+    render(<AksjonspunktVurderFeilutbetaling submitCallback={lagre} />);
 
     expect(await screen.findByText('Simulering')).toBeInTheDocument();
 
-    const begrunnelseInput = utils.getByLabelText(
+    const begrunnelseInput = screen.getByLabelText(
       'Beskriv hvorfor det har oppstått en feilutbetaling og hvordan den skal behandles videre',
     );
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
@@ -58,7 +58,7 @@ describe('SimuleringProsessIndex', () => {
 
     expect(await screen.findByText('Send varsel om tilbakekreving')).toBeInTheDocument();
 
-    const fritekstVarselInput = utils.getByLabelText('Fritekst i varselet');
+    const fritekstVarselInput = screen.getByLabelText('Fritekst i varselet');
     await userEvent.type(fritekstVarselInput, 'Dette er en fritekst');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -94,12 +94,14 @@ describe('SimuleringProsessIndex', () => {
   });
 
   it('skal ikke vise aksjonspunkt-tekst og input-felter når en ikke har aksjonspunkt', async () => {
-    const utils = render(<SimuleringspanelUtenAksjonspunkt />);
+    render(<SimuleringspanelUtenAksjonspunkt />);
 
     expect(await screen.findByText('Simulering')).toBeInTheDocument();
     expect(screen.queryByText('Vurder videre behandling av tilbakekreving')).not.toBeInTheDocument();
     expect(
-      utils.queryByLabelText('Beskriv hvorfor det har oppstått en feilutbetaling og hvordan den skal behandles videre'),
+      screen.queryByLabelText(
+        'Beskriv hvorfor det har oppstått en feilutbetaling og hvordan den skal behandles videre',
+      ),
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Opprett tilbakekreving, send varsel')).not.toBeInTheDocument();
 
@@ -113,7 +115,7 @@ describe('SimuleringProsessIndex', () => {
   it('skal kunne løse aksjonspunkt for stor etterbetaling til søker', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktKontrollerEtterbetaling submitCallback={lagre} />);
+    render(<AksjonspunktKontrollerEtterbetaling submitCallback={lagre} />);
 
     expect(await screen.findByText('Simulering')).toBeInTheDocument();
     expect(
@@ -121,7 +123,7 @@ describe('SimuleringProsessIndex', () => {
         'Ny inntektsmelding vil føre til en høy etterbetaling til bruker i en tidligere innvilget periode. Kontroller om dette er riktig',
       ),
     ).toBeInTheDocument();
-    const begrunnelse = utils.getByLabelText('Begrunn hvorfor du går videre med denne behandlingen.');
+    const begrunnelse = screen.getByLabelText('Begrunn hvorfor du går videre med denne behandlingen.');
     await userEvent.type(begrunnelse, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/prosess/soknadsfrist/src/VurderSoknadsfristForeldrepengerIndex.spec.tsx
+++ b/packages/prosess/soknadsfrist/src/VurderSoknadsfristForeldrepengerIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('VurderSoknadsfristForeldrepengerIndex', () => {
   it('skal velge ingen grunn og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<PanelForSoknadsfrist submitCallback={lagre} />);
+    render(<PanelForSoknadsfrist submitCallback={lagre} />);
 
     expect(await screen.findByText('Søknadsfrist')).toBeInTheDocument();
     expect(screen.getByText('Søknad ble mottatt 2 dager etter søknadsfrist (01.10.2019)')).toBeInTheDocument();
@@ -19,7 +19,7 @@ describe('VurderSoknadsfristForeldrepengerIndex', () => {
     expect(screen.getByText('Søknadsperiode')).toBeInTheDocument();
     expect(screen.getByText('01.01.2019 - 10.01.2019')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Ingen gyldig grunn for sen fremsetting av søknaden'));
@@ -38,7 +38,7 @@ describe('VurderSoknadsfristForeldrepengerIndex', () => {
   it('skal velge gyldig grunn og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<PanelForSoknadsfrist submitCallback={lagre} />);
+    render(<PanelForSoknadsfrist submitCallback={lagre} />);
 
     expect(await screen.findByText('Søknadsfrist')).toBeInTheDocument();
     expect(screen.getByText('Søknad ble mottatt 2 dager etter søknadsfrist (01.10.2019)')).toBeInTheDocument();
@@ -47,7 +47,7 @@ describe('VurderSoknadsfristForeldrepengerIndex', () => {
     expect(screen.getByText('Søknadsperiode')).toBeInTheDocument();
     expect(screen.getByText('01.01.2019 - 10.01.2019')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Gyldig grunn for sen fremsetting av søknaden'));

--- a/packages/prosess/uttak/src/UttakProsessIndex.spec.tsx
+++ b/packages/prosess/uttak/src/UttakProsessIndex.spec.tsx
@@ -107,7 +107,7 @@ describe('UttakProsessIndex', () => {
 
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktDerValgtStønadskontoIkkeFinnes submitCallback={lagre} />);
+    render(<AksjonspunktDerValgtStønadskontoIkkeFinnes submitCallback={lagre} />);
 
     expect(
       await screen.findByText('Alle aksjonspunkter skal vurderes manuelt. Kontakt søker ved behov.'),
@@ -118,17 +118,17 @@ describe('UttakProsessIndex', () => {
       ),
     ).toBeInTheDocument();
 
-    const inputFelter = utils.getAllByRole('textbox');
+    const inputFelter = screen.getAllByRole('textbox');
     expect(inputFelter).toHaveLength(7);
 
     await userEvent.type(inputFelter[2]!, '0');
     await userEvent.type(inputFelter[5]!, '10');
 
-    await userEvent.type(utils.getByLabelText('Vurdering:'), 'Dette er en vurdering');
+    await userEvent.type(screen.getByLabelText('Vurdering:'), 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Oppfylt'));
 
-    await userEvent.selectOptions(utils.getByLabelText('Årsak til innvilgelse'), '2002');
+    await userEvent.selectOptions(screen.getByLabelText('Årsak til innvilgelse'), '2002');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
@@ -140,7 +140,7 @@ describe('UttakProsessIndex', () => {
 
     expect(await screen.findByText('Detaljer for valgt periode')).toBeInTheDocument();
 
-    const dropdowns = utils.getAllByRole('combobox');
+    const dropdowns = screen.getAllByRole('combobox');
     expect(dropdowns).toHaveLength(3);
 
     await userEvent.selectOptions(dropdowns[0]!, 'MØDREKVOTE');
@@ -239,7 +239,7 @@ describe('UttakProsessIndex', () => {
   it('skal ha aksjonspunkt og dele opp periode i to og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AksjonspunktDerValgtStønadskontoIkkeFinnes submitCallback={lagre} />);
+    render(<AksjonspunktDerValgtStønadskontoIkkeFinnes submitCallback={lagre} />);
 
     expect(
       await screen.findByText('Alle aksjonspunkter skal vurderes manuelt. Kontakt søker ved behov.'),
@@ -262,25 +262,25 @@ describe('UttakProsessIndex', () => {
 
     expect(await screen.findByText('20.10.2022 - 28.10.2022')).toBeInTheDocument();
 
-    const inputFelter = utils.getAllByRole('textbox');
+    const inputFelter = screen.getAllByRole('textbox');
     expect(inputFelter).toHaveLength(7);
 
     await userEvent.type(inputFelter[2]!, '0');
     await userEvent.type(inputFelter[5]!, '0');
 
-    await userEvent.type(utils.getByLabelText('Vurdering:'), 'Dette er en vurdering');
+    await userEvent.type(screen.getByLabelText('Vurdering:'), 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
     expect(await screen.findByText('29.10.2022 - 09.11.2022')).toBeInTheDocument();
 
-    const inputFelter2 = utils.getAllByRole('textbox');
+    const inputFelter2 = screen.getAllByRole('textbox');
     expect(inputFelter2).toHaveLength(7);
 
     await userEvent.type(inputFelter2[2]!, '0');
     await userEvent.type(inputFelter2[5]!, '0');
 
-    await userEvent.type(utils.getByLabelText('Vurdering:'), 'Dette er en vurdering på periode 2');
+    await userEvent.type(screen.getByLabelText('Vurdering:'), 'Dette er en vurdering på periode 2');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
@@ -412,7 +412,7 @@ describe('UttakProsessIndex', () => {
   });
 
   it('skal vise feilmelding når det ikke er valgt et gyldig antall dager for mødrekvoten', async () => {
-    const utils = render(<StønadskontoMedUgyldigForbruk />);
+    render(<StønadskontoMedUgyldigForbruk />);
 
     expect(
       await screen.findByText('Alle aksjonspunkter skal vurderes manuelt. Kontakt søker ved behov.'),
@@ -423,12 +423,12 @@ describe('UttakProsessIndex', () => {
       ),
     ).toBeInTheDocument();
 
-    const inputFelter = utils.getAllByRole('textbox');
+    const inputFelter = screen.getAllByRole('textbox');
     expect(inputFelter).toHaveLength(4);
 
     await userEvent.type(inputFelter[2]!, '0');
 
-    await userEvent.type(utils.getByLabelText('Vurdering:'), 'Dette er en vurdering');
+    await userEvent.type(screen.getByLabelText('Vurdering:'), 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Oppdater'));
 
@@ -439,7 +439,7 @@ describe('UttakProsessIndex', () => {
 
   // TODO FIX!
   it.skip('skal vise varsel når samlet utbetalingsgrad og andel i arbeid overskrider 100%', async () => {
-    const utils = render(<VisAdvarselNårProsentIArbeidTotaltErMindreEnn100Prosent />);
+    render(<VisAdvarselNårProsentIArbeidTotaltErMindreEnn100Prosent />);
 
     expect(
       await screen.findByText('Alle aksjonspunkter skal vurderes manuelt. Kontakt søker ved behov.'),
@@ -450,12 +450,12 @@ describe('UttakProsessIndex', () => {
       ),
     ).toBeInTheDocument();
 
-    const inputFelter = utils.getAllByRole('textbox');
+    const inputFelter = screen.getAllByRole('textbox');
     expect(inputFelter).toHaveLength(4);
 
     await userEvent.type(inputFelter[2]!, '0');
 
-    await userEvent.type(utils.getByLabelText('Vurdering:'), 'Dette er en vurdering');
+    await userEvent.type(screen.getByLabelText('Vurdering:'), 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Oppfylt'));
 
@@ -468,7 +468,7 @@ describe('UttakProsessIndex', () => {
   });
 
   it('skal vise varsel når utbetalingsgrad og andel i arbeid overskrider 100%', async () => {
-    const utils = render(<VisAdvarselNårUtbetalingsgradOgProsentArbeidOverstiger100Prosent />);
+    render(<VisAdvarselNårUtbetalingsgradOgProsentArbeidOverstiger100Prosent />);
 
     expect(
       await screen.findByText('Alle aksjonspunkter skal vurderes manuelt. Kontakt søker ved behov.'),
@@ -476,7 +476,7 @@ describe('UttakProsessIndex', () => {
 
     expect(screen.getByText('Samlet utbetalingsgrad og andel i arbeid bør ikke overskride 100%.')).toBeInTheDocument();
 
-    const inputFelter = utils.getAllByRole('textbox');
+    const inputFelter = screen.getAllByRole('textbox');
     expect(inputFelter).toHaveLength(4);
 
     await userEvent.clear(inputFelter[2]!);

--- a/packages/prosess/varsel-om-revurdering/src/VarselOmRevurderingProsessIndex.spec.tsx
+++ b/packages/prosess/varsel-om-revurdering/src/VarselOmRevurderingProsessIndex.spec.tsx
@@ -12,14 +12,14 @@ describe('VarselOmRevurderingProsessIndex', () => {
   it('skal for førstegangsbehandling velge å ikke sende varsel til søker og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ForFørstegangsbehandling submitCallback={lagre} />);
+    render(<ForFørstegangsbehandling submitCallback={lagre} />);
 
     expect(await screen.findByText('Varsel om revurdering')).toBeInTheDocument();
     expect(screen.getByText('Vurder om varsel om revurdering skal sendes til søker')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Ikke send varsel til søker'));
 
-    const vurderingInput = utils.getByLabelText('Begrunnelse');
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -36,16 +36,16 @@ describe('VarselOmRevurderingProsessIndex', () => {
     const lagre = vi.fn();
     const forhåndsvis = vi.fn();
 
-    const utils = render(<ForFørstegangsbehandling submitCallback={lagre} previewCallback={forhåndsvis} />);
+    render(<ForFørstegangsbehandling submitCallback={lagre} previewCallback={forhåndsvis} />);
 
     expect(await screen.findByText('Varsel om revurdering')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Send varsel til søker'));
 
-    const fritekstInput = utils.getByLabelText('Fritekst i brev');
+    const fritekstInput = screen.getByLabelText('Fritekst i brev');
     await userEvent.type(fritekstInput, 'Dette er en fritekst');
 
-    const vurderingInput = utils.getByLabelText('Begrunnelse');
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Forhåndsvis'));
@@ -61,7 +61,7 @@ describe('VarselOmRevurderingProsessIndex', () => {
 
     expect(await screen.findByText('Behandlingen settes på vent')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Årsak'), 'AVV_DOK');
+    await userEvent.selectOptions(screen.getByLabelText('Årsak'), 'AVV_DOK');
 
     await userEvent.click(screen.getByText('OK'));
 
@@ -79,14 +79,14 @@ describe('VarselOmRevurderingProsessIndex', () => {
   it('skal for revurdering velge å ikke sende varsel til søker og så bekrefte', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ForRevurdering submitCallback={lagre} />);
+    render(<ForRevurdering submitCallback={lagre} />);
 
     expect(await screen.findByText('Varsel om revurdering')).toBeInTheDocument();
     expect(screen.getByText('Vurder om varsel om revurdering skal sendes til søker')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Ikke send varsel til søker'));
 
-    const vurderingInput = utils.getByLabelText('Begrunnelse');
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/prosess/vedtak-innsyn/src/VedtakInnsynProsessIndex.spec.tsx
+++ b/packages/prosess/vedtak-innsyn/src/VedtakInnsynProsessIndex.spec.tsx
@@ -46,7 +46,7 @@ describe('VedtakInnsynProsessIndex', () => {
     const lagre = vi.fn();
     const forhåndsvise = vi.fn();
 
-    const utils = render(<PanelForAvvistVedtak submitCallback={lagre} previewCallback={forhåndsvise} />);
+    render(<PanelForAvvistVedtak submitCallback={lagre} previewCallback={forhåndsvise} />);
 
     expect(await screen.findByText('Forslag til vedtak')).toBeInTheDocument();
     expect(screen.getByText('Resultat')).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe('VedtakInnsynProsessIndex', () => {
     expect(screen.getByText('Vurdering')).toBeInTheDocument();
     expect(screen.getByText('Dette er utført')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Fritekst i brev');
+    const vurderingInput = screen.getByLabelText('Fritekst i brev');
     await userEvent.type(vurderingInput, 'Dette er en fritekst');
 
     await userEvent.click(screen.getByText('Forhåndsvis brev'));

--- a/packages/prosess/vedtak/src/VedtakProsessIndex.spec.tsx
+++ b/packages/prosess/vedtak/src/VedtakProsessIndex.spec.tsx
@@ -164,7 +164,7 @@ describe('VedtakProsessIndex', () => {
   it('skal forhåndsvise avslått vedtaksbrev og så fatte vedtak med fritekst', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<AvslåttForeldrepengerTilGodkjenningForSaksbehandlerMedOverstyring submitCallback={lagre} />);
+    render(<AvslåttForeldrepengerTilGodkjenningForSaksbehandlerMedOverstyring submitCallback={lagre} />);
 
     expect(await screen.findByText('Vedtak')).toBeInTheDocument();
     expect(screen.getByText('Foreldrepenger er avslått')).toBeInTheDocument();
@@ -174,13 +174,13 @@ describe('VedtakProsessIndex', () => {
     expect(screen.getByText('Årsak til avslag')).toBeInTheDocument();
     expect(screen.getByText('Søker har ikke noen gyldig uttaksperiode')).toBeInTheDocument();
 
-    await userEvent.type(utils.getByLabelText('Fritekst i brev til søker'), 'D');
+    await userEvent.type(screen.getByLabelText('Fritekst i brev til søker'), 'D');
 
     await userEvent.click(screen.getByText('Til godkjenning'));
 
     expect(await screen.findByText('Du må skrive minst 3 tegn')).toBeInTheDocument();
 
-    await userEvent.type(utils.getByLabelText('Fritekst i brev til søker'), 'ette er en tekst');
+    await userEvent.type(screen.getByLabelText('Fritekst i brev til søker'), 'ette er en tekst');
 
     await userEvent.click(screen.getByText('Til godkjenning'));
 
@@ -199,7 +199,7 @@ describe('VedtakProsessIndex', () => {
   it('skal vise info om hva saksbehandler må ta stilling til før godkjenning', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<TeksterForAksjonspunkterSomSaksbehandlerMåTaStillingTil submitCallback={lagre} />);
+    render(<TeksterForAksjonspunkterSomSaksbehandlerMåTaStillingTil submitCallback={lagre} />);
 
     expect(await screen.findByText('Vedtak')).toBeInTheDocument();
     expect(screen.getByText('Foreldrepenger er innvilget')).toBeInTheDocument();
@@ -215,7 +215,7 @@ describe('VedtakProsessIndex', () => {
       screen.getByText('Beregningsgrunnlaget er endret til ugunst for søker. Skal det sendes varsel?'),
     ).toBeInTheDocument();
 
-    const fritekstInput = utils.getByLabelText(
+    const fritekstInput = screen.getByLabelText(
       'Fritekst i brev til søker som handler om fastsettelse av beregningsgrunnlaget',
     );
     await userEvent.type(fritekstInput, 'Dette er en tekst');

--- a/packages/prosess/vilkar-adopsjon/src/AdopsjonVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-adopsjon/src/AdopsjonVilkarProsessIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('AdopsjonVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Adopsjon')).toBeInTheDocument();
     expect(screen.getByText('§§Dette er en lovreferanse')).toBeInTheDocument();
@@ -18,7 +18,7 @@ describe('AdopsjonVilkarProsessIndex', () => {
 
     await userEvent.click(screen.getByText('Er utbetalt for et annet barn, vilkåret er oppfylt'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -34,20 +34,20 @@ describe('AdopsjonVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret ikke er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Adopsjon')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/ikke/));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), '1006');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1006');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/prosess/vilkar-fodsel/src/FodselVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-fodsel/src/FodselVilkarProsessIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('FodselVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Fødsel')).toBeInTheDocument();
     expect(screen.getByText('§§Dette er en lovreferanse')).toBeInTheDocument();
@@ -18,7 +18,7 @@ describe('FodselVilkarProsessIndex', () => {
 
     await userEvent.click(screen.getByText('Er utbetalt for et annet barn, vilkåret er oppfylt'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -34,20 +34,20 @@ describe('FodselVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret ikke er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Fødsel')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/ikke/));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), '1031');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1031');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/prosess/vilkar-foreldreansvar/src/ForeldreansvarVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-foreldreansvar/src/ForeldreansvarVilkarProsessIndex.spec.tsx
@@ -17,14 +17,14 @@ describe('ForeldreansvarVilkarProsessIndex', () => {
   it('skal bestemme at 2-ledd er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt2Ledd submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt2Ledd submitCallback={lagre} />);
 
     expect(await screen.findByText('Foreldreansvaret')).toBeInTheDocument();
     expect(screen.getByText('Rett til stønad ved overtakelse av foreldreansvaret')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Far har rett til foreldrepenger, vilkåret er oppfylt'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -42,20 +42,20 @@ describe('ForeldreansvarVilkarProsessIndex', () => {
   it('skal bestemme at 2-ledd ikke er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt2Ledd submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt2Ledd submitCallback={lagre} />);
 
     expect(await screen.findByText('Foreldreansvaret')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/Far har ikke rett til foreldrepenger, vilkåret er/));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), '1015');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1015');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
@@ -73,14 +73,14 @@ describe('ForeldreansvarVilkarProsessIndex', () => {
   it('skal bestemme at 4-ledd er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt4Ledd submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt4Ledd submitCallback={lagre} />);
 
     expect(await screen.findByText('Foreldreansvaret')).toBeInTheDocument();
     expect(screen.getByText('Rett til stønad ved overtakelse av foreldreansvaret')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Far har rett til foreldrepenger, vilkåret er oppfylt'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -98,20 +98,20 @@ describe('ForeldreansvarVilkarProsessIndex', () => {
   it('skal bestemme at 4-ledd ikke er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt4Ledd submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt4Ledd submitCallback={lagre} />);
 
     expect(await screen.findByText('Foreldreansvaret')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/Far har ikke rett til foreldrepenger, vilkåret er/));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), '1034');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1034');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/prosess/vilkar-omsorg/src/OmsorgVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-omsorg/src/OmsorgVilkarProsessIndex.spec.tsx
@@ -10,14 +10,14 @@ describe('OmsorgVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Omsorg')).toBeInTheDocument();
     expect(screen.getByText('Far rett til engangsstønad')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Far har rett til engangsstønad, vilkåret er oppfylt'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -35,20 +35,20 @@ describe('OmsorgVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret ikke er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Omsorg')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/Far har ikke rett til engangsstønad, vilkåret er/));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), '1011');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1011');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/prosess/vilkar-opptjening/src/OpptjeningVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-opptjening/src/OpptjeningVilkarProsessIndex.spec.tsx
@@ -17,7 +17,7 @@ describe('OpptjeningVilkarProsessIndex', () => {
   it('skal løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Opptjening')).toBeInTheDocument();
     expect(screen.getByText('Opptjent rett til foreldrepenger')).toBeInTheDocument();
@@ -27,7 +27,7 @@ describe('OpptjeningVilkarProsessIndex', () => {
 
     await userEvent.click(screen.getByText('Søker har oppfylt krav om 6 mnd opptjening, vilkåret er oppfylt.'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -43,13 +43,13 @@ describe('OpptjeningVilkarProsessIndex', () => {
   it('skal validere at en ikke kan oppfylle vilkår når det ikke finnes aktiviteter', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunktMenUtenAktiviteter submitCallback={lagre} />);
+    render(<ÅpentAksjonspunktMenUtenAktiviteter submitCallback={lagre} />);
 
     expect(await screen.findByText('Opptjening')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Søker har oppfylt krav om 6 mnd opptjening, vilkåret er oppfylt.'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/prosess/vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.spec.tsx
@@ -11,7 +11,7 @@ describe('VilkarresultatMedOverstyringProsessIndex', () => {
   it('skal overstyre og fylle ut fødselsvilkåret ikke er oppfylt og så lagre', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<OverstyringspanelForFødsel submitCallback={lagre} />);
+    render(<OverstyringspanelForFødsel submitCallback={lagre} />);
 
     expect(await screen.findByText('Fødsel')).toBeInTheDocument();
     expect(screen.getByText('Vilkåret er oppfylt')).toBeInTheDocument();
@@ -26,9 +26,9 @@ describe('VilkarresultatMedOverstyringProsessIndex', () => {
 
     expect(await screen.findByText('Avslagsårsak')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), 'Dette er en avslagsårsak');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), 'Dette er en avslagsårsak');
 
-    const vurderingInput = utils.getByLabelText('Begrunnelse');
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft overstyring'));
@@ -59,7 +59,7 @@ describe('VilkarresultatMedOverstyringProsessIndex', () => {
   it('skal overstyre og fylle ut medlemskapsvilkåret ikke er oppfylt og så lagre', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<OverstyringspanelForMedlemskap submitCallback={lagre} />);
+    render(<OverstyringspanelForMedlemskap submitCallback={lagre} />);
 
     expect(await screen.findByText('Medlemskap')).toBeInTheDocument();
     expect(screen.getByText('Vilkåret er oppfylt')).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('VilkarresultatMedOverstyringProsessIndex', () => {
     await userEvent.type(opphørDatoInput, '20.12.2021');
     fireEvent.blur(opphørDatoInput);
 
-    const vurderingInput = utils.getByLabelText('Begrunnelse');
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft overstyring'));

--- a/packages/prosess/vilkar-sokers-opplysningsplikt/src/SokersOpplysningspliktVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-sokers-opplysningsplikt/src/SokersOpplysningspliktVilkarProsessIndex.spec.tsx
@@ -10,14 +10,14 @@ describe('SokersOpplysningspliktVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Søkers opplysningsplikt')).toBeInTheDocument();
     expect(screen.getByText('Manglende dokumentasjon')).toBeInTheDocument();
     expect(screen.getByText('Inntektsmelding')).toBeInTheDocument();
     expect(screen.getByText('Arbeidsgiver1 (1234)')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getAllByText(/Vilkåret er oppfylt/)[0]!);

--- a/packages/prosess/vilkar-soknadsfrist/src/SoknadsfristVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-soknadsfrist/src/SoknadsfristVilkarProsessIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('SoknadsfristVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret er oppfylt og så løse aksjonspunkt', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunkt submitCallback={lagre} />);
+    render(<ÅpentAksjonspunkt submitCallback={lagre} />);
 
     expect(await screen.findByText('Søknadsfrist')).toBeInTheDocument();
     expect(screen.getByText(/Søknaden ble mottatt/)).toBeInTheDocument();
@@ -24,7 +24,7 @@ describe('SoknadsfristVilkarProsessIndex', () => {
 
     await userEvent.click(screen.getAllByText('Vilkåret er oppfylt')[0]!);
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/prosess/vilkar-svangerskap/src/SvangerskapVilkarProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-svangerskap/src/SvangerskapVilkarProsessIndex.spec.tsx
@@ -11,7 +11,7 @@ describe('SvangerskapVilkarProsessIndex', () => {
   it('skal bestemme at vilkåret ikke er oppfylt fordi en ikke har perioder som kan innvilges', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunktSkalIkkeKunneInnvilge submitCallback={lagre} />);
+    render(<ÅpentAksjonspunktSkalIkkeKunneInnvilge submitCallback={lagre} />);
 
     expect(await screen.findByText('Svangerskap')).toBeInTheDocument();
     expect(screen.getByText('Rett til svangerskapspenger')).toBeInTheDocument();
@@ -19,9 +19,9 @@ describe('SvangerskapVilkarProsessIndex', () => {
 
     await userEvent.click(screen.getByText(/Mor har ikke rett til svangerskapspenger, vilkåret er/));
 
-    await userEvent.selectOptions(utils.getByLabelText('Avslagsårsak'), '1065');
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1065');
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -38,7 +38,7 @@ describe('SvangerskapVilkarProsessIndex', () => {
   it('skal kunne bestemme at vilkåret er oppfylt når en har perioder som kan innvilges', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ÅpentAksjonspunktSkalKunneInnvilge submitCallback={lagre} />);
+    render(<ÅpentAksjonspunktSkalKunneInnvilge submitCallback={lagre} />);
 
     expect(await screen.findByText('Svangerskap')).toBeInTheDocument();
     expect(screen.getByText('Rett til svangerskapspenger')).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe('SvangerskapVilkarProsessIndex', () => {
 
     await userEvent.click(screen.getByText('Mor har rett til svangerskapspenger, vilkåret er oppfylt'));
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
     await userEvent.type(vurderingInput, 'Dette er en vurdering');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));

--- a/packages/sak/dekorator/src/DekoratorMedFeilviserSakIndex.spec.tsx
+++ b/packages/sak/dekorator/src/DekoratorMedFeilviserSakIndex.spec.tsx
@@ -6,7 +6,7 @@ import * as stories from './DekoratorMedFeilviserSakIndex.stories';
 
 const { UtenFeilmeldinger, MedFeilmeldinger, MedFeilmeldingDetaljer } = composeStories(stories);
 
-describe('DekoratorSakIndex', () => {
+describe('DekoratorMedFeilviserSakIndex', () => {
   it('skal vise dekoratør uten feilmeldinger', async () => {
     render(<UtenFeilmeldinger />);
     expect(await screen.findByText('Nav')).toBeInTheDocument();

--- a/packages/sak/fagsak-profil/src/FagsakProfilSakIndex.spec.tsx
+++ b/packages/sak/fagsak-profil/src/FagsakProfilSakIndex.spec.tsx
@@ -5,7 +5,7 @@ import * as stories from './FagsakProfilSakIndex.stories';
 
 const { Default } = composeStories(stories);
 
-describe('FagsakProfile', () => {
+describe('FagsakProfilSakIndex', () => {
   it('skal vise fagsak-profil', async () => {
     render(<Default />);
     expect(await screen.findByText('Foreldrepenger')).toBeInTheDocument();

--- a/packages/sak/meldinger/src/MeldingerSakIndex.spec.tsx
+++ b/packages/sak/meldinger/src/MeldingerSakIndex.spec.tsx
@@ -14,10 +14,10 @@ const brukerenHarIkkeAdresseText =
 describe('MeldingerSakIndex', () => {
   it('skal bruke default mal og sende brev', async () => {
     const lagre = vi.fn();
-    const utils = render(<Default submitCallback={lagre} />);
+    render(<Default submitCallback={lagre} />);
     expect(await screen.findByText('Mal')).toBeInTheDocument();
 
-    const begrunnelseInput = utils.getByLabelText('Liste over dokumenter (skriv ett dokument pr. linje)');
+    const begrunnelseInput = screen.getByLabelText('Liste over dokumenter (skriv ett dokument pr. linje)');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Send brev'));
@@ -42,11 +42,11 @@ describe('MeldingerSakIndex', () => {
 
   it('skal vise feltet årsak men ikke fritekst når en velger mal Revurderingsdokumentasjon og ikke Annet', async () => {
     const lagre = vi.fn();
-    const utils = render(<Default submitCallback={lagre} />);
+    render(<Default submitCallback={lagre} />);
     expect(await screen.findByText('Mal')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
-    await userEvent.selectOptions(utils.getByLabelText('Årsak'), 'BARNIKKEREG');
+    await userEvent.selectOptions(screen.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
+    await userEvent.selectOptions(screen.getByLabelText('Årsak'), 'BARNIKKEREG');
 
     await userEvent.click(screen.getByText('Send brev'));
 
@@ -60,13 +60,13 @@ describe('MeldingerSakIndex', () => {
 
   it('skal vise feltet årsak og fritekst når en velger mal Revurderingsdokumentasjon og Annet', async () => {
     const lagre = vi.fn();
-    const utils = render(<Default submitCallback={lagre} />);
+    render(<Default submitCallback={lagre} />);
     expect(await screen.findByText('Mal')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
-    await userEvent.selectOptions(utils.getByLabelText('Årsak'), 'ANNET');
+    await userEvent.selectOptions(screen.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
+    await userEvent.selectOptions(screen.getByLabelText('Årsak'), 'ANNET');
 
-    const begrunnelseInput = utils.getByLabelText('Fritekst');
+    const begrunnelseInput = screen.getByLabelText('Fritekst');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Send brev'));
@@ -82,10 +82,10 @@ describe('MeldingerSakIndex', () => {
 
   it('skal ikke vise årsaksverdi Barn ikke registrert for Svangerskapspenger', async () => {
     const lagre = vi.fn();
-    const utils = render(<ForSvangerskapspenger submitCallback={lagre} />);
+    render(<ForSvangerskapspenger submitCallback={lagre} />);
     expect(await screen.findByText('Mal')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
+    await userEvent.selectOptions(screen.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
 
     expect(await screen.findByText('Annet')).toBeInTheDocument();
     expect(screen.queryByText('Barn ikke registrert i folkeregisteret')).not.toBeInTheDocument();
@@ -94,10 +94,10 @@ describe('MeldingerSakIndex', () => {
 
   it('skal vise melding til saksbehandler at bruker ikke har en adresse registrert', async () => {
     const lagre = vi.fn();
-    const utils = render(<BrukerManglerAdresse submitCallback={lagre} />);
+    render(<BrukerManglerAdresse submitCallback={lagre} />);
     expect(await screen.findByText('Mal')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
+    await userEvent.selectOptions(screen.getByLabelText('Mal'), 'VARREV' satisfies DokumentMalType);
 
     expect(await screen.findByText(brukerenHarIkkeAdresseText)).toBeInTheDocument();
   });

--- a/packages/sak/meny-henlegg/src/MenyHenleggIndex.spec.tsx
+++ b/packages/sak/meny-henlegg/src/MenyHenleggIndex.spec.tsx
@@ -10,7 +10,7 @@ const { ForFørstegangssøknad, ForKlage, ForInnsyn, ForTilbakekreving, ForTilba
 describe('MenyHenleggIndex', () => {
   it('skal velge henlegge behandling og så vise modal som viser at behandling er henlagt', async () => {
     const henleggBehandling = vi.fn(() => Promise.resolve());
-    const utils = render(<ForFørstegangssøknad henleggBehandling={henleggBehandling} />);
+    render(<ForFørstegangssøknad henleggBehandling={henleggBehandling} />);
     expect(await screen.findAllByText('Henlegg behandling')).toHaveLength(2);
     expect(screen.getAllByText('Henlegg behandling')[1]!.closest('button')).toBeDisabled();
 
@@ -21,9 +21,9 @@ describe('MenyHenleggIndex', () => {
     expect(screen.queryByText('Klagen er trukket')).not.toBeInTheDocument();
     expect(screen.queryByText('Innsynskrav er trukket')).not.toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Velg årsak'), 'HENLAGT_SØKNAD_TRUKKET');
+    await userEvent.selectOptions(screen.getByLabelText('Velg årsak'), 'HENLAGT_SØKNAD_TRUKKET');
 
-    const begrunnelseInput = utils.getByLabelText('Begrunnelse');
+    const begrunnelseInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getAllByText('Henlegg behandling')[1]!);
@@ -115,10 +115,12 @@ describe('MenyHenleggIndex', () => {
 
   it('skal vise lenke for forhåndsvisning når en har valgt årsak Søknaden er trukket', async () => {
     const forhandsvisHenleggBehandling = vi.fn(() => Promise.resolve());
-    const utils = render(<ForFørstegangssøknad forhandsvisHenleggBehandling={forhandsvisHenleggBehandling} />);
+
+    render(<ForFørstegangssøknad forhandsvisHenleggBehandling={forhandsvisHenleggBehandling} />);
+
     expect(await screen.findAllByText('Henlegg behandling')).toHaveLength(2);
 
-    await userEvent.selectOptions(utils.getByLabelText('Velg årsak'), 'HENLAGT_SØKNAD_TRUKKET');
+    await userEvent.selectOptions(screen.getByLabelText('Velg årsak'), 'HENLAGT_SØKNAD_TRUKKET');
 
     expect(await screen.findByText('Informer søker')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Forhåndsvis brev'));
@@ -133,10 +135,12 @@ describe('MenyHenleggIndex', () => {
 
   it('skal ikke vise lenke for forhåndsvisning når en har valgt årsak Søknaden mangler', async () => {
     const forhandsvisHenleggBehandling = vi.fn(() => Promise.resolve());
-    const utils = render(<ForFørstegangssøknad forhandsvisHenleggBehandling={forhandsvisHenleggBehandling} />);
+
+    render(<ForFørstegangssøknad forhandsvisHenleggBehandling={forhandsvisHenleggBehandling} />);
+
     expect(await screen.findAllByText('Henlegg behandling')).toHaveLength(2);
 
-    await userEvent.selectOptions(utils.getByLabelText('Velg årsak'), 'HENLAGT_SØKNAD_MANGLER');
+    await userEvent.selectOptions(screen.getByLabelText('Velg årsak'), 'HENLAGT_SØKNAD_MANGLER');
 
     await waitFor(() => expect(screen.queryByText('Informer søker')).not.toBeInTheDocument());
   });

--- a/packages/sak/meny-ny-behandling/src/MenyNyBehandlingIndex.spec.tsx
+++ b/packages/sak/meny-ny-behandling/src/MenyNyBehandlingIndex.spec.tsx
@@ -10,10 +10,10 @@ describe('MenyNyBehandlingIndex', () => {
   it('skal opprette ny klagebehandling', async () => {
     const lagNyBehandling = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
+    render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
     expect(await screen.findByText('Opprett ny behandling')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByRole('combobox', { hidden: true }), 'BT-003');
+    await userEvent.selectOptions(screen.getByRole('combobox', { hidden: true }), 'BT-003');
 
     await userEvent.click(screen.getByText('OK'));
 
@@ -29,18 +29,18 @@ describe('MenyNyBehandlingIndex', () => {
       },
     });
 
-    expect(utils.queryByRole('checkbox', { hidden: true })).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { hidden: true })).not.toBeInTheDocument();
   });
 
   it('skal opprette ny førstegangssøknad og krysse av for at den er et resultat av klagebehandling', async () => {
     const lagNyBehandling = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
+    render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
     expect(await screen.findByText('Opprett ny behandling')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByRole('combobox', { hidden: true }), 'BT-002');
+    await userEvent.selectOptions(screen.getByRole('combobox', { hidden: true }), 'BT-002');
 
-    await userEvent.click(utils.getByRole('checkbox', { hidden: true }));
+    await userEvent.click(screen.getByRole('checkbox', { hidden: true }));
 
     await userEvent.click(screen.getByText('OK'));
 
@@ -61,10 +61,10 @@ describe('MenyNyBehandlingIndex', () => {
   it('skal opprette ny førstegangssøknad og ikke krysse av for at den er et resultat av klagebehandling', async () => {
     const lagNyBehandling = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
+    render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
     expect(await screen.findByText('Opprett ny behandling')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByRole('combobox', { hidden: true }), 'BT-002');
+    await userEvent.selectOptions(screen.getByRole('combobox', { hidden: true }), 'BT-002');
 
     await userEvent.click(screen.getByText('OK'));
 
@@ -85,12 +85,12 @@ describe('MenyNyBehandlingIndex', () => {
   it('skal velge årsak når en har valgt revurderingsbehandling', async () => {
     const lagNyBehandling = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
+    render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
     expect(await screen.findByText('Opprett ny behandling')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByRole('combobox', { hidden: true }), 'BT-004');
+    await userEvent.selectOptions(screen.getByRole('combobox', { hidden: true }), 'BT-004');
 
-    await userEvent.selectOptions(utils.getAllByRole('combobox', { hidden: true })[1]!, 'RE-KLAG-U-INNTK');
+    await userEvent.selectOptions(screen.getAllByRole('combobox', { hidden: true })[1]!, 'RE-KLAG-U-INNTK');
 
     await userEvent.click(screen.getByText('OK'));
 
@@ -111,14 +111,14 @@ describe('MenyNyBehandlingIndex', () => {
   it('skal gi feilmelding når obligatoriske felter ikke er fylt ut', async () => {
     const lagNyBehandling = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
+    render(<Default lagNyBehandling={lagNyBehandling} lukkModal={lukkModal} />);
     expect(await screen.findByText('Opprett ny behandling')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('OK'));
 
     expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByRole('combobox', { hidden: true }), 'BT-004');
+    await userEvent.selectOptions(screen.getByRole('combobox', { hidden: true }), 'BT-004');
 
     await waitFor(() => expect(screen.queryByText('Feltet må fylles ut')).not.toBeInTheDocument());
 

--- a/packages/sak/meny-sett-pa-vent/src/MenySettPaVentIndex.spec.tsx
+++ b/packages/sak/meny-sett-pa-vent/src/MenySettPaVentIndex.spec.tsx
@@ -18,10 +18,12 @@ describe('MenySettPaVentIndex', () => {
   it('skal velge årsak for sett på vent og så fortsette', async () => {
     const settBehandlingPaVent = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default settBehandlingPaVent={settBehandlingPaVent} lukkModal={lukkModal} />);
+
+    render(<Default settBehandlingPaVent={settBehandlingPaVent} lukkModal={lukkModal} />);
+
     expect(await screen.findByText('Behandlingen settes på vent')).toBeInTheDocument();
 
-    await userEvent.selectOptions(utils.getByLabelText('Årsak'), 'AVV_DOK');
+    await userEvent.selectOptions(screen.getByLabelText('Årsak'), 'AVV_DOK');
 
     await userEvent.click(screen.getByText('OK'));
 

--- a/packages/sak/meny/src/endreEnhet/MenyEndreBehandlendeEnhetIndex.spec.tsx
+++ b/packages/sak/meny/src/endreEnhet/MenyEndreBehandlendeEnhetIndex.spec.tsx
@@ -10,14 +10,16 @@ describe('MenyEndreBehandlendeEnhetIndex', () => {
   it('skal velge og lagre ny enhet', async () => {
     const lagreNyBehandlendeEnhet = vi.fn();
     const lukkModal = vi.fn();
-    const utils = render(<Default nyBehandlendeEnhet={lagreNyBehandlendeEnhet} lukkModal={lukkModal} />);
+
+    render(<Default nyBehandlendeEnhet={lagreNyBehandlendeEnhet} lukkModal={lukkModal} />);
+
     expect(await screen.findByText('Endre behandlende enhet for valgt behandling')).toBeInTheDocument();
     expect(screen.getByText('OK').closest('button')).toBeDisabled();
 
-    const begrunnelseInput = utils.getByLabelText('Begrunnelse');
+    const begrunnelseInput = screen.getByLabelText('Begrunnelse');
     await userEvent.type(begrunnelseInput, 'Dette er en begrunnelse');
 
-    await userEvent.selectOptions(utils.getByLabelText('Ny enhet'), '0');
+    await userEvent.selectOptions(screen.getByLabelText('Ny enhet'), '0');
 
     expect(await screen.findByText('OK')).toBeEnabled();
     await userEvent.click(screen.getByText('OK'));

--- a/packages/sak/notat/src/NotatSakIndex.spec.tsx
+++ b/packages/sak/notat/src/NotatSakIndex.spec.tsx
@@ -10,7 +10,7 @@ describe('NotatSakIndex', () => {
   it('skal legge til notat', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<Default lagreNotat={lagre} />);
+    render(<Default lagreNotat={lagre} />);
 
     expect(await screen.findByText('Dette er et notat skrevet av Espen som nå er innlogget')).toBeInTheDocument();
     expect(screen.getByText('Du')).toBeInTheDocument();
@@ -24,7 +24,7 @@ describe('NotatSakIndex', () => {
 
     expect(screen.getByText('Kun saksbehandlere får se notatet')).toBeInTheDocument();
 
-    const notatInput = utils.getByRole('textbox');
+    const notatInput = screen.getByRole('textbox');
     await userEvent.type(notatInput, 'Dette er et notat');
 
     await userEvent.click(screen.getByText('Legg til notat'));

--- a/packages/sak/risikoklassifisering/src/RisikoklassifiseringSakIndex.spec.tsx
+++ b/packages/sak/risikoklassifisering/src/RisikoklassifiseringSakIndex.spec.tsx
@@ -19,7 +19,7 @@ describe('RisikoklassifiseringSakIndex', () => {
 
   it('skal vurdere faresignaler som ikke reelle', async () => {
     const lagreAksjonspunkt = vi.fn();
-    const utils = render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
+    render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
     expect(await screen.findByText('Faresignaler oppdaget')).toBeInTheDocument();
     expect(await screen.findByText('Vurder faresignalene')).toBeInTheDocument();
 
@@ -31,7 +31,7 @@ describe('RisikoklassifiseringSakIndex', () => {
     expect(await screen.findByText('Faresignal 3')).toBeInTheDocument();
     expect(await screen.findByText('Faresignal 4')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
 
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Faresignalene vurderes ikke som reelle'));
@@ -47,7 +47,7 @@ describe('RisikoklassifiseringSakIndex', () => {
 
   it('skal vurdere faresignaler som reelle', async () => {
     const lagreAksjonspunkt = vi.fn();
-    const utils = render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
+    render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
     expect(await screen.findByText('Faresignaler oppdaget')).toBeInTheDocument();
     expect(screen.getByText('Vurder faresignalene')).toBeInTheDocument();
 
@@ -59,7 +59,7 @@ describe('RisikoklassifiseringSakIndex', () => {
     expect(screen.getByText('Faresignal 3')).toBeInTheDocument();
     expect(screen.getByText('Faresignal 4')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
 
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Faresignalene vurderes som reelle'));
@@ -76,11 +76,11 @@ describe('RisikoklassifiseringSakIndex', () => {
 
   it('skal få feilmelding når en ikke krysser av type vurdering og vurdering er for kort', async () => {
     const lagreAksjonspunkt = vi.fn();
-    const utils = render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
+    render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
     expect(await screen.findByText('Faresignaler oppdaget')).toBeInTheDocument();
     expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
 
     await userEvent.type(vurderingInput, 'De');
 
@@ -96,10 +96,10 @@ describe('RisikoklassifiseringSakIndex', () => {
 
   it('skal få feilmelding når en ikke krysser av grunn til at sak er innvilget eller avslått', async () => {
     const lagreAksjonspunkt = vi.fn();
-    const utils = render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
+    render(<HøyRisikoklassifisering submitAksjonspunkt={lagreAksjonspunkt} />);
     expect(await screen.findByText('Faresignaler oppdaget')).toBeInTheDocument();
 
-    const vurderingInput = utils.getByLabelText('Vurdering');
+    const vurderingInput = screen.getByLabelText('Vurdering');
 
     await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Faresignalene vurderes som reelle'));

--- a/packages/sak/sok/src/FagsakSokSakIndex.spec.tsx
+++ b/packages/sak/sok/src/FagsakSokSakIndex.spec.tsx
@@ -8,11 +8,11 @@ const { Default, IkkeAdgang, IngenTreff } = composeStories(stories);
 
 describe('FagsakSokSakIndex', () => {
   it('skal skrive inn ikke gyldig saksnummer og få feilmelding', async () => {
-    const utils = render(<Default />);
+    render(<Default />);
     expect(await screen.findByText('Søk på sak eller person')).toBeInTheDocument();
     expect(screen.getByText('Søk').closest('button')).toBeDisabled();
 
-    const nrInput = utils.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
+    const nrInput = screen.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
     await userEvent.type(nrInput, 'TEST');
 
     expect(await screen.findByText('Søk')).toBeEnabled();
@@ -23,11 +23,11 @@ describe('FagsakSokSakIndex', () => {
   });
 
   it('skal skrive inn gyldig saksnummer og få opp to treff', async () => {
-    const utils = render(<Default />);
+    render(<Default />);
     expect(await screen.findByText('Søk på sak eller person')).toBeInTheDocument();
     expect(screen.getByText('Søk').closest('button')).toBeDisabled();
 
-    const nrInput = utils.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
+    const nrInput = screen.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
     await userEvent.type(nrInput, '123');
 
     expect(await screen.findByText('Søk')).toBeEnabled();
@@ -49,12 +49,12 @@ describe('FagsakSokSakIndex', () => {
   });
 
   it('skal ikke få noen treff på søk', async () => {
-    const utils = render(<IngenTreff />);
+    render(<IngenTreff />);
 
     expect(await screen.findByText('Søk på sak eller person')).toBeInTheDocument();
     expect(screen.getByText('Søk').closest('button')).toBeDisabled();
 
-    const nrInput = utils.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
+    const nrInput = screen.getByLabelText('Saksnummer eller fødselsnummer/D-nummer');
     await userEvent.type(nrInput, '123');
 
     expect(await screen.findByText('Søk')).toBeEnabled();

--- a/packages/sak/totrinnskontroll/src/TotrinnskontrollSakIndex.spec.tsx
+++ b/packages/sak/totrinnskontroll/src/TotrinnskontrollSakIndex.spec.tsx
@@ -56,7 +56,7 @@ describe('TotrinnskontrollSakIndex', () => {
   it('skal sende tilbake til saksbehandler fordi det er feil i fakta og feil i lovanvendelse', async () => {
     const lagre = vi.fn();
 
-    const utils = render(<ForBeslutter onSubmit={lagre} />);
+    render(<ForBeslutter onSubmit={lagre} />);
 
     expect(await screen.findByText('Kontroller endrede opplysninger og faglige vurderinger')).toBeInTheDocument();
     expect(screen.getByText('Formkrav klage NFP')).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('TotrinnskontrollSakIndex', () => {
     await userEvent.click(screen.getByText('Fakta'));
     await userEvent.click(screen.getByText('Regel-/lovanvendelse'));
 
-    const begrunnelseInput = utils.getAllByLabelText('Begrunnelse');
+    const begrunnelseInput = screen.getAllByLabelText('Begrunnelse');
     await userEvent.type(begrunnelseInput[1]!, 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Send til saksbehandler'));

--- a/packages/sak/totrinnskontroll/src/components/aksjonspunktTekster/OpptjeningTotrinnText.spec.tsx
+++ b/packages/sak/totrinnskontroll/src/components/aksjonspunktTekster/OpptjeningTotrinnText.spec.tsx
@@ -34,7 +34,7 @@ const lagOpptjeningAktivitet = (resultat: string): OpptjeningAktiviteter => ({
   godkjent: resultat === 'GODKJENT',
 });
 
-describe('OpptjeningTotrinnnText', () => {
+describe('OpptjeningTotrinnText', () => {
   it('skal vise korrekt tekst for opptjening med endring av arbeid med navn', async () => {
     render(
       <RawIntlProvider value={intlMock}>

--- a/packages/sak/ukjent-adresse/src/UkjentAdresseMeldingIndex.spec.tsx
+++ b/packages/sak/ukjent-adresse/src/UkjentAdresseMeldingIndex.spec.tsx
@@ -5,7 +5,7 @@ import * as stories from './UkjentAdresseMeldingIndex.stories';
 
 const { IngenAdresse } = composeStories(stories);
 
-describe('IngenAdresse', () => {
+describe('UkjentAdresseMeldingIndex', () => {
   it('skal vise panelet om brukeren mangler adresse', async () => {
     render(<IngenAdresse />);
     expect(

--- a/packages/sak/visittkort/src/components/VisittkortLabels.spec.tsx
+++ b/packages/sak/visittkort/src/components/VisittkortLabels.spec.tsx
@@ -11,7 +11,7 @@ import messages from '../../i18n/nb_NO.json';
 
 const intl = createIntl(messages);
 
-describe('VisittkortSakIndex', () => {
+describe('VisittkortLabels', () => {
   const fagsakPerson: Person = {
     navn: 'Olga Utvikler',
     kjønn: 'K',


### PR DESCRIPTION
Jeg har prøvd å gjøre en refaktorering vha. en codemod som er generert av ai, og har brukt [jscodeshift](https://github.com/facebook/jscodeshift) til å utføre den.

Her er promt:
```txt
I need a jscodeshift codemod written in TypeScript.

The codemod should:
Find all statements like const X = render(<Something />) (where X is any variable name).
Replace those lines with just render(<Something />);.
Replace all usages of that variable (X.getByText(...), X.queryByRole(...), etc.) with screen.getByText(...).
Add an import for screen from @testing-library/react if it’s used in the file and not already imported.
Replace the name in the outermost describe to be the basename of the test file, without the postfix '.spec.tsx'

Don’t:
Replace or break other variable declarations.
Leave behind invalid code like const undefined;.

Requirements:
Must work with TypeScript and JSX.
Use jscodeshift API idiomatically.
The output should be a self-contained codemod file with export default function transform(...).
Provide a minimal example input and output for clarity.
```

OUTPUT:
```ts
import { basename } from 'path';
import { API, FileInfo, JSCodeshift, Collection } from 'jscodeshift';

const TEST_LIB = '@testing-library/react';
const RENDER_FN = 'render';
const SCREEN_ID = 'screen';

function getBasenameWithoutSpec(filePath: string): string {
  const base = basename(filePath).replace(/\.spec\.tsx?$/, '');
  return base;
}

function hasScreenImport(j: JSCodeshift, root: Collection): boolean {
  return root
    .find(j.ImportDeclaration, {
      source: { value: TEST_LIB },
    })
    .some(imp => imp.node.specifiers?.some(s => s.type === 'ImportSpecifier' && s.imported.name === SCREEN_ID));
}

function addScreenImport(j: JSCodeshift, root: Collection) {
  const imports = root.find(j.ImportDeclaration, {
    source: { value: TEST_LIB },
  });
  if (imports.size() > 0) {
    imports.forEach(imp => {
      const specifiers = imp.node.specifiers || [];
      if (!specifiers.some(s => s.type === 'ImportSpecifier' && s.imported.name === SCREEN_ID)) {
        specifiers.push(j.importSpecifier(j.identifier(SCREEN_ID)));
        imp.node.specifiers = specifiers;
      }
    });
  } else {
    root
      .find(j.Statement)
      .at(0)
      .insertBefore(j.importDeclaration([j.importSpecifier(j.identifier(SCREEN_ID))], j.literal(TEST_LIB)));
  }
}

export default function transform(file: FileInfo, api: API) {
  const j = api.jscodeshift;
  const root = j(file.source);

  // 1. Find all `const X = render(<Something />)`
  const renderVars: string[] = [];
  root.find(j.VariableDeclaration).forEach(vd => {
    vd.node.declarations.forEach(decl => {
      if (
        decl.id.type === 'Identifier' &&
        decl.init &&
        decl.init.type === 'CallExpression' &&
        decl.init.callee.type === 'Identifier' &&
        decl.init.callee.name === RENDER_FN &&
        decl.init.arguments.length === 1 &&
        (decl.init.arguments[0].type === 'JSXElement' || decl.init.arguments[0].type === 'JSXFragment')
      ) {
        renderVars.push(decl.id.name);
        // Replace with just `render(<Something />);`
        j(vd).replaceWith(j.expressionStatement(j.callExpression(j.identifier(RENDER_FN), decl.init.arguments)));
      }
    });
  });

  // 2. Replace all usages of X.getByText(...) etc. with screen.getByText(...)
  let usedScreen = false;
  renderVars.forEach(varName => {
    root
      .find(j.MemberExpression, {
        object: { type: 'Identifier', name: varName },
      })
      .forEach(path => {
        path.node.object = j.identifier(SCREEN_ID);
        usedScreen = true;
      });
  });

  // 3. Add import for screen if needed
  if (usedScreen && !hasScreenImport(j, root)) {
    addScreenImport(j, root);
  }

  // 4. Replace outermost describe name
  const baseName = getBasenameWithoutSpec(file.path);
  root
    .find(j.CallExpression, {
      callee: { name: 'describe' },
    })
    .at(0)
    .forEach(path => {
      const firstArg = path.node.arguments[0];
      if (firstArg && firstArg.type === 'Literal') {
        firstArg.value = baseName;
      } else if (firstArg && firstArg.type === 'StringLiteral') {
        firstArg.value = baseName;
      }
    });

  return root.toSource();
}
```

Eksempel som modellen har outputtet basert på prompt
```tsx
// Example Input: 
import { render } from "@testing-library/react";
describe("hello world", () => {
  it("renders", () => {
    const utils = render(<MyComponent />);
    expect(utils.getByText("Hello")).toBeInTheDocument();
  });
});

//Example Output:
import { render, screen } from "@testing-library/react";
describe("MyComponent", () => {
  it("renders", () => {
    render(<MyComponent />);
    expect(screen.getByText("Hello")).toBeInTheDocument();
  });
});
```
