### PR TITLE
FAGSYSTEM-426245: legg til overflow-wrap på dokumentlenke tittel og betinget visning av gjelderFor kolonne

### DIFF
--- a/apps/fp-frontend/.storybook/testdata/dokumenter.ts
+++ b/apps/fp-frontend/.storybook/testdata/dokumenter.ts
@@ -2,20 +2,20 @@ import type { Dokument } from '@navikt/fp-types';
 
 export const dokumenter: Dokument[] = [
   {
-    journalpostId: '35164101',
-    dokumentId: '35164101',
+    journalpostId: '0000',
+    dokumentId: '00000',
     behandlingUuidList: [],
-    tidspunkt: '2025-03-05T17:00:37',
+    tidspunkt: '2025-03-07T17:00:37',
     tittel: 'Inntektsmelding',
     kommunikasjonsretning: 'INN',
+    gjelderFor: 'NAV FAMILIE- OG PENSJONSYTELSER OSLO',
   },
   {
-    journalpostId: '35164102',
-    dokumentId: '35164102',
+    journalpostId: '1111',
+    dokumentId: '11111',
     behandlingUuidList: ['a47091ce-638c-403a-8ef9-b4419b4d4313'],
     tidspunkt: '2025-03-05T17:00:37',
     tittel: 'Søknad for foreldrepenger',
     kommunikasjonsretning: 'INN',
-    gjelderFor: 'NAV FAMILIE- OG PENSJONSYTELSER OSLO',
   },
 ];

--- a/packages/sak/dokumenter/src/DokumenterSakIndex.stories.tsx
+++ b/packages/sak/dokumenter/src/DokumenterSakIndex.stories.tsx
@@ -7,9 +7,6 @@ import { DokumenterSakIndex } from './DokumenterSakIndex';
 const meta = {
   title: 'sak/sak-dokumenter',
   component: DokumenterSakIndex,
-  decorators: [
-
-  ],
   args: {
     saksnummer: '2',
     behandlingUuid: '1',
@@ -62,7 +59,7 @@ export const Default: Story = {
         journalpostId: '5',
         dokumentId: '5',
         behandlingUuidList: [],
-        tittel: 'Dette er et femte dokument',
+        tittel: '2023.11.11_NAV_Innvilgelsesbrev_svangerskapspenger.pdf',
         tidspunkt: '2017-04-01T02:54:25.455',
         kommunikasjonsretning: 'INN',
         gjelderFor: 'test5',

--- a/packages/sak/dokumenter/src/DokumenterSakIndex.stories.tsx
+++ b/packages/sak/dokumenter/src/DokumenterSakIndex.stories.tsx
@@ -1,29 +1,19 @@
-import type { Meta, ReactRenderer, StoryObj } from '@storybook/react';
-import type { DecoratorFunction } from 'storybook/internal/types';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import type { Dokument } from '@navikt/fp-types';
 
 import { DokumenterSakIndex } from './DokumenterSakIndex';
 
-import '@navikt/ft-ui-komponenter/dist/style.css';
-
-const withStyleProvider: DecoratorFunction<ReactRenderer> = Story => (
-  <div
-    style={{
-      width: '700px',
-      margin: '50px',
-      padding: '20px',
-      backgroundColor: 'var(--ax-bg-default)',
-    }}
-  >
-    <Story />
-  </div>
-);
-
 const meta = {
   title: 'sak/sak-dokumenter',
   component: DokumenterSakIndex,
-  decorators: [withStyleProvider],
+  decorators: [
+    Story => (
+      <div>
+        <Story />
+      </div>
+    ),
+  ],
   args: {
     saksnummer: '2',
     behandlingUuid: '1',

--- a/packages/sak/dokumenter/src/DokumenterSakIndex.stories.tsx
+++ b/packages/sak/dokumenter/src/DokumenterSakIndex.stories.tsx
@@ -8,11 +8,7 @@ const meta = {
   title: 'sak/sak-dokumenter',
   component: DokumenterSakIndex,
   decorators: [
-    Story => (
-      <div>
-        <Story />
-      </div>
-    ),
+
   ],
   args: {
     saksnummer: '2',

--- a/packages/sak/dokumenter/src/components/DocumentList.tsx
+++ b/packages/sak/dokumenter/src/components/DocumentList.tsx
@@ -29,21 +29,14 @@ interface Props {
 export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) => {
   const intl = useIntl();
 
-  const [valgteDokumenter, setValgteDokumenter] = useState<string[]>([]);
+  const [valgteDokumentKeys, setValgteDokumentKeys] = useState<string[]>([]);
   const toggleValgDokument = (dokument: Dokument) =>
-    setValgteDokumenter(dokumentKeys => {
+    setValgteDokumentKeys(dokumentKeys => {
       const key = getDokumentKey(dokument);
       return dokumentKeys.includes(key) ? dokumentKeys.filter(id => id !== key) : [...dokumentKeys, key];
     });
 
   const [sort, setSort] = useState<SortConfig>({ orderBy: 'tidspunkt', direction: 'descending' });
-  const handleSort = (sortKey: TableHeaders) => {
-    setSort({ orderBy: sortKey, direction: getNextSortingDirection(sortKey, sort) });
-  };
-
-  const sortedDocuments = documents.toSorted(compareByOrder(sort));
-
-  const visGjelderForKolonne = documents.some(d => d.gjelderFor !== undefined);
 
   if (documents.length === 0) {
     return (
@@ -52,21 +45,29 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
       </BodyShort>
     );
   }
+
+  const visGjelderForKolonne = documents.some(d => d.gjelderFor !== undefined);
+  const sortedDocuments = documents.toSorted(compareByOrder(sort));
+
+  const handleSort = (sortKey: TableHeaders) => {
+    setSort({ orderBy: sortKey, direction: getNextSortingDirection(sortKey, sort) });
+  };
+
   return (
     <HStack gap="space-8">
-      {valgteDokumenter.length > 0 && (
+      {valgteDokumentKeys.length > 0 && (
         <Button
           size="small"
           variant="primary"
-          onClick={() =>
+          onClick={() => {
             documents
-              .filter(d => valgteDokumenter.includes(getDokumentKey(d)))
+              .filter(d => valgteDokumentKeys.includes(getDokumentKey(d)))
               .forEach(dokument => {
                 åpneDokument(saksnummer, dokument.journalpostId, dokument.dokumentId, dokument.tittel ?? undefined);
-              })
-          }
+              });
+          }}
         >
-          <FormattedMessage id="DocumentList.LastNedKnapp" values={{ antall: valgteDokumenter.length }} />
+          <FormattedMessage id="DocumentList.LastNedKnapp" values={{ antall: valgteDokumentKeys.length }} />
         </Button>
       )}
 
@@ -76,12 +77,12 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
             <Table.HeaderCell>
               <Checkbox
                 size="small"
-                checked={valgteDokumenter.length === sortedDocuments.length}
-                indeterminate={valgteDokumenter.length > 0 && valgteDokumenter.length !== sortedDocuments.length}
+                checked={valgteDokumentKeys.length === sortedDocuments.length}
+                indeterminate={valgteDokumentKeys.length > 0 && valgteDokumentKeys.length !== sortedDocuments.length}
                 onChange={() =>
-                  valgteDokumenter.length > 0
-                    ? setValgteDokumenter([])
-                    : setValgteDokumenter(sortedDocuments.map(getDokumentKey))
+                  valgteDokumentKeys.length > 0
+                    ? setValgteDokumentKeys([])
+                    : setValgteDokumentKeys(sortedDocuments.map(getDokumentKey))
                 }
                 hideLabel
               >
@@ -111,7 +112,7 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
                 <Checkbox
                   size="small"
                   hideLabel
-                  checked={valgteDokumenter.includes(getDokumentKey(document))}
+                  checked={valgteDokumentKeys.includes(getDokumentKey(document))}
                   onChange={() => toggleValgDokument(document)}
                   aria-labelledby={document.tittel ?? undefined}
                 >

--- a/packages/sak/dokumenter/src/components/DocumentList.tsx
+++ b/packages/sak/dokumenter/src/components/DocumentList.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { StarFillIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Checkbox, HStack, Table } from '@navikt/ds-react';
+import { BodyShort, Button, Checkbox, HStack, Table, VStack } from '@navikt/ds-react';
 import { DateTimeLabel } from '@navikt/ft-ui-komponenter';
 
 import type { Dokument } from '@navikt/fp-types';
@@ -54,11 +54,12 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
   };
 
   return (
-    <HStack gap="space-8">
+    <VStack gap="space-8">
       {valgteDokumentKeys.length > 0 && (
         <Button
           size="small"
           variant="primary"
+          className="self-start"
           onClick={() => {
             documents
               .filter(d => valgteDokumentKeys.includes(getDokumentKey(d)))
@@ -114,9 +115,8 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
                   hideLabel
                   checked={valgteDokumentKeys.includes(getDokumentKey(document))}
                   onChange={() => toggleValgDokument(document)}
-                  aria-labelledby={document.tittel ?? undefined}
                 >
-                  {' '}
+                  {document.tittel}
                 </Checkbox>
               </Table.DataCell>
               <Table.DataCell>
@@ -153,6 +153,6 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
           ))}
         </Table.Body>
       </Table>
-    </HStack>
+    </VStack>
   );
 };

--- a/packages/sak/dokumenter/src/components/DocumentList.tsx
+++ b/packages/sak/dokumenter/src/components/DocumentList.tsx
@@ -115,8 +115,9 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
                   hideLabel
                   checked={valgteDokumentKeys.includes(getDokumentKey(document))}
                   onChange={() => toggleValgDokument(document)}
+                  aria-label={document.tittel}
                 >
-                  {document.tittel}
+                  {' '}
                 </Checkbox>
               </Table.DataCell>
               <Table.DataCell>

--- a/packages/sak/dokumenter/src/components/DocumentList.tsx
+++ b/packages/sak/dokumenter/src/components/DocumentList.tsx
@@ -1,18 +1,22 @@
 import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import {
-  ChevronLeftCircleFillIcon,
-  ChevronRightCircleFillIcon,
-  NotePencilFillIcon,
-  StarFillIcon,
-} from '@navikt/aksel-icons';
-import { BodyShort, Button, Checkbox, type SortState, Table } from '@navikt/ds-react';
+import { StarFillIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, Checkbox, HStack, Table } from '@navikt/ds-react';
 import { DateTimeLabel } from '@navikt/ft-ui-komponenter';
 
 import type { Dokument } from '@navikt/fp-types';
 import { DokumentLink } from '@navikt/fp-ui-komponenter';
 import { åpneDokument } from '@navikt/fp-utils';
+
+import {
+  compareByOrder,
+  getDokumentKey,
+  getNextSortingDirection,
+  type SortConfig,
+  type TableHeaders,
+} from './documentListUtils';
+import { KommunikasjonsretningIkon } from './KommunikasjonsretningIkon';
 
 import styles from './documentList.module.css';
 
@@ -22,107 +26,24 @@ interface Props {
   saksnummer: string;
 }
 
-type TableHeaders = 'kommunikasjonsretning' | 'tittel' | 'gjelderFor' | 'tidspunkt';
-
-const KommunikasjonsretningIkon = ({
-  kommunikasjonsretning,
-}: {
-  kommunikasjonsretning: Dokument['kommunikasjonsretning'];
-}) => {
-  const intl = useIntl();
-  if (kommunikasjonsretning === 'INN') {
-    return (
-      <span className={styles['kommunikasjonsretning']}>
-        <ChevronRightCircleFillIcon
-          color="var(--ax-meta-purple-900)"
-          width={25}
-          height={25}
-          title={intl.formatMessage({ id: 'DocumentList.Motta' })}
-        />
-        <FormattedMessage id="DocumentList.Motta" />
-      </span>
-    );
-  }
-  if (kommunikasjonsretning === 'UT') {
-    return (
-      <span className={styles['kommunikasjonsretning']}>
-        <ChevronLeftCircleFillIcon
-          color="var(--ax-meta-purple-500)"
-          width={25}
-          height={25}
-          title={intl.formatMessage({ id: 'DocumentList.Send' })}
-        />
-        <FormattedMessage id="DocumentList.Send" />
-      </span>
-    );
-  }
-  return (
-    <span className={styles['kommunikasjonsretning']}>
-      <NotePencilFillIcon
-        color="var(--ax-neutral-800)"
-        width={25}
-        height={25}
-        title={intl.formatMessage({ id: 'DocumentList.Intern' })}
-      />
-      <FormattedMessage id="DocumentList.Intern" />
-    </span>
-  );
-};
-
-/**
- * DocumentList
- *
- * Presentasjonskomponent. Viser dokumenter i en liste. Tar også inn en callback-funksjon som blir
- * trigget når saksbehandler velger et dokument. Finnes ingen dokumenter blir det kun vist en label
- * som viser at ingen dokumenter finnes på fagsak.
- */
 export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) => {
   const intl = useIntl();
 
-  // Logikk for å toggle checkboxes tilpasset fra Aksel-eksempel: https://aksel.nav.no/komponenter/core/table#tabledemo-selectable
-  const [valgteDokumentIder, setValgteDokumentIder] = useState<string[]>([]);
-  const toggleValgDokument = (dokumentId: string) =>
-    setValgteDokumentIder(dokumentIder =>
-      dokumentIder.includes(dokumentId) ? dokumentIder.filter(id => id !== dokumentId) : [...dokumentIder, dokumentId],
-    );
+  const [valgteDokumenter, setValgteDokumenter] = useState<string[]>([]);
+  const toggleValgDokument = (dokument: Dokument) =>
+    setValgteDokumenter(dokumentKeys => {
+      const key = getDokumentKey(dokument);
+      return dokumentKeys.includes(key) ? dokumentKeys.filter(id => id !== key) : [...dokumentKeys, key];
+    });
 
-  // Logikk for å sortere tabell tilpasset fra Aksel-eksempel: https://aksel.nav.no/komponenter/core/table#tabledemo-sortable
-  const [sort, setSort] = useState<SortState | undefined>({ orderBy: 'tidspunkt', direction: 'descending' });
+  const [sort, setSort] = useState<SortConfig>({ orderBy: 'tidspunkt', direction: 'descending' });
   const handleSort = (sortKey: TableHeaders) => {
-    setSort(
-      sortKey === sort?.orderBy && sort.direction === 'descending'
-        ? undefined
-        : {
-            orderBy: sortKey,
-            direction: sortKey === sort?.orderBy && sort.direction === 'ascending' ? 'descending' : 'ascending',
-          },
-    );
-  };
-  const comparator = (a: Dokument, b: Dokument, orderBy: TableHeaders) => {
-    const aValue = a[orderBy];
-    const bValue = b[orderBy];
-
-    if (!aValue || !bValue) {
-      return -1;
-    }
-
-    if (bValue < aValue) {
-      return -1;
-    }
-    if (bValue > aValue) {
-      return 1;
-    }
-    return 0;
+    setSort({ orderBy: sortKey, direction: getNextSortingDirection(sortKey, sort) });
   };
 
-  const sortedDocuments = documents.slice().sort((a, b) => {
-    if (sort) {
-      return sort.direction === 'ascending'
-        ? comparator(b, a, sort.orderBy as TableHeaders)
-        : comparator(a, b, sort.orderBy as TableHeaders);
-    }
-    return 1;
-  });
+  const sortedDocuments = documents.toSorted(compareByOrder(sort));
+
+  const visGjelderForKolonne = documents.some(d => d.gjelderFor !== undefined);
 
   if (documents.length === 0) {
     return (
@@ -132,34 +53,35 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
     );
   }
   return (
-    <>
-      {valgteDokumentIder.length > 0 && (
+    <HStack gap="space-8">
+      {valgteDokumenter.length > 0 && (
         <Button
+          size="small"
+          variant="primary"
           onClick={() =>
             documents
-              .filter(d => valgteDokumentIder.includes(d.dokumentId))
+              .filter(d => valgteDokumenter.includes(getDokumentKey(d)))
               .forEach(dokument => {
                 åpneDokument(saksnummer, dokument.journalpostId, dokument.dokumentId, dokument.tittel ?? undefined);
               })
           }
-          className={styles['openDocumentButton']}
-          size="small"
-          variant="primary"
         >
-          <FormattedMessage id="DocumentList.LastNedKnapp" values={{ antall: valgteDokumentIder.length }} />
+          <FormattedMessage id="DocumentList.LastNedKnapp" values={{ antall: valgteDokumenter.length }} />
         </Button>
       )}
+
       <Table size="small" sort={sort} onSortChange={sortKey => handleSort(sortKey as TableHeaders)}>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>
               <Checkbox
-                checked={valgteDokumentIder.length === sortedDocuments.length}
-                indeterminate={valgteDokumentIder.length > 0 && valgteDokumentIder.length !== sortedDocuments.length}
+                size="small"
+                checked={valgteDokumenter.length === sortedDocuments.length}
+                indeterminate={valgteDokumenter.length > 0 && valgteDokumenter.length !== sortedDocuments.length}
                 onChange={() =>
-                  valgteDokumentIder.length > 0
-                    ? setValgteDokumentIder([])
-                    : setValgteDokumentIder(sortedDocuments.map(({ dokumentId }) => dokumentId))
+                  valgteDokumenter.length > 0
+                    ? setValgteDokumenter([])
+                    : setValgteDokumenter(sortedDocuments.map(getDokumentKey))
                 }
                 hideLabel
               >
@@ -172,9 +94,11 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
             <Table.ColumnHeader sortKey="tittel" sortable>
               <FormattedMessage id="DocumentList.DocumentType" />
             </Table.ColumnHeader>
-            <Table.ColumnHeader sortKey="gjelderFor" sortable>
-              <FormattedMessage id="DocumentList.Gjelder" />
-            </Table.ColumnHeader>
+            {visGjelderForKolonne && (
+              <Table.ColumnHeader sortKey="gjelderFor" sortable>
+                <FormattedMessage id="DocumentList.Gjelder" />
+              </Table.ColumnHeader>
+            )}
             <Table.ColumnHeader sortKey="tidspunkt" sortable>
               <FormattedMessage id="DocumentList.DateTime" />
             </Table.ColumnHeader>
@@ -182,12 +106,13 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
         </Table.Header>
         <Table.Body>
           {sortedDocuments.map(document => (
-            <Table.Row key={document.dokumentId}>
+            <Table.Row key={getDokumentKey(document)}>
               <Table.DataCell>
                 <Checkbox
+                  size="small"
                   hideLabel
-                  checked={valgteDokumentIder.includes(document.dokumentId)}
-                  onChange={() => toggleValgDokument(document.dokumentId)}
+                  checked={valgteDokumenter.includes(getDokumentKey(document))}
+                  onChange={() => toggleValgDokument(document)}
                   aria-labelledby={document.tittel ?? undefined}
                 >
                   {' '}
@@ -197,35 +122,36 @@ export const DocumentList = ({ documents, behandlingUuid, saksnummer }: Props) =
                 <KommunikasjonsretningIkon kommunikasjonsretning={document.kommunikasjonsretning} />
               </Table.DataCell>
               <Table.DataCell scope="row">
-                {document.behandlingUuidList &&
-                  behandlingUuid &&
-                  document.behandlingUuidList.includes(behandlingUuid) && (
-                    <StarFillIcon
-                      className={styles['image']}
-                      title={intl.formatMessage({ id: 'DocumentList.IBruk' })}
-                    />
-                  )}
-                <DokumentLink
-                  saksnummer={saksnummer}
-                  journalpostId={document.journalpostId}
-                  dokumentId={document.dokumentId}
-                  dokumentTittel={document.tittel ?? undefined}
-                />
+                <HStack gap="space-4" wrap={false}>
+                  {document.behandlingUuidList &&
+                    behandlingUuid &&
+                    document.behandlingUuidList.includes(behandlingUuid) && (
+                      <StarFillIcon
+                        color="var(--ax-warning-500)"
+                        fontSize="1.25rem"
+                        title={intl.formatMessage({ id: 'DocumentList.IBruk' })}
+                      />
+                    )}
+                  <DokumentLink
+                    saksnummer={saksnummer}
+                    journalpostId={document.journalpostId}
+                    dokumentId={document.dokumentId}
+                    dokumentTittel={document.tittel ?? undefined}
+                  />
+                </HStack>
               </Table.DataCell>
-              <Table.DataCell>{document.gjelderFor}</Table.DataCell>
+              {visGjelderForKolonne && <Table.DataCell>{document.gjelderFor}</Table.DataCell>}
               <Table.DataCell>
                 {document.tidspunkt ? (
                   <DateTimeLabel dateTimeString={document.tidspunkt} />
                 ) : (
-                  <BodyShort size="small">
-                    <FormattedMessage id="DocumentList.IProduksjon" />
-                  </BodyShort>
+                  <FormattedMessage id="DocumentList.IProduksjon" />
                 )}
               </Table.DataCell>
             </Table.Row>
           ))}
         </Table.Body>
       </Table>
-    </>
+    </HStack>
   );
 };

--- a/packages/sak/dokumenter/src/components/KommunikasjonsretningIkon.tsx
+++ b/packages/sak/dokumenter/src/components/KommunikasjonsretningIkon.tsx
@@ -1,0 +1,40 @@
+import { useIntl } from 'react-intl';
+
+import { ChevronLeftCircleFillIcon, ChevronRightCircleFillIcon, NotePencilFillIcon } from '@navikt/aksel-icons';
+
+import type { Dokument } from '@navikt/fp-types';
+
+import styles from './documentList.module.css';
+
+interface Props {
+  kommunikasjonsretning: Dokument['kommunikasjonsretning'];
+}
+export const KommunikasjonsretningIkon = ({ kommunikasjonsretning }: Props) => {
+  const intl = useIntl();
+
+  if (kommunikasjonsretning === 'INN') {
+    const mottaText = intl.formatMessage({ id: 'DocumentList.Motta' });
+    return (
+      <span className={styles['kommunikasjonsretning']}>
+        <ChevronRightCircleFillIcon color="var(--ax-meta-purple-900)" fontSize="1.5rem" title={mottaText} />
+        {mottaText}
+      </span>
+    );
+  }
+  if (kommunikasjonsretning === 'UT') {
+    const sendText = intl.formatMessage({ id: 'DocumentList.Send' });
+    return (
+      <span className={styles['kommunikasjonsretning']}>
+        <ChevronLeftCircleFillIcon color="var(--ax-meta-purple-500)" fontSize="1.5rem" title={sendText} />
+        {sendText}
+      </span>
+    );
+  }
+  const internText = intl.formatMessage({ id: 'DocumentList.Intern' });
+  return (
+    <span className={styles['kommunikasjonsretning']}>
+      <NotePencilFillIcon color="var(--ax-neutral-800)" fontSize="1.5rem" title={internText} />
+      {internText}
+    </span>
+  );
+};

--- a/packages/sak/dokumenter/src/components/documentList.module.css
+++ b/packages/sak/dokumenter/src/components/documentList.module.css
@@ -1,9 +1,3 @@
-.image {
-  color: var(--ax-warning-500);
-  height: 20px;
-  width: 25px;
-}
-
 .noDocuments {
   margin-top: 30px;
 }
@@ -12,8 +6,4 @@
   align-items: center;
   display: flex;
   gap: var(--ax-space-8);
-}
-
-.dokumentlenke {
-  word-break: break-word;
 }

--- a/packages/sak/dokumenter/src/components/documentList.module.css
+++ b/packages/sak/dokumenter/src/components/documentList.module.css
@@ -3,18 +3,17 @@
   height: 20px;
   width: 25px;
 }
+
 .noDocuments {
   margin-top: 30px;
 }
+
 .kommunikasjonsretning {
   align-items: center;
   display: flex;
   gap: var(--ax-space-8);
 }
+
 .dokumentlenke {
-  cursor: pointer;
-  display: inline;
-}
-.openDocumentButton {
-  margin-top: var(--ax-space-8);
+  word-break: break-word;
 }

--- a/packages/sak/dokumenter/src/components/documentListUtils.spec.ts
+++ b/packages/sak/dokumenter/src/components/documentListUtils.spec.ts
@@ -1,0 +1,64 @@
+import type { Dokument } from '@navikt/fp-types';
+
+import { compareByOrder, getNextSortingDirection } from './documentListUtils';
+
+const lagDokumentMedTittel = (tittel: string | undefined): Dokument => ({
+  journalpostId: 'jp1',
+  dokumentId: 'dok1',
+  kommunikasjonsretning: 'INN',
+  tittel,
+});
+
+describe('documentListUtils', () => {
+  describe('compareByOrder', () => {
+    const inputOrder = [
+      ' Terminbekreftelse',
+      'Avslutningstillatelse',
+      undefined,
+      'Søknad',
+      'Inntektsmelding',
+      undefined,
+    ];
+    const expectedAscending = [
+      'Avslutningstillatelse',
+      'Inntektsmelding',
+      'Søknad',
+      ' Terminbekreftelse',
+      undefined,
+      undefined,
+    ];
+
+    const sorted = (direction: 'ascending' | 'descending' | 'none') =>
+      inputOrder
+        .map(lagDokumentMedTittel)
+        .toSorted(compareByOrder({ orderBy: 'tittel', direction }))
+        .map(d => d.tittel);
+
+    it('skal sortere dokumenter stigende etter tittel', () => {
+      expect(sorted('ascending')).toEqual(expectedAscending);
+    });
+
+    it('skal sortere dokumenter synkende etter tittel', () => {
+      expect(sorted('descending')).toEqual(expectedAscending.toReversed());
+    });
+
+    it('skal ikke sortere dokumenter når direction er none', () => {
+      expect(sorted('none')).toEqual(inputOrder);
+    });
+  });
+
+  describe('getNextSortingDirection', () => {
+    const sortKey = 'tittel';
+    it('skal returnere ascending når sortKey er en ny kolonne', () => {
+      expect(getNextSortingDirection(sortKey, { orderBy: 'tidspunkt', direction: 'descending' })).toBe('ascending');
+      expect(getNextSortingDirection(sortKey, { orderBy: 'tidspunkt', direction: 'ascending' })).toBe('ascending');
+      expect(getNextSortingDirection(sortKey, { orderBy: 'tidspunkt', direction: 'none' })).toBe('ascending');
+    });
+
+    it('skal sykle sorterings retning for endring på samme kolonne', () => {
+      expect(getNextSortingDirection(sortKey, { orderBy: sortKey, direction: 'ascending' })).toBe('descending');
+      expect(getNextSortingDirection(sortKey, { orderBy: sortKey, direction: 'descending' })).toBe('none');
+      expect(getNextSortingDirection(sortKey, { orderBy: sortKey, direction: 'none' })).toBe('ascending');
+    });
+  });
+});

--- a/packages/sak/dokumenter/src/components/documentListUtils.ts
+++ b/packages/sak/dokumenter/src/components/documentListUtils.ts
@@ -1,0 +1,47 @@
+import type { Dokument } from '@navikt/fp-types';
+
+export type TableHeaders = 'kommunikasjonsretning' | 'tittel' | 'gjelderFor' | 'tidspunkt';
+export type SortConfig = { orderBy: TableHeaders; direction: 'ascending' | 'descending' | 'none' };
+
+const comparator = (orderBy: TableHeaders, aDok: Dokument, bDok: Dokument): number => {
+  const a = aDok[orderBy]?.trim();
+  const b = bDok[orderBy]?.trim();
+
+  if (a != undefined && b != undefined) {
+    return a.localeCompare(b);
+  }
+  if (a == undefined && b == undefined) {
+    return 0;
+  }
+  return a == undefined ? 1 : -1;
+};
+
+export const compareByOrder =
+  (sort: SortConfig) =>
+  (a: Dokument, b: Dokument): number => {
+    switch (sort.direction) {
+      case 'ascending':
+        return comparator(sort.orderBy, a, b);
+      case 'descending':
+        return comparator(sort.orderBy, b, a);
+      default:
+        return 1;
+    }
+  };
+
+export const getNextSortingDirection = (newSortKey: TableHeaders, currentSortState: SortConfig) => {
+  if (newSortKey !== currentSortState.orderBy) {
+    return 'ascending';
+  }
+
+  switch (currentSortState.direction) {
+    case 'ascending':
+      return 'descending';
+    case 'descending':
+      return 'none';
+    case 'none':
+      return 'ascending';
+  }
+};
+
+export const getDokumentKey = (dokument: Dokument) => `${dokument.journalpostId}-${dokument.dokumentId}`;

--- a/packages/sak/dokumenter/src/components/documentListUtils.ts
+++ b/packages/sak/dokumenter/src/components/documentListUtils.ts
@@ -7,13 +7,13 @@ const comparator = (orderBy: TableHeaders, aDok: Dokument, bDok: Dokument): numb
   const a = aDok[orderBy]?.trim();
   const b = bDok[orderBy]?.trim();
 
-  if (a != undefined && b != undefined) {
+  if (a !== undefined && b !== undefined) {
     return a.localeCompare(b);
   }
-  if (a == undefined && b == undefined) {
+  if (a === undefined && b === undefined) {
     return 0;
   }
-  return a == undefined ? 1 : -1;
+  return a === undefined ? 1 : -1;
 };
 
 export const compareByOrder =

--- a/packages/sak/dokumenter/src/components/documentListUtils.ts
+++ b/packages/sak/dokumenter/src/components/documentListUtils.ts
@@ -25,7 +25,7 @@ export const compareByOrder =
       case 'descending':
         return comparator(sort.orderBy, b, a);
       default:
-        return 1;
+        return 0;
     }
   };
 

--- a/packages/ui-komponenter/src/DokumentLink.tsx
+++ b/packages/ui-komponenter/src/DokumentLink.tsx
@@ -23,7 +23,13 @@ export const DokumentLink = ({
   const url = hentDokumentLenke(saksnummer, journalpostId, dokumentId);
 
   return (
-    <Link href={url} target={target} rel="noopener noreferrer" onClick={openDocumentFromLink(dokumentTittel)}>
+    <Link
+      href={url}
+      target={target}
+      rel="noopener noreferrer"
+      onClick={openDocumentFromLink(dokumentTittel)}
+      className="wrap-anywhere"
+    >
       {children ?? dokumentTittel}
     </Link>
   );


### PR DESCRIPTION
Buggen oppstod fordi dokumentlisten innholdt et dokument med lang tittel uten mellomrom. f.eks. `'2023.11.11_NAV_Innvilgelsesbrev_svangerskapspenger.pdf'` denne har ingen naturlig word-break, derfor forsvant tidspunkt-kolonnen ut av skjermen. 
`overflow-wrap: anywhere;` fikser dette for tilfeller hvor filnavn er dokumenttittel. Dokumenter med mellomrom i navnet vil brekke på naturlig sted som før (f.eks. `Søknad om foreldrepenger`)


##  Andre Endringer

- Skjuler `Gjelder`-kolonnen, når det ikke finnes dokumenter om har den satt.
- Ekstraherer `KommunikasjonsretningIkon` til egen komponentfil
- Ekstraherer sorteringslogikk og hjelpefunksjoner til `documentListUtils.ts`
- Legger til enhetstester for utils i `documentListUtils.spec.ts`
- Forenkler `DocumentList.tsx` ved å bruke de nye abstraksjonene