### PR TITLE
TFP-6947: Hent personoversikt per panel istedenfor globalt

### DIFF
--- a/apps/fp-frontend/src/behandling/BehandlingPanelerIndex.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingPanelerIndex.tsx
@@ -36,18 +36,12 @@ export const BehandlingPanelerIndex = () => {
   const arbeidsgivereOversiktQuery = useQuery(
     behandlingApi.arbeidsgiverOversiktOptions(behandling, erFørstegangssøknadEllerRevurdering),
   );
-  const behandlingPersonoversiktQuery = useQuery(
-    behandlingApi.behandlingPersonoversiktOptions(behandling, erFørstegangssøknadEllerRevurdering),
-  );
 
-  if (
-    erFørstegangssøknadEllerRevurdering &&
-    (arbeidsgivereOversiktQuery.isPending || behandlingPersonoversiktQuery.isPending)
-  ) {
+  if (erFørstegangssøknadEllerRevurdering && arbeidsgivereOversiktQuery.isPending) {
     return <LoadingPanel />;
   }
 
-  if (arbeidsgivereOversiktQuery.isError || behandlingPersonoversiktQuery.isError) {
+  if (arbeidsgivereOversiktQuery.isError) {
     return <ErrorPage />;
   }
 
@@ -73,7 +67,6 @@ export const BehandlingPanelerIndex = () => {
               valgtProsessSteg={query['punkt']}
               valgtFaktaSteg={query['fakta']}
               arbeidsgivere={notEmpty(arbeidsgivereOversiktQuery.data).arbeidsgivere}
-              personoversikt={behandlingPersonoversiktQuery.data!} // TODO: [JOHANNES]: midlertidig fiks frme til vi finner en god løsning
             />
           </ErrorBoundary>
         </Suspense>
@@ -85,7 +78,6 @@ export const BehandlingPanelerIndex = () => {
               valgtProsessSteg={query['punkt']}
               valgtFaktaSteg={query['fakta']}
               arbeidsgivere={notEmpty(arbeidsgivereOversiktQuery.data).arbeidsgivere}
-              personoversikt={behandlingPersonoversiktQuery.data!} // TODO: [JOHANNES]: midlertidig fiks frme til vi finner en god løsning
             />
           </ErrorBoundary>
         </Suspense>

--- a/apps/fp-frontend/src/behandling/foreldrepenger/ForeldrepengerPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/ForeldrepengerPaneler.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import type { ArbeidsgiverOpplysningerPerId, Personoversikt } from '@navikt/fp-types';
+import type { ArbeidsgiverOpplysningerPerId } from '@navikt/fp-types';
 
 import { FaktaMeny } from '../felles/fakta/FaktaMeny';
 import type { FaktaPanelMedÅpentApInfo } from '../felles/fakta/useFaktaPanelMenyData';
@@ -39,10 +39,9 @@ interface Props {
   valgtProsessSteg: string | undefined;
   valgtFaktaSteg: string | undefined;
   arbeidsgivere: ArbeidsgiverOpplysningerPerId;
-  personoversikt: Personoversikt;
 }
 
-const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere, personoversikt }: Props) => {
+const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
   const [faktaPanelMedÅpentApInfo, setFaktaPanelMedÅpentApInfo] = useState<FaktaPanelMedÅpentApInfo>();
 
   return (
@@ -54,11 +53,8 @@ const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere
         <BeregningsgrunnlagProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <SoknadsfristProsessStegInitPanel />
         <FortsattMedlemskapProsessStegInitPanel />
-        <UttakProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} personoversikt={personoversikt} />
-        <TilkjentYtelseFpProsessStegInitPanel
-          arbeidsgiverOpplysningerPerId={arbeidsgivere}
-          personoversikt={personoversikt}
-        />
+        <UttakProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
+        <TilkjentYtelseFpProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <SimuleringProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <VedtakProsessStegInitPanel />
       </ProsessMeny>
@@ -81,8 +77,8 @@ const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere
         <BeregningFaktaInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <BesteberegningFaktaInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <FordelingFaktaInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
-        <OmsorgOgRettFaktaInitPanel personoversikt={personoversikt} />
-        <OmsorgFaktaInitPanel personoversikt={personoversikt} />
+        <OmsorgOgRettFaktaInitPanel />
+        <OmsorgFaktaInitPanel />
         <UttakFaktaInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <UttakEøsFaktaInitPanel />
         <UttakDokumentasjonFaktaInitPanel />

--- a/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgFaktaInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgFaktaInitPanel.tsx
@@ -6,7 +6,6 @@ import { useQuery } from '@tanstack/react-query';
 import { OmsorgFaktaIndex } from '@navikt/fp-fakta-omsorg';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { FaktaPanelCode } from '@navikt/fp-konstanter';
-import type { Personoversikt } from '@navikt/fp-types';
 import { harAksjonspunkt } from '@navikt/fp-utils';
 
 import { useBehandlingApi } from '../../../data/behandlingApi';
@@ -16,11 +15,7 @@ import { useStandardFaktaPanelProps } from '../../felles/fakta/useStandardFaktaP
 
 const AKSJONSPUNKT_KODER = [AksjonspunktKode.AVKLAR_LØPENDE_OMSORG];
 
-interface Props {
-  personoversikt: Personoversikt;
-}
-
-export const OmsorgFaktaInitPanel = ({ personoversikt }: Props) => {
+export const OmsorgFaktaInitPanel = () => {
   const standardPanelProps = useStandardFaktaPanelProps(AKSJONSPUNKT_KODER);
 
   const { behandling } = useBehandlingDataContext();
@@ -28,7 +23,7 @@ export const OmsorgFaktaInitPanel = ({ personoversikt }: Props) => {
   const api = useBehandlingApi(behandling);
 
   const { data: ytelsefordeling } = useQuery(api.ytelsefordelingOptions(behandling));
-
+  const { data: personoversikt } = useQuery(api.behandlingPersonoversiktOptions(behandling));
   return (
     <FaktaDefaultInitPanel
       standardPanelProps={standardPanelProps}
@@ -36,7 +31,7 @@ export const OmsorgFaktaInitPanel = ({ personoversikt }: Props) => {
       faktaPanelMenyTekst={useIntl().formatMessage({ id: 'FaktaInitPanel.Title.Omsorg' })}
       skalPanelVisesIMeny={AKSJONSPUNKT_KODER.some(kode => harAksjonspunkt(kode, behandling.aksjonspunkt))}
     >
-      {ytelsefordeling ? (
+      {ytelsefordeling && personoversikt ? (
         <OmsorgFaktaIndex ytelsefordeling={ytelsefordeling} personoversikt={personoversikt} />
       ) : (
         <LoadingPanel />

--- a/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgFaktaInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgFaktaInitPanel.tsx
@@ -31,7 +31,7 @@ export const OmsorgFaktaInitPanel = () => {
       faktaPanelMenyTekst={useIntl().formatMessage({ id: 'FaktaInitPanel.Title.Omsorg' })}
       skalPanelVisesIMeny={AKSJONSPUNKT_KODER.some(kode => harAksjonspunkt(kode, behandling.aksjonspunkt))}
     >
-      {ytelsefordeling && personoversikt ? (
+      {ytelsefordeling ? (
         <OmsorgFaktaIndex ytelsefordeling={ytelsefordeling} personoversikt={personoversikt} />
       ) : (
         <LoadingPanel />

--- a/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgOgRettFaktaInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgOgRettFaktaInitPanel.tsx
@@ -35,7 +35,7 @@ export const OmsorgOgRettFaktaInitPanel = () => {
       faktaPanelMenyTekst={useIntl().formatMessage({ id: 'FaktaInitPanel.Title.OmsorgOgRett' })}
       skalPanelVisesIMeny
     >
-      {omsorgOgRett && personoversikt ? (
+      {omsorgOgRett ? (
         <OmsorgOgRettFaktaIndex
           omsorgOgRett={omsorgOgRett}
           personoversikt={personoversikt}

--- a/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgOgRettFaktaInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/faktaPaneler/OmsorgOgRettFaktaInitPanel.tsx
@@ -6,7 +6,6 @@ import { useQuery } from '@tanstack/react-query';
 import { OmsorgOgRettFaktaIndex } from '@navikt/fp-fakta-omsorg-og-rett';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { FaktaPanelCode } from '@navikt/fp-konstanter';
-import type { Personoversikt } from '@navikt/fp-types';
 
 import { useBehandlingApi } from '../../../data/behandlingApi';
 import { useBehandlingDataContext } from '../../felles/context/BehandlingDataContext';
@@ -19,11 +18,7 @@ const AKSJONSPUNKT_KODER = [
   AksjonspunktKode.OVERSTYRING_AV_RETT_OG_OMSORG,
 ];
 
-interface Props {
-  personoversikt?: Personoversikt;
-}
-
-export const OmsorgOgRettFaktaInitPanel = ({ personoversikt }: Props) => {
+export const OmsorgOgRettFaktaInitPanel = () => {
   const standardPanelProps = useStandardFaktaPanelProps(AKSJONSPUNKT_KODER);
 
   const { behandling, rettigheter } = useBehandlingDataContext();
@@ -31,6 +26,7 @@ export const OmsorgOgRettFaktaInitPanel = ({ personoversikt }: Props) => {
   const api = useBehandlingApi(behandling);
 
   const { data: omsorgOgRett } = useQuery(api.omsorgOgRettOptions(behandling));
+  const { data: personoversikt } = useQuery(api.behandlingPersonoversiktOptions(behandling));
 
   return (
     <FaktaDefaultInitPanel
@@ -39,7 +35,7 @@ export const OmsorgOgRettFaktaInitPanel = ({ personoversikt }: Props) => {
       faktaPanelMenyTekst={useIntl().formatMessage({ id: 'FaktaInitPanel.Title.OmsorgOgRett' })}
       skalPanelVisesIMeny
     >
-      {omsorgOgRett ? (
+      {omsorgOgRett && personoversikt ? (
         <OmsorgOgRettFaktaIndex
           omsorgOgRett={omsorgOgRett}
           personoversikt={personoversikt}

--- a/apps/fp-frontend/src/behandling/foreldrepenger/prosessPaneler/TilkjentYtelseFpProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/prosessPaneler/TilkjentYtelseFpProsessStegInitPanel.tsx
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { ProsessStegCode } from '@navikt/fp-konstanter';
 import { TilkjentYtelseProsessIndex } from '@navikt/fp-prosess-tilkjent-ytelse';
-import type { ArbeidsgiverOpplysningerPerId, Personoversikt, VilkårUtfallType } from '@navikt/fp-types';
+import type { ArbeidsgiverOpplysningerPerId, VilkårUtfallType } from '@navikt/fp-types';
 
 import { BehandlingRel, useBehandlingApi } from '../../../data/behandlingApi';
 import { useBehandlingDataContext } from '../../felles/context/BehandlingDataContext';
@@ -17,10 +17,9 @@ const AKSJONSPUNKT_KODER = [AksjonspunktKode.UTGÅTT_5090];
 
 interface Props {
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  personoversikt: Personoversikt;
 }
 
-export const TilkjentYtelseFpProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, personoversikt }: Props) => {
+export const TilkjentYtelseFpProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }: Props) => {
   const intl = useIntl();
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER);
   const { behandling } = useBehandlingDataContext();
@@ -39,6 +38,7 @@ export const TilkjentYtelseFpProsessStegInitPanel = ({ arbeidsgiverOpplysningerP
   const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalHenteData));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
   const { data: feriepengegrunnlag } = useQuery(api.feriepengegrunnlagOptions(behandling, skalHenteData));
+  const { data: personoversikt } = useQuery(api.behandlingPersonoversiktOptions(behandling));
 
   return (
     <ProsessDefaultInitPanel
@@ -48,7 +48,7 @@ export const TilkjentYtelseFpProsessStegInitPanel = ({ arbeidsgiverOpplysningerP
       skalPanelVisesIMeny
       overstyrtStatus={overstyrtStatus}
     >
-      {beregningsresultatDagytelse && familiehendelse && søknad ? (
+      {beregningsresultatDagytelse && familiehendelse && søknad && personoversikt ? (
         <TilkjentYtelseProsessIndex
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
           personoversikt={personoversikt}

--- a/apps/fp-frontend/src/behandling/foreldrepenger/prosessPaneler/UttakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/prosessPaneler/UttakProsessStegInitPanel.tsx
@@ -6,12 +6,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { ProsessStegCode } from '@navikt/fp-konstanter';
 import { UttakProsessIndex } from '@navikt/fp-prosess-uttak';
-import type {
-  ArbeidsgiverOpplysningerPerId,
-  BehandlingFpSak,
-  Personoversikt,
-  VilkårUtfallType,
-} from '@navikt/fp-types';
+import type { ArbeidsgiverOpplysningerPerId, BehandlingFpSak, VilkårUtfallType } from '@navikt/fp-types';
 
 import { harLenke, useBehandlingApi } from '../../../data/behandlingApi';
 import { useBehandlingDataContext } from '../../felles/context/BehandlingDataContext';
@@ -41,10 +36,9 @@ const AKSJONSPUNKT_KODER = [
 
 interface Props {
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  personoversikt: Personoversikt;
 }
 
-export const UttakProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, personoversikt }: Props) => {
+export const UttakProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }: Props) => {
   const intl = useIntl();
 
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER);
@@ -62,6 +56,7 @@ export const UttakProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, perso
   const { data: familieHendelse } = useQuery(api.familiehendelseOptions(behandling, skalHenteData));
   const { data: uttakStønadskontoer } = useQuery(api.uttakStønadskontoerOptions(behandling));
   const { data: annenForelderUttakEøs } = useQuery(api.uttakAnnenpartEøsOptions(behandling));
+  const { data: personoversikt } = useQuery(api.behandlingPersonoversiktOptions(behandling));
 
   const { mutateAsync: oppdaterStønadskontoer } = useMutation({
     mutationFn: api.oppdaterStønadskontoer,
@@ -75,7 +70,7 @@ export const UttakProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, perso
       skalPanelVisesIMeny
       overstyrtStatus={overstyrtStatus}
     >
-      {uttaksresultat && søknad && familieHendelse && uttakStønadskontoer ? (
+      {uttaksresultat && søknad && familieHendelse && uttakStønadskontoer && personoversikt ? (
         <UttakProsessIndex
           kanOverstyre={rettigheter.kanOverstyreAccess.isEnabled}
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}

--- a/apps/fp-frontend/src/behandling/svangerskapspenger/SvangerskapspengerPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/svangerskapspenger/SvangerskapspengerPaneler.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import type { ArbeidsgiverOpplysningerPerId, Personoversikt } from '@navikt/fp-types';
+import type { ArbeidsgiverOpplysningerPerId } from '@navikt/fp-types';
 
 import { FaktaMeny } from '../felles/fakta/FaktaMeny';
 import type { FaktaPanelMedÅpentApInfo } from '../felles/fakta/useFaktaPanelMenyData';
@@ -30,10 +30,9 @@ interface Props {
   valgtProsessSteg: string | undefined;
   valgtFaktaSteg: string | undefined;
   arbeidsgivere: ArbeidsgiverOpplysningerPerId;
-  personoversikt: Personoversikt;
 }
 
-const SvangerskapspengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere, personoversikt }: Props) => {
+const SvangerskapspengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
   const [faktaPanelMedÅpentApInfo, setFaktaPanelMedÅpentApInfo] = useState<FaktaPanelMedÅpentApInfo>();
 
   return (
@@ -44,10 +43,7 @@ const SvangerskapspengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgi
         <BeregningsgrunnlagProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <SoknadsfristProsessStegInitPanel />
         <FortsattMedlemskapProsessStegInitPanel />
-        <TilkjentYtelseProsessStegInitPanel
-          arbeidsgiverOpplysningerPerId={arbeidsgivere}
-          personoversikt={personoversikt}
-        />
+        <TilkjentYtelseProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <SimuleringProsessStegInitPanel arbeidsgiverOpplysningerPerId={arbeidsgivere} />
         <VedtakProsessStegInitPanel />
       </ProsessMeny>

--- a/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }: Props) => {
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER);
-
+  const intl = useIntl();
   const { behandling } = useBehandlingDataContext();
 
   const api = useBehandlingApi(behandling);
@@ -44,7 +44,7 @@ export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPer
     <ProsessDefaultInitPanel
       standardPanelProps={standardPanelProps}
       prosessPanelKode={ProsessStegCode.TILKJENT_YTELSE}
-      prosessPanelMenyTekst={useIntl().formatMessage({ id: 'Behandlingspunkt.TilkjentYtelse' })}
+      prosessPanelMenyTekst={intl.formatMessage({ id: 'Behandlingspunkt.TilkjentYtelse' })}
       skalPanelVisesIMeny
       overstyrtStatus={overstyrtStatus}
     >

--- a/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
@@ -6,7 +6,8 @@ import { useQuery } from '@tanstack/react-query';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { ProsessStegCode } from '@navikt/fp-konstanter';
 import { TilkjentYtelseProsessIndex } from '@navikt/fp-prosess-tilkjent-ytelse';
-import type { ArbeidsgiverOpplysningerPerId, Personoversikt, VilkårUtfallType } from '@navikt/fp-types';
+import type { ArbeidsgiverOpplysningerPerId, VilkårUtfallType } from '@navikt/fp-types';
+import { notEmpty } from '@navikt/fp-utils';
 
 import { BehandlingRel, useBehandlingApi } from '../../../data/behandlingApi';
 import { useBehandlingDataContext } from '../../felles/context/BehandlingDataContext';
@@ -17,10 +18,9 @@ const AKSJONSPUNKT_KODER = [AksjonspunktKode.UTGÅTT_5090];
 
 interface Props {
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
-  personoversikt: Personoversikt;
 }
 
-export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId, personoversikt }: Props) => {
+export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPerId }: Props) => {
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER);
 
   const { behandling } = useBehandlingDataContext();
@@ -39,6 +39,7 @@ export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPer
   const { data: familiehendelse } = useQuery(api.familiehendelseOptions(behandling, skalHenteData));
   const { data: søknad } = useQuery(api.søknadOptions(behandling));
   const { data: feriepengegrunnlag } = useQuery(api.feriepengegrunnlagOptions(behandling, skalHenteData));
+  const { data: personoversikt } = useQuery(api.behandlingPersonoversiktOptions(behandling));
 
   return (
     <ProsessDefaultInitPanel
@@ -51,7 +52,7 @@ export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPer
       {beregningsresultatDagytelse && familiehendelse && søknad ? (
         <TilkjentYtelseProsessIndex
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-          personoversikt={personoversikt}
+          personoversikt={notEmpty(personoversikt)}
           beregningresultat={beregningsresultatDagytelse}
           familiehendelse={familiehendelse}
           søknad={søknad}

--- a/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/TilkjentYtelseProsessStegInitPanel.tsx
@@ -7,7 +7,6 @@ import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { ProsessStegCode } from '@navikt/fp-konstanter';
 import { TilkjentYtelseProsessIndex } from '@navikt/fp-prosess-tilkjent-ytelse';
 import type { ArbeidsgiverOpplysningerPerId, VilkårUtfallType } from '@navikt/fp-types';
-import { notEmpty } from '@navikt/fp-utils';
 
 import { BehandlingRel, useBehandlingApi } from '../../../data/behandlingApi';
 import { useBehandlingDataContext } from '../../felles/context/BehandlingDataContext';
@@ -49,10 +48,10 @@ export const TilkjentYtelseProsessStegInitPanel = ({ arbeidsgiverOpplysningerPer
       skalPanelVisesIMeny
       overstyrtStatus={overstyrtStatus}
     >
-      {beregningsresultatDagytelse && familiehendelse && søknad ? (
+      {beregningsresultatDagytelse && familiehendelse && søknad && personoversikt ? (
         <TilkjentYtelseProsessIndex
           arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-          personoversikt={notEmpty(personoversikt)}
+          personoversikt={personoversikt}
           beregningresultat={beregningsresultatDagytelse}
           familiehendelse={familiehendelse}
           søknad={søknad}

--- a/apps/fp-frontend/src/data/behandlingApi.ts
+++ b/apps/fp-frontend/src/data/behandlingApi.ts
@@ -1,4 +1,4 @@
-import type { FeilutbetalingÅrsak, FeilutbetalingFakta } from '@navikt/ft-fakta-tilbakekreving-feilutbetaling';
+import type { FeilutbetalingÅrsak,FeilutbetalingFakta } from '@navikt/ft-fakta-tilbakekreving-feilutbetaling';
 import type {
   BeregnBeløpParams,
   DetaljerteFeilutbetalingsperioder,
@@ -215,15 +215,14 @@ const getArbeidsgiverOversiktOptions =
       staleTime: Infinity,
     });
 
-const getBehandlingPersonoversiktOptions =
-  (links: ApiLink[]) => (behandling: BehandlingFpSak, erFørstegangssøknadEllerRevurdering: boolean) =>
-    queryOptions({
-      queryKey: [BehandlingRel.BEHANDLING_PERSONOVERSIKT, behandling.uuid, behandling.versjon],
-      queryFn: () => jsonEllerNull<Personoversikt>(kyExtended.get(getUrlFromRel('BEHANDLING_PERSONOVERSIKT', links))),
-      enabled: erFørstegangssøknadEllerRevurdering,
-      staleTime: Infinity,
-      select: data => data ?? undefined,
-    });
+const getBehandlingPersonoversiktOptions = (links: ApiLink[]) => (behandling: BehandlingFpSak) =>
+  queryOptions({
+    queryKey: [BehandlingRel.BEHANDLING_PERSONOVERSIKT, behandling.uuid, behandling.versjon],
+    queryFn: () => jsonEllerNull<Personoversikt>(kyExtended.get(getUrlFromRel('BEHANDLING_PERSONOVERSIKT', links))),
+    enabled: harLenke(behandling, 'BEHANDLING_PERSONOVERSIKT'),
+    staleTime: Infinity,
+    select: data => data ?? undefined,
+  });
 
 const getAnkeVurderingOptions = (links: ApiLink[]) => (behandling: BehandlingFpSak) =>
   queryOptions({

--- a/apps/fp-frontend/src/data/behandlingApi.ts
+++ b/apps/fp-frontend/src/data/behandlingApi.ts
@@ -1,4 +1,4 @@
-import type { FeilutbetalingÅrsak,FeilutbetalingFakta } from '@navikt/ft-fakta-tilbakekreving-feilutbetaling';
+import type { FeilutbetalingÅrsak, FeilutbetalingFakta } from '@navikt/ft-fakta-tilbakekreving-feilutbetaling';
 import type {
   BeregnBeløpParams,
   DetaljerteFeilutbetalingsperioder,

--- a/packages/app-felles/src/app-shell/queryUtils.ts
+++ b/packages/app-felles/src/app-shell/queryUtils.ts
@@ -46,7 +46,7 @@ export const getErrorHandler =
     addErrorMessage: (data: FpError) => void,
     additionalErrorHandler?: (error: Error, addErrorMessage: (data: FpError) => void) => boolean,
   ) =>
-  async (error: Error) => {
+  (error: Error) => {
     // eslint-disable-next-line no-console
     console.log(error);
 

--- a/packages/fakta/omsorg/src/OmsorgFaktaIndex.tsx
+++ b/packages/fakta/omsorg/src/OmsorgFaktaIndex.tsx
@@ -12,7 +12,7 @@ const intl = createIntl(messages);
 
 interface Props {
   ytelsefordeling: Ytelsefordeling;
-  personoversikt: Personoversikt;
+  personoversikt: Personoversikt | undefined;
 }
 
 export const OmsorgFaktaIndex = (props: Props) => (

--- a/packages/fakta/omsorg/src/components/OmsorgInfoPanel.tsx
+++ b/packages/fakta/omsorg/src/components/OmsorgInfoPanel.tsx
@@ -32,7 +32,7 @@ const transformValues = (values: FormValues): BekreftOmsorgVurderingAp => ({
 });
 
 interface Props {
-  personoversikt: Personoversikt;
+  personoversikt: Personoversikt | undefined;
   ytelsefordeling: Ytelsefordeling;
 }
 
@@ -62,7 +62,7 @@ export const OmsorgInfoPanel = ({ personoversikt, ytelsefordeling }: Props) => {
           <FormattedMessage id="OmsorgInfoPanel.VurderOmsorg" />
         </AksjonspunktHelpTextHTML>
       )}
-      <PersonopplysningerForFamilie alleKodeverk={alleKodeverk} personoversikt={personoversikt} />
+      {personoversikt && <PersonopplysningerForFamilie alleKodeverk={alleKodeverk} personoversikt={personoversikt} />}
       {harAksjonspunkt && (
         <RhfForm
           formMethods={formMethods}


### PR DESCRIPTION
## Beskrivelse

Fikser et problem der personoversikt kunne være `null` for behandlinger som ikke er førstegangssøknad eller revurdering.

### Endringer
- Fjerner global henting av `personoversikt` i `BehandlingPanelerIndex` og propdrilling ned til paneler
- Hvert panel som trenger personoversikt (`OmsorgFaktaInitPanel`, `OmsorgOgRettFaktaInitPanel`, `UttakProsessStegInitPanel`, `TilkjentYtelseFpProsessStegInitPanel`, `TilkjentYtelseProsessStegInitPanel`) henter nå sin egen `personoversikt` via `useQuery`
- Bruker `harLenke` i `getBehandlingPersonoversiktOptions` for å aktivere queryen kun når lenken er tilgjengelig, istedenfor å basere seg på behandlingstype

Jira: [TFP-6947](https://jira.adeo.no/browse/TFP-6947)