### PR TITLE
TFP-6923: koble AvsluttedeOppgaverDialog til køStatistikk-endepunkt

### DIFF
--- a/packages/los/felles/i18n/nb_NO.json
+++ b/packages/los/felles/i18n/nb_NO.json
@@ -23,6 +23,8 @@
   "LukkedeOppgaverGraf.TotalForrigeUkeAlternativ": "Totalt uken før",
   "LukkedeOppgaverPanel.DenneUken": "Denne uken",
   "LukkedeOppgaverPanel.ForrigeUke": "Forrige uke",
+  "LukkedeOppgaverPanel.Beskrivelse": "En oppgave er et saksbehandlingspunkt i en behandling. Én behandling kan generere flere oppgaver over tid, og en oppgave er ikke det samme som en sak eller en behandling.",
+  "LukkedeOppgaverPanel.GrafBeskrivelse": "Grafen viser antall avsluttede oppgaver per dag i valgt uke, fordelt på ukedager. Stiplede linjer viser totalt og onsdag forrige uke som sammenligningsgrunnlag.",
 
   "EndreReservasjonDato.Lagrer": "Lagrer...",
   "EndreReservasjonDato.Lagret": "Lagret",

--- a/packages/los/felles/i18n/nb_NO.json
+++ b/packages/los/felles/i18n/nb_NO.json
@@ -25,6 +25,7 @@
   "LukkedeOppgaverPanel.ForrigeUke": "Forrige uke",
   "LukkedeOppgaverPanel.Beskrivelse": "En oppgave er et saksbehandlingspunkt i en behandling. Én behandling kan generere flere oppgaver over tid, og en oppgave er ikke det samme som en sak eller en behandling.",
   "LukkedeOppgaverPanel.GrafBeskrivelse": "Grafen viser antall avsluttede oppgaver per dag i valgt uke, fordelt på ukedager. Stiplede linjer viser totalt og onsdag forrige uke som sammenligningsgrunnlag.",
+  "LukkedeOppgaverPanel.SistOppdatert": "Sist oppdatert: {tidspunkt}",
 
   "EndreReservasjonDato.Lagrer": "Lagrer...",
   "EndreReservasjonDato.Lagret": "Lagret",

--- a/packages/los/felles/i18n/nb_NO.json
+++ b/packages/los/felles/i18n/nb_NO.json
@@ -26,6 +26,7 @@
   "LukkedeOppgaverPanel.Beskrivelse": "En oppgave er et saksbehandlingspunkt i en behandling. Én behandling kan generere flere oppgaver over tid, og en oppgave er ikke det samme som en sak eller en behandling.",
   "LukkedeOppgaverPanel.GrafBeskrivelse": "Grafen viser antall avsluttede oppgaver per dag i valgt uke, fordelt på ukedager. Stiplede linjer viser totalt og onsdag forrige uke som sammenligningsgrunnlag.",
   "LukkedeOppgaverPanel.SistOppdatert": "Sist oppdatert: {tidspunkt}",
+  "LukkedeOppgaverGraf.IngenData": "Ingen statistikk tilgjengelig for denne køen",
 
   "EndreReservasjonDato.Lagrer": "Lagrer...",
   "EndreReservasjonDato.Lagret": "Lagret",

--- a/packages/los/felles/src/graf/lukkedeOppgaver/LukkedeOppgaverGraf.tsx
+++ b/packages/los/felles/src/graf/lukkedeOppgaver/LukkedeOppgaverGraf.tsx
@@ -68,6 +68,27 @@ export const LukkedeOppgaverGraf = ({ height, lukkedeOppgaver, yMax }: Props) =>
   const options = getStyle();
 
   const { antallPerDag, mandagDato } = lukkedeOppgaver;
+  const ingenData = antallPerDag.every(v => v === 0) && lukkedeOppgaver.forrigeUkeTotal === 0;
+
+  if (ingenData) {
+    const emptyOption: EChartsOption = {
+      title: {
+        text: intl.formatMessage({ id: 'LukkedeOppgaverGraf.IngenData' }),
+        left: 'center',
+        top: 'middle',
+        textStyle: {
+          color: getAkselVariable('--ax-text-neutral-subtle'),
+          fontSize: 14,
+          fontWeight: 'normal',
+        },
+      },
+      xAxis: { show: false },
+      yAxis: { show: false },
+      series: [],
+    };
+    return <ReactECharts height={height} option={emptyOption} />;
+  }
+
   const erInneværendeUke = dayjs(mandagDato).startOf('day').isSame(startAvIsoUke(dayjs()), 'day');
   const xAxisDatoer = lagUkedatoer(mandagDato);
   const offsetSerieData = lagStackOffsetSerieData(antallPerDag);

--- a/packages/los/felles/src/graf/lukkedeOppgaver/LukkedeOppgaverPanel.tsx
+++ b/packages/los/felles/src/graf/lukkedeOppgaver/LukkedeOppgaverPanel.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from 'react';
 import { RawIntlProvider } from 'react-intl';
 
-import { BodyShort, ToggleGroup, VStack } from '@navikt/ds-react';
+import { BodyShort, HStack, ToggleGroup, VStack } from '@navikt/ds-react';
 import { createIntl } from '@navikt/ft-utils';
+import dayjs from 'dayjs';
 
 import { type KøStatistikkDto } from '@navikt/fp-types';
 
@@ -31,19 +32,32 @@ export const LukkedeOppgaverPanel = ({ køStatistikk, height = 400 }: Props) => 
   const yMax = beregnFellesYMax(denneUken, forrigeUke);
   const valgtData = valgtUke === UkeValg.DENNE_UKEN ? denneUken : forrigeUke;
 
+  const sistOppdatert = useMemo(() => {
+    if (køStatistikk.length === 0) return undefined;
+    const nyeste = køStatistikk.reduce((a, b) => (a.tidspunkt > b.tidspunkt ? a : b));
+    return dayjs(nyeste.tidspunkt).format('DD.MM.YYYY HH:mm');
+  }, [køStatistikk]);
+
   return (
     <RawIntlProvider value={intl}>
       <VStack gap="space-16">
         <BodyShort size="small">{intl.formatMessage({ id: 'LukkedeOppgaverPanel.Beskrivelse' })}</BodyShort>
         <BodyShort size="small">{intl.formatMessage({ id: 'LukkedeOppgaverPanel.GrafBeskrivelse' })}</BodyShort>
-        <ToggleGroup size="small" value={valgtUke} onChange={value => setValgtUke(value as UkeValg)}>
-          <ToggleGroup.Item value={UkeValg.FORRIGE_UKE}>
-            {intl.formatMessage({ id: 'LukkedeOppgaverPanel.ForrigeUke' })}
-          </ToggleGroup.Item>
-          <ToggleGroup.Item value={UkeValg.DENNE_UKEN}>
-            {intl.formatMessage({ id: 'LukkedeOppgaverPanel.DenneUken' })}
-          </ToggleGroup.Item>
-        </ToggleGroup>
+        <HStack justify="space-between" align="end">
+          <ToggleGroup size="small" value={valgtUke} onChange={value => setValgtUke(value as UkeValg)}>
+            <ToggleGroup.Item value={UkeValg.FORRIGE_UKE}>
+              {intl.formatMessage({ id: 'LukkedeOppgaverPanel.ForrigeUke' })}
+            </ToggleGroup.Item>
+            <ToggleGroup.Item value={UkeValg.DENNE_UKEN}>
+              {intl.formatMessage({ id: 'LukkedeOppgaverPanel.DenneUken' })}
+            </ToggleGroup.Item>
+          </ToggleGroup>
+          {sistOppdatert && (
+            <BodyShort size="small" textColor="subtle">
+              {intl.formatMessage({ id: 'LukkedeOppgaverPanel.SistOppdatert' }, { tidspunkt: sistOppdatert })}
+            </BodyShort>
+          )}
+        </HStack>
         <LukkedeOppgaverGraf height={height} lukkedeOppgaver={valgtData} yMax={yMax} />
       </VStack>
     </RawIntlProvider>

--- a/packages/los/felles/src/graf/lukkedeOppgaver/LukkedeOppgaverPanel.tsx
+++ b/packages/los/felles/src/graf/lukkedeOppgaver/LukkedeOppgaverPanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { RawIntlProvider } from 'react-intl';
 
-import { ToggleGroup, VStack } from '@navikt/ds-react';
+import { BodyShort, ToggleGroup, VStack } from '@navikt/ds-react';
 import { createIntl } from '@navikt/ft-utils';
 
 import { type KøStatistikkDto } from '@navikt/fp-types';
@@ -23,6 +23,33 @@ interface Props {
   height?: number;
 }
 
+export const LukkedeOppgaverPanel = ({ køStatistikk, height = 400 }: Props) => {
+  const [valgtUke, setValgtUke] = useState<UkeValg>(UkeValg.DENNE_UKEN);
+
+  const { denneUken, forrigeUke } = useMemo(() => mapLukkedeOppgaver(køStatistikk), [køStatistikk]);
+
+  const yMax = beregnFellesYMax(denneUken, forrigeUke);
+  const valgtData = valgtUke === UkeValg.DENNE_UKEN ? denneUken : forrigeUke;
+
+  return (
+    <RawIntlProvider value={intl}>
+      <VStack gap="space-16">
+        <BodyShort size="small">{intl.formatMessage({ id: 'LukkedeOppgaverPanel.Beskrivelse' })}</BodyShort>
+        <BodyShort size="small">{intl.formatMessage({ id: 'LukkedeOppgaverPanel.GrafBeskrivelse' })}</BodyShort>
+        <ToggleGroup size="small" value={valgtUke} onChange={value => setValgtUke(value as UkeValg)}>
+          <ToggleGroup.Item value={UkeValg.FORRIGE_UKE}>
+            {intl.formatMessage({ id: 'LukkedeOppgaverPanel.ForrigeUke' })}
+          </ToggleGroup.Item>
+          <ToggleGroup.Item value={UkeValg.DENNE_UKEN}>
+            {intl.formatMessage({ id: 'LukkedeOppgaverPanel.DenneUken' })}
+          </ToggleGroup.Item>
+        </ToggleGroup>
+        <LukkedeOppgaverGraf height={height} lukkedeOppgaver={valgtData} yMax={yMax} />
+      </VStack>
+    </RawIntlProvider>
+  );
+};
+
 /**
  * Beregner felles yMax for begge uker for å unngå endring i y-akse ved ukebytte.
  */
@@ -39,29 +66,4 @@ const beregnFellesYMax = (denneUken: LukkedeOppgaverData, forrigeUke: LukkedeOpp
   if (maksMedMargin <= 500) steg = 50;
 
   return Math.ceil(maksMedMargin / steg) * steg;
-};
-
-export const LukkedeOppgaverPanel = ({ køStatistikk, height = 400 }: Props) => {
-  const [valgtUke, setValgtUke] = useState<UkeValg>(UkeValg.DENNE_UKEN);
-
-  const { denneUken, forrigeUke } = useMemo(() => mapLukkedeOppgaver(køStatistikk), [køStatistikk]);
-
-  const yMax = beregnFellesYMax(denneUken, forrigeUke);
-  const valgtData = valgtUke === UkeValg.DENNE_UKEN ? denneUken : forrigeUke;
-
-  return (
-    <RawIntlProvider value={intl}>
-      <VStack gap="space-16">
-        <ToggleGroup size="small" value={valgtUke} onChange={value => setValgtUke(value as UkeValg)}>
-          <ToggleGroup.Item value={UkeValg.FORRIGE_UKE}>
-            {intl.formatMessage({ id: 'LukkedeOppgaverPanel.ForrigeUke' })}
-          </ToggleGroup.Item>
-          <ToggleGroup.Item value={UkeValg.DENNE_UKEN}>
-            {intl.formatMessage({ id: 'LukkedeOppgaverPanel.DenneUken' })}
-          </ToggleGroup.Item>
-        </ToggleGroup>
-        <LukkedeOppgaverGraf height={height} lukkedeOppgaver={valgtData} yMax={yMax} />
-      </VStack>
-    </RawIntlProvider>
-  );
 };

--- a/packages/los/saksbehandler/i18n/nb_NO.json
+++ b/packages/los/saksbehandler/i18n/nb_NO.json
@@ -114,5 +114,8 @@
   "SaksbehandlerNokkeltallPanel.ForAlleDetaljer": "Statistikk for alle som jobber med foreldrepenger, engangsstønad og svangerskapspenger",
 
   "NotatModal.SkrivNotat": "Legg til notat på reservasjon",
-  "NotatModal.Notat": "Notat"
+  "NotatModal.Notat": "Notat",
+
+  "AvsluttedeOppgaverDialog.Tittel": "Avsluttede oppgaver",
+  "AvsluttedeOppgaverDialog.IngenData": "Ingen statistikk tilgjengelig for denne køen."
 }

--- a/packages/los/saksbehandler/i18n/nb_NO.json
+++ b/packages/los/saksbehandler/i18n/nb_NO.json
@@ -116,6 +116,6 @@
   "NotatModal.SkrivNotat": "Legg til notat på reservasjon",
   "NotatModal.Notat": "Notat",
 
-  "AvsluttedeOppgaverDialog.Tittel": "Avsluttede oppgaver",
+  "AvsluttedeOppgaverDialog.Tittel": "Avsluttede oppgaver – {sakslisteNavn}",
   "AvsluttedeOppgaverDialog.IngenData": "Ingen statistikk tilgjengelig for denne køen."
 }

--- a/packages/los/saksbehandler/i18n/nb_NO.json
+++ b/packages/los/saksbehandler/i18n/nb_NO.json
@@ -116,6 +116,5 @@
   "NotatModal.SkrivNotat": "Legg til notat på reservasjon",
   "NotatModal.Notat": "Notat",
 
-  "AvsluttedeOppgaverDialog.Tittel": "Avsluttede oppgaver – {sakslisteNavn}",
-  "AvsluttedeOppgaverDialog.IngenData": "Ingen statistikk tilgjengelig for denne køen."
+  "AvsluttedeOppgaverDialog.Tittel": "Avsluttede oppgaver – {sakslisteNavn}"
 }

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
@@ -9,19 +9,20 @@ import { saksbehandlerKøStatistikkOptions } from '../../data/fplosSaksbehandler
 
 interface Props {
   valgtSakslisteId: number;
+  sakslisteNavn: string;
 }
 
-export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId }: Props) => {
+export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId, sakslisteNavn }: Props) => {
   const { data: køStatistikk = [] } = useQuery(saksbehandlerKøStatistikkOptions(valgtSakslisteId));
   return (
     <Dialog>
       <Dialog.Trigger>
-        <Button title="Åpne dialog" aria-label="Åpne dialog" icon={<BarChartIcon />}></Button>
+        <Button variant="secondary" size="small" className="self-end" title="Åpne dialog" aria-label="Åpne dialog" icon={<BarChartIcon />}></Button>
       </Dialog.Trigger>
       <Dialog.Popup>
         <Dialog.Header>
           <Dialog.Title>
-            <FormattedMessage id="AvsluttedeOppgaverDialog.Tittel" />
+            <FormattedMessage id="AvsluttedeOppgaverDialog.Tittel" values={{ sakslisteNavn }} />
           </Dialog.Title>
         </Dialog.Header>
         <Dialog.Body>

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
@@ -1,0 +1,36 @@
+import { BarChartIcon } from '@navikt/aksel-icons';
+import { Button, Dialog } from '@navikt/ds-react';
+
+import { LukkedeOppgaverPanel } from '@navikt/fp-los-felles';
+import { useQuery } from '@tanstack/react-query';
+
+import { saksbehandlerKøStatistikkOptions } from '../../data/fplosSaksbehandlerApi';
+
+interface Props {
+  valgtSakslisteId: number;
+}
+
+export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId }: Props) => {
+  const køStatistikk = useQuery(saksbehandlerKøStatistikkOptions(valgtSakslisteId)).data ?? [];
+  return (
+    <Dialog>
+      <Dialog.Trigger>
+        <Button title="Åpne dialog" aria-label="Åpne dialog" icon={<BarChartIcon />}></Button>
+      </Dialog.Trigger>
+      <Dialog.Popup>
+        <Dialog.Header>
+          <Dialog.Title>Overskrift</Dialog.Title>
+          <Dialog.Description>En kort beskrivelse av dialogen.</Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Body>
+          <LukkedeOppgaverPanel køStatistikk={køStatistikk} />
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Dialog.CloseTrigger>
+            <Button>Lukk</Button>
+          </Dialog.CloseTrigger>
+        </Dialog.Footer>
+      </Dialog.Popup>
+    </Dialog>
+  );
+};

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
@@ -1,9 +1,13 @@
-import { BarChartIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Dialog } from '@navikt/ds-react';
+
+import { useState } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 
-import { LukkedeOppgaverPanel } from '@navikt/fp-los-felles';
+import { BarChartIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, Dialog } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
+
+import { LukkedeOppgaverPanel } from '@navikt/fp-los-felles';
 
 import { saksbehandlerKøStatistikkOptions } from '../../data/fplosSaksbehandlerApi';
 
@@ -13,9 +17,13 @@ interface Props {
 }
 
 export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId, sakslisteNavn }: Props) => {
-  const { data: køStatistikk = [] } = useQuery(saksbehandlerKøStatistikkOptions(valgtSakslisteId));
+  const [open, setOpen] = useState(false);
+  const { data: køStatistikk = [] } = useQuery({
+    ...saksbehandlerKøStatistikkOptions(valgtSakslisteId),
+    enabled: open,
+  });
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={nextOpen => setOpen(nextOpen)}>
       <Dialog.Trigger>
         <Button variant="secondary" size="small" className="self-end" title="Åpne dialog" aria-label="Åpne dialog" icon={<BarChartIcon />}></Button>
       </Dialog.Trigger>

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
@@ -1,5 +1,6 @@
 import { BarChartIcon } from '@navikt/aksel-icons';
-import { Button, Dialog } from '@navikt/ds-react';
+import { BodyShort, Button, Dialog } from '@navikt/ds-react';
+import { FormattedMessage } from 'react-intl';
 
 import { LukkedeOppgaverPanel } from '@navikt/fp-los-felles';
 import { useQuery } from '@tanstack/react-query';
@@ -11,7 +12,7 @@ interface Props {
 }
 
 export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId }: Props) => {
-  const køStatistikk = useQuery(saksbehandlerKøStatistikkOptions(valgtSakslisteId)).data ?? [];
+  const { data: køStatistikk = [] } = useQuery(saksbehandlerKøStatistikkOptions(valgtSakslisteId));
   return (
     <Dialog>
       <Dialog.Trigger>
@@ -19,15 +20,24 @@ export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId }: Props) => {
       </Dialog.Trigger>
       <Dialog.Popup>
         <Dialog.Header>
-          <Dialog.Title>Overskrift</Dialog.Title>
-          <Dialog.Description>En kort beskrivelse av dialogen.</Dialog.Description>
+          <Dialog.Title>
+            <FormattedMessage id="AvsluttedeOppgaverDialog.Tittel" />
+          </Dialog.Title>
         </Dialog.Header>
         <Dialog.Body>
-          <LukkedeOppgaverPanel køStatistikk={køStatistikk} />
+          {køStatistikk.length === 0 ? (
+            <BodyShort>
+              <FormattedMessage id="AvsluttedeOppgaverDialog.IngenData" />
+            </BodyShort>
+          ) : (
+            <LukkedeOppgaverPanel køStatistikk={køStatistikk} />
+          )}
         </Dialog.Body>
         <Dialog.Footer>
           <Dialog.CloseTrigger>
-            <Button>Lukk</Button>
+            <Button>
+              <FormattedMessage id="Label.Avbryt" />
+            </Button>
           </Dialog.CloseTrigger>
         </Dialog.Footer>
       </Dialog.Popup>

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/AvsluttedeOppgaverDialog.tsx
@@ -1,10 +1,9 @@
-
 import { useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
 import { BarChartIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Dialog } from '@navikt/ds-react';
+import { Button, Dialog, Loader } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
 
 import { LukkedeOppgaverPanel } from '@navikt/fp-los-felles';
@@ -18,14 +17,22 @@ interface Props {
 
 export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId, sakslisteNavn }: Props) => {
   const [open, setOpen] = useState(false);
-  const { data: køStatistikk = [] } = useQuery({
+  const { data: køStatistikk = [], isPending } = useQuery({
     ...saksbehandlerKøStatistikkOptions(valgtSakslisteId),
     enabled: open,
   });
+
   return (
     <Dialog open={open} onOpenChange={nextOpen => setOpen(nextOpen)}>
       <Dialog.Trigger>
-        <Button variant="secondary" size="small" className="self-end" title="Åpne dialog" aria-label="Åpne dialog" icon={<BarChartIcon />}></Button>
+        <Button
+          variant="secondary"
+          size="small"
+          className="self-end"
+          title="Åpne dialog"
+          aria-label="Åpne dialog"
+          icon={<BarChartIcon />}
+        ></Button>
       </Dialog.Trigger>
       <Dialog.Popup>
         <Dialog.Header>
@@ -34,13 +41,7 @@ export const AvsluttedeOppgaverDialog = ({ valgtSakslisteId, sakslisteNavn }: Pr
           </Dialog.Title>
         </Dialog.Header>
         <Dialog.Body>
-          {køStatistikk.length === 0 ? (
-            <BodyShort>
-              <FormattedMessage id="AvsluttedeOppgaverDialog.IngenData" />
-            </BodyShort>
-          ) : (
-            <LukkedeOppgaverPanel køStatistikk={køStatistikk} />
-          )}
+          {isPending ? <Loader /> : <LukkedeOppgaverPanel køStatistikk={køStatistikk} />}
         </Dialog.Body>
         <Dialog.Footer>
           <Dialog.CloseTrigger>

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.spec.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.spec.tsx
@@ -5,8 +5,16 @@ import { applyRequestHandlers, type MswParameters } from 'msw-storybook-addon';
 
 import * as stories from './SakslisteVelgerForm.stories';
 
-const { Default, MedToSakslister, MedFlereEnnTreSaksbehandlere, MedBelopFraOgTil, MedBelopKunFra, MedBelopKunTil } =
-  composeStories(stories);
+const {
+  Default,
+  MedToSakslister,
+  MedFlereEnnTreSaksbehandlere,
+  MedBelopFraOgTil,
+  MedBelopKunFra,
+  MedBelopKunTil,
+  MedAvsluttedeOppgaver,
+  MedAvsluttedeOppgaverTomListe,
+} = composeStories(stories);
 
 const hentSorteringBoks = () => {
   const sorteringLabel = screen.getByText('Sortering');
@@ -148,5 +156,30 @@ describe('SakslisteVelgerForm', () => {
 
     expect(hentSorteringBoks()).not.toHaveTextContent('Fra: 20 000 kr');
     expect(hentSorteringBoks()).not.toHaveTextContent('Til: 30 000 kr');
+  });
+
+  it('skal åpne dialog og vise graf med avsluttede oppgaver', async () => {
+    applyRequestHandlers(MedAvsluttedeOppgaver.parameters['msw'] as MswParameters['msw']);
+    render(<MedAvsluttedeOppgaver />);
+
+    expect(await screen.findByText('A03 Førstegangsbehandling (3 saker)')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Åpne dialog' }));
+
+    expect(await screen.findByText('Avsluttede oppgaver – A03 Førstegangsbehandling')).toBeInTheDocument();
+    expect(screen.getByText('Denne uken')).toBeInTheDocument();
+    expect(screen.getByText('Forrige uke')).toBeInTheDocument();
+  });
+
+  it('skal vise melding om ingen data når køStatistikk er tom', async () => {
+    applyRequestHandlers(MedAvsluttedeOppgaverTomListe.parameters['msw'] as MswParameters['msw']);
+    render(<MedAvsluttedeOppgaverTomListe />);
+
+    expect(await screen.findByText('A03 Førstegangsbehandling (3 saker)')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Åpne dialog' }));
+
+    expect(await screen.findByText('Avsluttede oppgaver – A03 Førstegangsbehandling')).toBeInTheDocument();
+    expect(screen.getByText('Ingen statistikk tilgjengelig for denne køen.')).toBeInTheDocument();
   });
 });

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.stories.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.stories.tsx
@@ -48,6 +48,13 @@ const saksliste1: SakslisteDto = {
   },
 };
 
+const køStatistikkMock = [
+  { tidspunkt: '2024-04-08T08:00:00', aktive: 21, tilgjengelige: 5, ventende: 32, avsluttet: 14 },
+  { tidspunkt: '2024-04-08T10:00:00', aktive: 19, tilgjengelige: 3, ventende: 28, avsluttet: 22 },
+  { tidspunkt: '2024-04-09T08:00:00', aktive: 24, tilgjengelige: 8, ventende: 37, avsluttet: 31 },
+  { tidspunkt: '2024-04-09T10:00:00', aktive: 27, tilgjengelige: 7, ventende: 41, avsluttet: 19 },
+];
+
 const meta = {
   title: 'behandlingskoer/SakslisteVelgerForm',
   component: SakslisteVelgerForm,
@@ -55,7 +62,10 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
     msw: {
-      handlers: [http.get(LosUrl.KODEVERK_LOS, () => HttpResponse.json(alleKodeverkLos))],
+      handlers: [
+        http.get(LosUrl.KODEVERK_LOS, () => HttpResponse.json(alleKodeverkLos)),
+        http.get(LosUrl.SAKSBEHANDLER_KØ_STATISTIKK, () => HttpResponse.json([])),
+      ],
     },
   },
   args: {
@@ -73,6 +83,34 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  args: {
+    sakslister: [saksliste1],
+  },
+};
+
+export const MedAvsluttedeOppgaver: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(LosUrl.KODEVERK_LOS, () => HttpResponse.json(alleKodeverkLos)),
+        http.get(LosUrl.SAKSBEHANDLER_KØ_STATISTIKK, () => HttpResponse.json(køStatistikkMock)),
+      ],
+    },
+  },
+  args: {
+    sakslister: [saksliste1],
+  },
+};
+
+export const MedAvsluttedeOppgaverTomListe: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(LosUrl.KODEVERK_LOS, () => HttpResponse.json(alleKodeverkLos)),
+        http.get(LosUrl.SAKSBEHANDLER_KØ_STATISTIKK, () => HttpResponse.json([])),
+      ],
+    },
+  },
   args: {
     sakslister: [saksliste1],
   },

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Detail, HStack, Label, Spacer, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, Detail, HStack, Label, Modal, Spacer, VStack } from '@navikt/ds-react';
 import { RhfForm, RhfSelect } from '@navikt/ft-form-hooks';
 
 import type { SakslisteDto } from '@navikt/fp-types';
@@ -16,6 +16,7 @@ import {
 import { KøFiltere } from './KøFiltere';
 
 import styles from './sakslisteVelgerForm.module.css';
+import { AvsluttedeOppgaverDialog } from './AvsluttedeOppgaverDialog.tsx';
 
 type FormValues = {
   sakslisteId: string | undefined;
@@ -85,6 +86,7 @@ export const SakslisteVelgerForm = ({ sakslister, setValgtSakslisteId, fetchAnta
           <Detail className="content-end pb-1 whitespace-pre-line">{valgtSaksliste.beskrivelse}</Detail>
         )}
         <Spacer />
+        {valgtSaksliste && <AvsluttedeOppgaverDialog valgtSakslisteId={valgtSaksliste.sakslisteId} />}
         <Button
           size="small"
           variant="tertiary"

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Detail, HStack, Label, Modal, Spacer, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, Detail, HStack, Label, Spacer, VStack } from '@navikt/ds-react';
 import { RhfForm, RhfSelect } from '@navikt/ft-form-hooks';
 
 import type { SakslisteDto } from '@navikt/fp-types';
@@ -16,7 +16,7 @@ import {
 import { KøFiltere } from './KøFiltere';
 
 import styles from './sakslisteVelgerForm.module.css';
-import { AvsluttedeOppgaverDialog } from './AvsluttedeOppgaverDialog.tsx';
+import { AvsluttedeOppgaverDialog } from './AvsluttedeOppgaverDialog';
 
 type FormValues = {
   sakslisteId: string | undefined;
@@ -86,7 +86,7 @@ export const SakslisteVelgerForm = ({ sakslister, setValgtSakslisteId, fetchAnta
           <Detail className="content-end pb-1 whitespace-pre-line">{valgtSaksliste.beskrivelse}</Detail>
         )}
         <Spacer />
-        {valgtSaksliste && <AvsluttedeOppgaverDialog valgtSakslisteId={valgtSaksliste.sakslisteId} />}
+        {valgtSaksliste && <AvsluttedeOppgaverDialog valgtSakslisteId={valgtSaksliste.sakslisteId} sakslisteNavn={valgtSaksliste.navn} />}
         <Button
           size="small"
           variant="tertiary"

--- a/packages/los/saksbehandler/src/data/fplosSaksbehandlerApi.ts
+++ b/packages/los/saksbehandler/src/data/fplosSaksbehandlerApi.ts
@@ -4,6 +4,7 @@ import ky from 'ky';
 import { LosUrlFelles } from '@navikt/fp-los-felles';
 import type {
   FagsakEnkel,
+  KøStatistikkDto,
   OppgaveDto,
   OppgaveDtoMedStatus,
   ReservasjonStatusDto,
@@ -33,6 +34,7 @@ const wrapUrl = (url: string) => (isTest ? `https://www.test.com${url}` : url);
 export const LosUrl = {
   ...LosUrlFelles,
   SØK_FAGSAK: wrapUrl('/fpsak/api/fagsak/sok'),
+  SAKSBEHANDLER_KØ_STATISTIKK: wrapUrl('/fplos/api/saksbehandler/nøkkeltall/statistikk-oppgave-filter'),
   SAKSLISTE: wrapUrl('/fplos/api/saksbehandler/saksliste'),
   RESERVERTE_OPPGAVER: wrapUrl('/fplos/api/reservasjon/reserverte-oppgaver'),
   TIDLIGERE_RESERVERTE: wrapUrl('/fplos/api/reservasjon/tidligere-reserverte'),
@@ -76,6 +78,15 @@ export const oppgaverForFagsakerOptions = (saksnummer: string[]) =>
     queryKey: [LosUrl.OPPGAVER_FOR_FAGSAKER, saksnummer],
     queryFn: () => getOppgaverForFagsaker(saksnummer),
     staleTime: Infinity,
+  });
+
+export const saksbehandlerKøStatistikkOptions = (sakslisteId: number) =>
+  queryOptions({
+    queryKey: [LosUrl.SAKSBEHANDLER_KØ_STATISTIKK, sakslisteId],
+    queryFn: () =>
+      kyExtended
+        .get(LosUrl.SAKSBEHANDLER_KØ_STATISTIKK, { searchParams: { sakslisteId } })
+        .json<KøStatistikkDto[]>(),
   });
 
 export const sakslisteOptions = () =>


### PR DESCRIPTION
## TFP-6923

Kobler `AvsluttedeOppgaverDialog` til det nye saksbehandler-endepunktet i fplos.

**Endringer:**
- Legger til `SAKSBEHANDLER_KØ_STATISTIKK` URL og `saksbehandlerKøStatistikkOptions` i `fplosSaksbehandlerApi.ts`
- Setter opp `useQuery` i `AvsluttedeOppgaverDialog` med korrekt sakslisteId
- Oppdaterer `SakslisteVelgerForm` til å sende `valgtSakslisteId` (number) i stedet for `køStatistikk`

Avhenger av: navikt/fplos – `GET /saksbehandler/nøkkeltall/statistikk-oppgave-filter`