### PR TITLE
Fix/sentry api errors

### DIFF
--- a/apps/fp-avdelingsleder/src/LosAppIndex.tsx
+++ b/apps/fp-avdelingsleder/src/LosAppIndex.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Theme } from '@navikt/ds-react';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { createIntl } from '@navikt/ft-utils';
+import { captureException } from '@sentry/browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
@@ -146,16 +147,18 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
   console.log(error);
 
   if (error instanceof HTTPError) {
-    if (error.response.status === 403) {
+    const { status } = error.response;
+    if (status === 403) {
       addErrorMessage({ type: ErrorType.REQUEST_FORBIDDEN, message: error.message });
-    } else if (error.response.status === 401) {
+    } else if (status === 401) {
       addErrorMessage({ type: ErrorType.REQUEST_UNAUTHORIZED, message: error.message });
-    } else if (error.response.status === 504 || error.response.status === 404) {
+    } else if (status === 504 || status === 404) {
       addErrorMessage({
         type: ErrorType.REQUEST_GATEWAY_TIMEOUT_OR_NOT_FOUND,
         location: error.response.url,
       });
     } else {
+      captureException(error);
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const feildataJson = await error.response.json();
@@ -166,6 +169,7 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
       }
     }
   } else {
+    captureException(error);
     addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: error.message });
   }
 };

--- a/apps/fp-avdelingsleder/src/LosAppIndex.tsx
+++ b/apps/fp-avdelingsleder/src/LosAppIndex.tsx
@@ -5,7 +5,6 @@ import { Link, useLocation } from 'react-router-dom';
 import { Theme } from '@navikt/ds-react';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { createIntl } from '@navikt/ft-utils';
-import { captureException } from '@sentry/browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
@@ -14,6 +13,7 @@ import {
   ErrorBoundary,
   ErrorType,
   type FpError,
+  captureException,
   parseQueryString,
   useRestApiError,
   useRestApiErrorDispatcher,

--- a/apps/fp-avdelingsleder/src/LosAppIndex.tsx
+++ b/apps/fp-avdelingsleder/src/LosAppIndex.tsx
@@ -10,10 +10,10 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
 
 import {
+  captureException,
   ErrorBoundary,
   ErrorType,
   type FpError,
-  captureException,
   parseQueryString,
   useRestApiError,
   useRestApiErrorDispatcher,

--- a/apps/fp-frontend/src/app/AppIndex.tsx
+++ b/apps/fp-frontend/src/app/AppIndex.tsx
@@ -4,16 +4,16 @@ import { Link, useLocation } from 'react-router-dom';
 
 import { Theme } from '@navikt/ds-react';
 import { createIntl } from '@navikt/ft-utils';
-import { captureException } from '@sentry/browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
 
-import { parseQueryString } from '@navikt/fp-app-felles';
 import {
   ErrorBoundary,
   ErrorType,
   type FpError,
+  captureException,
+  parseQueryString,
   useRestApiError,
   useRestApiErrorDispatcher,
 } from '@navikt/fp-app-felles';

--- a/apps/fp-frontend/src/app/AppIndex.tsx
+++ b/apps/fp-frontend/src/app/AppIndex.tsx
@@ -157,7 +157,6 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
   console.log(error);
 
   if (error instanceof PollingTimeoutError) {
-    captureException(error);
     addErrorMessage({ type: ErrorType.POLLING_TIMEOUT, message: error.message, location: error.location });
   } else if (error instanceof HTTPError) {
     const { status } = error.response;

--- a/apps/fp-frontend/src/app/AppIndex.tsx
+++ b/apps/fp-frontend/src/app/AppIndex.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from 'react-router-dom';
 
 import { Theme } from '@navikt/ds-react';
 import { createIntl } from '@navikt/ft-utils';
+import { captureException } from '@sentry/browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
@@ -156,18 +157,21 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
   console.log(error);
 
   if (error instanceof PollingTimeoutError) {
+    captureException(error);
     addErrorMessage({ type: ErrorType.POLLING_TIMEOUT, message: error.message, location: error.location });
   } else if (error instanceof HTTPError) {
-    if (error.response.status === 403) {
+    const { status } = error.response;
+    if (status === 403) {
       addErrorMessage({ type: ErrorType.REQUEST_FORBIDDEN, message: error.message });
-    } else if (error.response.status === 401) {
+    } else if (status === 401) {
       addErrorMessage({ type: ErrorType.REQUEST_UNAUTHORIZED, message: error.message });
-    } else if (error.response.status === 504 || error.response.status === 404) {
+    } else if (status === 504 || status === 404) {
       addErrorMessage({
         type: ErrorType.REQUEST_GATEWAY_TIMEOUT_OR_NOT_FOUND,
         location: error.response.url,
       });
     } else {
+      captureException(error);
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const feildataJson = await error.response.json();
@@ -178,6 +182,7 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
       }
     }
   } else {
+    captureException(error);
     addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: error.message });
   }
 };

--- a/apps/fp-frontend/src/app/AppIndex.tsx
+++ b/apps/fp-frontend/src/app/AppIndex.tsx
@@ -9,10 +9,10 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
 
 import {
+  captureException,
   ErrorBoundary,
   ErrorType,
   type FpError,
-  captureException,
   parseQueryString,
   useRestApiError,
   useRestApiErrorDispatcher,

--- a/apps/fp-journalforing/src/JournalforingAppIndex.tsx
+++ b/apps/fp-journalforing/src/JournalforingAppIndex.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Theme } from '@navikt/ds-react';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { createIntl } from '@navikt/ft-utils';
+import { captureException } from '@sentry/browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
@@ -146,16 +147,18 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
   console.log(error);
 
   if (error instanceof HTTPError) {
-    if (error.response.status === 403) {
+    const { status } = error.response;
+    if (status === 403) {
       addErrorMessage({ type: ErrorType.REQUEST_FORBIDDEN, message: error.message });
-    } else if (error.response.status === 401) {
+    } else if (status === 401) {
       addErrorMessage({ type: ErrorType.REQUEST_UNAUTHORIZED, message: error.message });
-    } else if (error.response.status === 504 || error.response.status === 404) {
+    } else if (status === 504 || status === 404) {
       addErrorMessage({
         type: ErrorType.REQUEST_GATEWAY_TIMEOUT_OR_NOT_FOUND,
         location: error.response.url,
       });
     } else {
+      captureException(error);
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const feildataJson = await error.response.json();
@@ -166,6 +169,7 @@ const getErrorHandler = (addErrorMessage: (data: FpError) => void) => async (err
       }
     }
   } else {
+    captureException(error);
     addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: error.message });
   }
 };

--- a/apps/fp-journalforing/src/JournalforingAppIndex.tsx
+++ b/apps/fp-journalforing/src/JournalforingAppIndex.tsx
@@ -5,7 +5,6 @@ import { Link, useLocation } from 'react-router-dom';
 import { Theme } from '@navikt/ds-react';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { createIntl } from '@navikt/ft-utils';
-import { captureException } from '@sentry/browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
@@ -14,6 +13,7 @@ import {
   ErrorBoundary,
   ErrorType,
   type FpError,
+  captureException,
   parseQueryString,
   useRestApiError,
   useRestApiErrorDispatcher,

--- a/apps/fp-journalforing/src/JournalforingAppIndex.tsx
+++ b/apps/fp-journalforing/src/JournalforingAppIndex.tsx
@@ -10,10 +10,10 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HTTPError } from 'ky';
 
 import {
+  captureException,
   ErrorBoundary,
   ErrorType,
   type FpError,
-  captureException,
   parseQueryString,
   useRestApiError,
   useRestApiErrorDispatcher,

--- a/packages/app-felles/index.ts
+++ b/packages/app-felles/index.ts
@@ -6,6 +6,7 @@ export {
 export { ErrorType, type FpError } from './src/restApiError/errorType';
 export { ErrorBoundary } from './src/ErrorBoundary';
 export { initSentry } from './src/initSentry';
+export { captureException } from '@sentry/browser';
 export { FellesDekorator, type QueryStrings } from './src/dekorator/FellesDekorator';
 export { getLocationWithQueryParams, parseQueryString } from './src/utils/urlUtils';
 export { useTrackRouteParam } from './src/hooks/useTrackRouteParam';

--- a/packages/app-felles/src/ErrorBoundary.tsx
+++ b/packages/app-felles/src/ErrorBoundary.tsx
@@ -7,8 +7,6 @@ import { ErrorPage } from '@navikt/fp-sak-infosider';
 
 import { ErrorType, type FpError } from './restApiError/errorType';
 
-const isDevelopment = import.meta.env.MODE === 'development';
-
 interface Props {
   errorMessageCallback: (error: FpError) => void;
   children: ReactNode;
@@ -38,14 +36,12 @@ export class ErrorBoundary extends Component<Props, State> {
   override componentDidCatch(error: Error, info: ErrorInfo): void {
     const { errorMessageCallback } = this.props;
 
-    if (!isDevelopment) {
-      withScope(scope => {
-        for (const entry of Object.entries(info)) {
-          scope.setExtra(entry[0], entry[1]);
-          captureException(error);
-        }
-      });
-    }
+    withScope(scope => {
+      for (const entry of Object.entries(info)) {
+        scope.setExtra(entry[0], entry[1]);
+        captureException(error);
+      }
+    });
 
     const errorStrings = info.componentStack
       ? [

--- a/packages/app-felles/src/ErrorBoundary.tsx
+++ b/packages/app-felles/src/ErrorBoundary.tsx
@@ -39,8 +39,8 @@ export class ErrorBoundary extends Component<Props, State> {
     withScope(scope => {
       for (const entry of Object.entries(info)) {
         scope.setExtra(entry[0], entry[1]);
-        captureException(error);
       }
+      captureException(error);
     });
 
     const errorStrings = info.componentStack


### PR DESCRIPTION
Det logges kun feil til sentry ved total react crash, slik at errorboundary nåes. Tror det er lurt å logge andre apifeil også.

Ref denne feilen som ikke dukket opp i Sentry: https://nav-it.slack.com/archives/CEKQHNLLU/p1776665116445429