### PR TITLE
fix: håndter tom respons-body etter ky 2.0 oppgradering

### DIFF
--- a/apps/fp-frontend/src/data/behandlingApi.ts
+++ b/apps/fp-frontend/src/data/behandlingApi.ts
@@ -100,6 +100,7 @@ export type OverstyrteAksjonspunktArgs = {
 const kyExtended = ky.extend({
   retry: 0,
   timeout: 15000,
+  parseJson: text => (text ? (JSON.parse(text) as unknown) : null),
   hooks: {
     beforeRequest: [
       ({ request }) => {

--- a/apps/fp-frontend/src/data/fagsakApi.ts
+++ b/apps/fp-frontend/src/data/fagsakApi.ts
@@ -61,6 +61,7 @@ export type NyBehandlingParams = {
 const kyExtended = ky.extend({
   retry: 0,
   timeout: 15000,
+  parseJson: text => (text ? (JSON.parse(text) as unknown) : null),
   hooks: {
     beforeRequest: [
       ({ request }) => {
@@ -264,7 +265,7 @@ const getLagreTotrinnsaksjonspunkt = (links?: ApiLink[]) => (params: BekreftedeT
     .post(getUrlFromRel('SAVE_TOTRINNSAKSJONSPUNKT', links), {
       json: params,
     })
-    .json<BehandlingFpSak>();
+    .then(() => {});
 
 const getSendMelding = (links?: ApiLink[]) => (params: SubmitMessageParams) =>
   kyExtended


### PR DESCRIPTION
ky 2.0 endret oppførsel slik at .json() på en tom response body kaster SyntaxError: 'Unexpected end of JSON input'. I ky 1.x returnerte den samme situasjonen undefined stille.

Dette fanget vi bl.a. når saksbehandlere trykket 'fatte vedtak' (POST /api/behandling/aksjonspunkt/beslutt returnerer 202 Accepted + tom body som del av polling-mønsteret), og når vi hentet ytelsefordeling/omsorg-og-rett (backend returnerer Optional.orElse(null) som JAX-RS oversetter til 204 No Content).

Fix:
- Legg til en parseJson-hook i begge kyExtended-definisjoner som returnerer null for tom body. Dette er en runtime-hook som ikke endrer .json<T>()-typene, så ingen kaskade av T|null gjennom konsumenter. Konsumentene har allerede if (data)/?.-mønstre på endepunkt som kan returnere null.
- Rydd getLagreTotrinnsaksjonspunkt til å returnere .then(() => {}) i stedet for .json<BehandlingFpSak>(), tilsvarende getSendMelding. Returverdien har aldri blitt brukt; .json()-kallet var en rest fra ky 1.x-tiden hvor det stille returnerte undefined.