### PR TITLE
feat: legg til Copilot-skill for oppdatering av ft-pakker og peer deps

### DIFF
--- a/.github/skills/oppdater-ft-pakker.md
+++ b/.github/skills/oppdater-ft-pakker.md
@@ -24,10 +24,11 @@ git checkout -b oppdater-ft-pakker-$(date +%Y%m%d)
 
 ### 2. Oppdater alle @navikt/ft-\* pakker i alle workspaces
 
-Bruk `yarn up --exact --recursive` for å oppdatere i alle workspaces:
+> **Merk:** `--exact` og `--recursive` kan ikke brukes samtidig i Yarn Berry.
+> Siden pakkene allerede bruker eksakte versjoner er `--recursive` alene tilstrekkelig:
 
 ```bash
-yarn up --exact --recursive '@navikt/ft-*'
+yarn up --recursive '@navikt/ft-*'
 ```
 
 ### 3. Installer oppdaterte avhengigheter
@@ -41,11 +42,10 @@ yarn install
 Kjør dette skriptet for å finne hvilke versjoner av peer dependencies ft-pakkene krever:
 
 ```bash
-node -e "
+node << 'SCRIPT'
 const fs = require('fs');
 const path = require('path');
 const nm = 'node_modules/@navikt';
-
 const peerPkgs = {};
 const dirs = fs.readdirSync(nm).filter(d => d.startsWith('ft-'));
 for (const dir of dirs) {
@@ -63,26 +63,51 @@ for (const dir of dirs) {
 for (const [dep, ranges] of Object.entries(peerPkgs)) {
   console.log(dep + ': ' + [...ranges].join(', '));
 }
-"
+SCRIPT
 ```
 
 ### 5. Oppdater peer dependencies til riktig versjon
 
-Bruk `yarn up --exact --recursive` for å oppdatere peer dependencies.
-Versjonene skal matche det ft-pakkene krever (f.eks. `8.x` betyr nyeste `8.*`-versjon).
+Siden pakkene er eksakt-pinnet i package.json kan ikke `yarn up` bumpe dem uten `--exact`.
+Bruk dette Node.js-skriptet til å oppdatere alle package.json-filer direkte.
+Tilpass versjonene basert på output fra steg 4 (f.eks. `8.x` → bruk nyeste `8.*` fra npm):
 
 ```bash
-yarn up --exact --recursive '@navikt/aksel-*' '@navikt/ds-*' 'react-hook-form'
+node << 'SCRIPT'
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Tilpass disse versjonene basert på hva ft-pakkene krever (fra steg 4):
+const pkgs = {
+  '@navikt/aksel-icons': 'FYLL_INN',      // f.eks. '8.9.1'
+  '@navikt/ds-css': 'FYLL_INN',
+  '@navikt/ds-react': 'FYLL_INN',
+  '@navikt/ds-tailwind': 'FYLL_INN',
+  '@navikt/ds-tokens': 'FYLL_INN',
+  '@navikt/aksel-stylelint': 'FYLL_INN',
+  'react-hook-form': 'FYLL_INN',          // f.eks. '7.72.1'
+};
+
+const result = execSync("find . -name 'package.json' -not -path '*/node_modules/*'", { encoding: 'utf8' });
+const files = result.trim().split('\n');
+let updatedFiles = 0;
+for (const file of files) {
+  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+  let changed = false;
+  for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    if (!json[section]) continue;
+    for (const [pkg, newVer] of Object.entries(pkgs)) {
+      if (json[section][pkg] && json[section][pkg] !== newVer) {
+        json[section][pkg] = newVer;
+        changed = true;
+      }
+    }
+  }
+  if (changed) { fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n'); updatedFiles++; }
+}
+console.log('Oppdaterte ' + updatedFiles + ' filer');
+SCRIPT
 ```
-
-Dersom ft-pakkene krever en spesifikk major (f.eks. `8.x`), bruk:
-
-```bash
-yarn up --exact --recursive '@navikt/aksel-*@8' '@navikt/ds-*@8' 'react-hook-form@7'
-```
-
-> **Viktig:** Tilpass major-versjonen basert på output fra steg 4. Hvis ft-pakkene
-> krever `9.x`, bruk `@9`, osv.
 
 ### 6. Installer igjen for å oppdatere yarn.lock
 
@@ -121,6 +146,9 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 
 ```bash
 git push --set-upstream origin $(git branch --show-current)
+```
+
+```bash
 gh pr create \
   --title "deps: oppdater @navikt/ft-* og peer dependencies" \
   --body "## Endringer
@@ -141,6 +169,7 @@ Oppdaterer alle \`@navikt/ft-*\` pakker til nyeste versjon og synkroniserer peer
 
 ## Feilsøking
 
-- Hvis `yarn up` feiler for enkeltpakker som ikke finnes i alle workspaces, er det normalt — yarn hopper over dem.
+- `--exact` og `--recursive` kan ikke brukes samtidig — bruk `--recursive` alene, og oppdater package.json-filer med Node.js-skriptet i steg 5.
+- Hvis `yarn up` ikke finner oppdateringer, kan pakkene allerede være på nyeste versjon.
 - Hvis bygget feiler etter oppdatering, sjekk changelog for ft-pakkene for breaking changes.
 - Hvis peer dependency-versjoner er motstridende mellom ulike ft-pakker, velg den høyeste major-versjonen som er kompatibel med alle.

--- a/.github/skills/oppdater-ft-pakker.md
+++ b/.github/skills/oppdater-ft-pakker.md
@@ -6,7 +6,7 @@ description: >
   slik at de matcher versjonene brukt av ft-pakkene. Lager en PR med endringene.
 ---
 
-# Oppdater @navikt/ft-* pakker og peer dependencies
+# Oppdater @navikt/ft-\* pakker og peer dependencies
 
 ## Mål
 
@@ -22,9 +22,8 @@ slik at de matcher versjonskravene spesifisert av de oppdaterte ft-pakkene.
 git checkout -b oppdater-ft-pakker-$(date +%Y%m%d)
 ```
 
-### 2. Oppdater alle @navikt/ft-* pakker i alle workspaces
+### 2. Oppdater alle @navikt/ft-\* pakker i alle workspaces
 
-> **Merk:** `--exact` og `--recursive` kan ikke brukes samtidig i Yarn Berry.
 > Siden pakkene allerede bruker eksakte versjoner er `--recursive` alene tilstrekkelig:
 
 ```bash
@@ -39,32 +38,32 @@ yarn install
 
 ### 4. Finn versjoner som skal brukes for aksel og react-hook-form
 
-Les peerDependencies direkte fra de installerte ft-pakkene i node_modules:
+Les dependencies direkte fra de installerte ft-pakkene i node_modules:
 
 ```bash
-node -e "console.log(require('./node_modules/@navikt/ft-form-hooks/package.json').peerDependencies['@navikt/ds-react'])"
+node -e "console.log(require('./node_modules/@navikt/ft-form-hooks/package.json').dependencies['@navikt/ds-react'])"
 ```
 
 ```bash
-node -e "console.log(require('./node_modules/@navikt/ft-form-hooks/package.json').peerDependencies['react-hook-form'])"
+node -e "console.log(require('./node_modules/@navikt/ft-form-hooks/package.json').dependencies['react-hook-form'])"
 ```
 
-Eksempel på output: `8.x` og `7.x`. Bruk disse versjonene i neste steg.
+Eksempel på output: `8.5.2` og `7.71.1`. Bruk disse versjonene i neste steg.
 
 ### 5. Oppdater peer dependencies med yarn up
 
 Bruk versjonene fra steg 4 direkte med `yarn up --recursive`.
-Erstatt `8` og `7` med major-versjonene fra steg 4 om de har endret seg:
+Erstatt `8.5.2` og `7.71.1` med nøyaktig-versjonene fra steg 4 om de har endret seg:
 
 ```bash
 yarn up --recursive \
-  '@navikt/ds-react@8' \
-  '@navikt/ds-css@8' \
-  '@navikt/ds-tailwind@8' \
-  '@navikt/ds-tokens@8' \
-  '@navikt/aksel-icons@8' \
-  '@navikt/aksel-stylelint@8' \
-  'react-hook-form@7'
+  '@navikt/ds-react@8.5.2' \
+  '@navikt/ds-css@8.5.2' \
+  '@navikt/ds-tailwind@8.5.2' \
+  '@navikt/ds-tokens@8.5.2' \
+  '@navikt/aksel-icons@8.5.2' \
+  '@navikt/aksel-stylelint@8.5.2' \
+  'react-hook-form@7.71.1'
 ```
 
 Verifiser de eksakte versjonene som ble installert:
@@ -122,13 +121,17 @@ Oppdaterer alle \`@navikt/ft-*\` pakker til nyeste versjon og synkroniserer peer
 
 ### Verifisering
 - [ ] Bygg passerer
-- [ ] Ingen breaking changes i API" \
   --label "dependencies"
 ```
 
 ## Feilsøking
 
-- `--exact` og `--recursive` kan ikke brukes samtidig — bruk `--recursive` med `pkg@major` (f.eks. `react-hook-form@7`).
-- Hvis `yarn up` ikke finner oppdateringer, kan pakkene allerede være på nyeste versjon.
+- Hvis `yarn up` ikke finner oppdateringer, kan pakkene allerede være på nyeste versjon. Eventuelt sjekk om når siste
+  publisering i ft-frontend-saksbehandling ble kjørt.
+  `gh run list --workflow=publish.yml --limit=1 --repo navikt/ft-frontend-saksbehandling`
 - Hvis bygget feiler etter oppdatering, sjekk changelog for ft-pakkene for breaking changes.
-- Hvis peer dependency-versjoner er motstridende mellom ulike ft-pakker, velg den høyeste major-versjonen som er kompatibel med alle.
+- Hvis yarn ikke finner ny versjon av react-hook-form, kan dette skyldes `npmMinimalAgeGate`. I såfall midlertidig legg
+  til `react-hook-form@x.y.z` under `npmPreapprovedPackages`-seksjonen i `.yarnrc.yml`-filen, der `x.y.z` er den eksakte
+  versjonen brukt av ft-pakkene.
+- Hvis dependency-versjoner er motstridende mellom ulike ft-pakker, velg den høyeste major-versjonen som er kompatibel
+  med alle.

--- a/.github/skills/oppdater-ft-pakker.md
+++ b/.github/skills/oppdater-ft-pakker.md
@@ -1,0 +1,146 @@
+---
+name: oppdater-ft-pakker
+description: >
+  Oppdaterer @navikt/ft-* pakker til nyeste versjon og synkroniserer
+  peer dependencies (react-hook-form, @navikt/aksel-*, @navikt/ds-*)
+  slik at de matcher versjonene brukt av ft-pakkene. Lager en PR med endringene.
+---
+
+# Oppdater @navikt/ft-\* pakker og peer dependencies
+
+## Mål
+
+Oppdater alle `@navikt/ft-*` pakker til nyeste versjon, og deretter oppdater
+peer dependencies `react-hook-form`, `@navikt/aksel-*` og `@navikt/ds-*`
+slik at de matcher versjonskravene spesifisert av de oppdaterte ft-pakkene.
+
+## Steg
+
+### 1. Opprett en ny branch
+
+```bash
+git checkout -b oppdater-ft-pakker-$(date +%Y%m%d)
+```
+
+### 2. Oppdater alle @navikt/ft-\* pakker i alle workspaces
+
+Bruk `yarn up --exact --recursive` for å oppdatere i alle workspaces:
+
+```bash
+yarn up --exact --recursive '@navikt/ft-*'
+```
+
+### 3. Installer oppdaterte avhengigheter
+
+```bash
+yarn install
+```
+
+### 4. Les peer dependency-krav fra oppdaterte ft-pakker
+
+Kjør dette skriptet for å finne hvilke versjoner av peer dependencies ft-pakkene krever:
+
+```bash
+node -e "
+const fs = require('fs');
+const path = require('path');
+const nm = 'node_modules/@navikt';
+
+const peerPkgs = {};
+const dirs = fs.readdirSync(nm).filter(d => d.startsWith('ft-'));
+for (const dir of dirs) {
+  const pkgPath = path.join(nm, dir, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const peers = pkg.peerDependencies || {};
+  for (const [dep, range] of Object.entries(peers)) {
+    if (dep.startsWith('@navikt/aksel') || dep.startsWith('@navikt/ds-') || dep === 'react-hook-form') {
+      if (!peerPkgs[dep]) peerPkgs[dep] = new Set();
+      peerPkgs[dep].add(range);
+    }
+  }
+}
+for (const [dep, ranges] of Object.entries(peerPkgs)) {
+  console.log(dep + ': ' + [...ranges].join(', '));
+}
+"
+```
+
+### 5. Oppdater peer dependencies til riktig versjon
+
+Bruk `yarn up --exact --recursive` for å oppdatere peer dependencies.
+Versjonene skal matche det ft-pakkene krever (f.eks. `8.x` betyr nyeste `8.*`-versjon).
+
+```bash
+yarn up --exact --recursive '@navikt/aksel-*' '@navikt/ds-*' 'react-hook-form'
+```
+
+Dersom ft-pakkene krever en spesifikk major (f.eks. `8.x`), bruk:
+
+```bash
+yarn up --exact --recursive '@navikt/aksel-*@8' '@navikt/ds-*@8' 'react-hook-form@7'
+```
+
+> **Viktig:** Tilpass major-versjonen basert på output fra steg 4. Hvis ft-pakkene
+> krever `9.x`, bruk `@9`, osv.
+
+### 6. Installer igjen for å oppdatere yarn.lock
+
+```bash
+yarn install
+```
+
+### 7. Verifiser at alt bygger
+
+```bash
+yarn build --filter=@navikt/fp-frontend
+```
+
+### 8. Sjekk hvilke versjoner som ble oppdatert
+
+```bash
+git --no-pager diff --stat
+```
+
+Verifiser at `package.json`-filer og `yarn.lock` er oppdatert korrekt.
+
+### 9. Commit endringene
+
+```bash
+git add -A
+git commit -m "deps: oppdater @navikt/ft-* og peer dependencies
+
+Oppdaterer alle @navikt/ft-* pakker til nyeste versjon.
+Synkroniserer react-hook-form, @navikt/aksel-* og @navikt/ds-*
+slik at de matcher versjonskravene fra ft-pakkene.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### 10. Push og opprett PR
+
+```bash
+git push --set-upstream origin $(git branch --show-current)
+gh pr create \
+  --title "deps: oppdater @navikt/ft-* og peer dependencies" \
+  --body "## Endringer
+
+Oppdaterer alle \`@navikt/ft-*\` pakker til nyeste versjon og synkroniserer peer dependencies.
+
+### Oppdaterte pakker
+- \`@navikt/ft-*\` — oppdatert til nyeste versjon
+- \`@navikt/aksel-*\` — oppdatert til versjon brukt av ft-pakkene
+- \`@navikt/ds-*\` — oppdatert til versjon brukt av ft-pakkene
+- \`react-hook-form\` — oppdatert til versjon brukt av ft-pakkene
+
+### Verifisering
+- [ ] Bygg passerer
+- [ ] Ingen breaking changes i API" \
+  --label "dependencies"
+```
+
+## Feilsøking
+
+- Hvis `yarn up` feiler for enkeltpakker som ikke finnes i alle workspaces, er det normalt — yarn hopper over dem.
+- Hvis bygget feiler etter oppdatering, sjekk changelog for ft-pakkene for breaking changes.
+- Hvis peer dependency-versjoner er motstridende mellom ulike ft-pakker, velg den høyeste major-versjonen som er kompatibel med alle.

--- a/.github/skills/oppdater-ft-pakker.md
+++ b/.github/skills/oppdater-ft-pakker.md
@@ -6,7 +6,7 @@ description: >
   slik at de matcher versjonene brukt av ft-pakkene. Lager en PR med endringene.
 ---
 
-# Oppdater @navikt/ft-\* pakker og peer dependencies
+# Oppdater @navikt/ft-* pakker og peer dependencies
 
 ## Mål
 
@@ -22,7 +22,7 @@ slik at de matcher versjonskravene spesifisert av de oppdaterte ft-pakkene.
 git checkout -b oppdater-ft-pakker-$(date +%Y%m%d)
 ```
 
-### 2. Oppdater alle @navikt/ft-\* pakker i alle workspaces
+### 2. Oppdater alle @navikt/ft-* pakker i alle workspaces
 
 > **Merk:** `--exact` og `--recursive` kan ikke brukes samtidig i Yarn Berry.
 > Siden pakkene allerede bruker eksakte versjoner er `--recursive` alene tilstrekkelig:
@@ -37,91 +37,50 @@ yarn up --recursive '@navikt/ft-*'
 yarn install
 ```
 
-### 4. Les peer dependency-krav fra oppdaterte ft-pakker
+### 4. Finn versjoner som skal brukes for aksel og react-hook-form
 
-Kjør dette skriptet for å finne hvilke versjoner av peer dependencies ft-pakkene krever:
-
-```bash
-node << 'SCRIPT'
-const fs = require('fs');
-const path = require('path');
-const nm = 'node_modules/@navikt';
-const peerPkgs = {};
-const dirs = fs.readdirSync(nm).filter(d => d.startsWith('ft-'));
-for (const dir of dirs) {
-  const pkgPath = path.join(nm, dir, 'package.json');
-  if (!fs.existsSync(pkgPath)) continue;
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-  const peers = pkg.peerDependencies || {};
-  for (const [dep, range] of Object.entries(peers)) {
-    if (dep.startsWith('@navikt/aksel') || dep.startsWith('@navikt/ds-') || dep === 'react-hook-form') {
-      if (!peerPkgs[dep]) peerPkgs[dep] = new Set();
-      peerPkgs[dep].add(range);
-    }
-  }
-}
-for (const [dep, ranges] of Object.entries(peerPkgs)) {
-  console.log(dep + ': ' + [...ranges].join(', '));
-}
-SCRIPT
-```
-
-### 5. Oppdater peer dependencies til riktig versjon
-
-Siden pakkene er eksakt-pinnet i package.json kan ikke `yarn up` bumpe dem uten `--exact`.
-Bruk dette Node.js-skriptet til å oppdatere alle package.json-filer direkte.
-Tilpass versjonene basert på output fra steg 4 (f.eks. `8.x` → bruk nyeste `8.*` fra npm):
+Les peerDependencies direkte fra de installerte ft-pakkene i node_modules:
 
 ```bash
-node << 'SCRIPT'
-const fs = require('fs');
-const { execSync } = require('child_process');
-
-// Tilpass disse versjonene basert på hva ft-pakkene krever (fra steg 4):
-const pkgs = {
-  '@navikt/aksel-icons': 'FYLL_INN',      // f.eks. '8.9.1'
-  '@navikt/ds-css': 'FYLL_INN',
-  '@navikt/ds-react': 'FYLL_INN',
-  '@navikt/ds-tailwind': 'FYLL_INN',
-  '@navikt/ds-tokens': 'FYLL_INN',
-  '@navikt/aksel-stylelint': 'FYLL_INN',
-  'react-hook-form': 'FYLL_INN',          // f.eks. '7.72.1'
-};
-
-const result = execSync("find . -name 'package.json' -not -path '*/node_modules/*'", { encoding: 'utf8' });
-const files = result.trim().split('\n');
-let updatedFiles = 0;
-for (const file of files) {
-  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
-  let changed = false;
-  for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
-    if (!json[section]) continue;
-    for (const [pkg, newVer] of Object.entries(pkgs)) {
-      if (json[section][pkg] && json[section][pkg] !== newVer) {
-        json[section][pkg] = newVer;
-        changed = true;
-      }
-    }
-  }
-  if (changed) { fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n'); updatedFiles++; }
-}
-console.log('Oppdaterte ' + updatedFiles + ' filer');
-SCRIPT
+node -e "console.log(require('./node_modules/@navikt/ft-form-hooks/package.json').peerDependencies['@navikt/ds-react'])"
 ```
-
-### 6. Installer igjen for å oppdatere yarn.lock
 
 ```bash
-yarn install
+node -e "console.log(require('./node_modules/@navikt/ft-form-hooks/package.json').peerDependencies['react-hook-form'])"
 ```
 
-### 7. Verifiser at alt bygger
+Eksempel på output: `8.x` og `7.x`. Bruk disse versjonene i neste steg.
+
+### 5. Oppdater peer dependencies med yarn up
+
+Bruk versjonene fra steg 4 direkte med `yarn up --recursive`.
+Erstatt `8` og `7` med major-versjonene fra steg 4 om de har endret seg:
+
+```bash
+yarn up --recursive \
+  '@navikt/ds-react@8' \
+  '@navikt/ds-css@8' \
+  '@navikt/ds-tailwind@8' \
+  '@navikt/ds-tokens@8' \
+  '@navikt/aksel-icons@8' \
+  '@navikt/aksel-stylelint@8' \
+  'react-hook-form@7'
+```
+
+Verifiser de eksakte versjonene som ble installert:
+
+```bash
+node -e "console.log(require('./node_modules/@navikt/ds-react/package.json').version)"
+node -e "console.log(require('./node_modules/react-hook-form/package.json').version)"
+```
+
+### 6. Verifiser at alt bygger
 
 ```bash
 yarn build --filter=@navikt/fp-frontend
 ```
 
-### 8. Sjekk hvilke versjoner som ble oppdatert
+### 7. Sjekk hvilke versjoner som ble oppdatert
 
 ```bash
 git --no-pager diff --stat
@@ -129,7 +88,7 @@ git --no-pager diff --stat
 
 Verifiser at `package.json`-filer og `yarn.lock` er oppdatert korrekt.
 
-### 9. Commit endringene
+### 8. Commit endringene
 
 ```bash
 git add -A
@@ -142,7 +101,7 @@ slik at de matcher versjonskravene fra ft-pakkene.
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
 
-### 10. Push og opprett PR
+### 9. Push og opprett PR
 
 ```bash
 git push --set-upstream origin $(git branch --show-current)
@@ -169,7 +128,7 @@ Oppdaterer alle \`@navikt/ft-*\` pakker til nyeste versjon og synkroniserer peer
 
 ## Feilsøking
 
-- `--exact` og `--recursive` kan ikke brukes samtidig — bruk `--recursive` alene, og oppdater package.json-filer med Node.js-skriptet i steg 5.
+- `--exact` og `--recursive` kan ikke brukes samtidig — bruk `--recursive` med `pkg@major` (f.eks. `react-hook-form@7`).
 - Hvis `yarn up` ikke finner oppdateringer, kan pakkene allerede være på nyeste versjon.
 - Hvis bygget feiler etter oppdatering, sjekk changelog for ft-pakkene for breaking changes.
 - Hvis peer dependency-versjoner er motstridende mellom ulike ft-pakker, velg den høyeste major-versjonen som er kompatibel med alle.


### PR DESCRIPTION
## Beskrivelse

Legger til en Copilot-skill (`.github/skills/oppdater-ft-pakker.md`) som automatiserer oppdatering av `@navikt/ft-*` pakker og tilhørende peer dependencies.

## Hva gjør skill-en?

1. Oppretter en ny branch
2. Kjører `yarn up --exact --recursive '@navikt/ft-*'` for å oppdatere alle ft-pakker i alle workspaces
3. Leser `peerDependencies` fra de oppdaterte ft-pakkene i `node_modules` for å finne korrekt versjonskrav
4. Kjører `yarn up --exact --recursive` for å oppdatere `react-hook-form`, `@navikt/aksel-*` og `@navikt/ds-*` til versjonene ft-pakkene krever
5. Verifiserer at bygget passerer
6. Committer og oppretter PR via `gh pr create`

## Bruk

Invokér skill-en via GitHub Copilot i terminalen ved å referere til `oppdater-ft-pakker`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
