### PR TITLE
Prevent page reload on Enter in gruppe name field

### DIFF
--- a/apps/fp-avdelingsleder/src/grupper/GruppeSaksbehandlere.tsx
+++ b/apps/fp-avdelingsleder/src/grupper/GruppeSaksbehandlere.tsx
@@ -114,7 +114,7 @@ export const GruppeSaksbehandlere = ({ valgAvdeldingEnhet, saksbehandlerGruppe, 
   };
 
   return (
-    <RhfForm formMethods={formMethods}>
+    <RhfForm formMethods={formMethods} onSubmit={() => undefined}>
       <VStack gap="space-20">
         <RhfTextField
           name="navn"


### PR DESCRIPTION
RhfForm without onSubmit renders <form onSubmit={undefined}>, so the browser default submit fires on Enter, reloading the page. Adding a no-op onSubmit handler lets handleSubmit call preventDefault. Saving already happens via onBlur debounce.

Testet Ky branchen min og fant denne lille buggen