### PR TITLE
fix: rett ESLint-feil i hent-openapi-spec.js

### DIFF
--- a/packages/types/scripts/hent-openapi-spec.js
+++ b/packages/types/scripts/hent-openapi-spec.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 import fs from 'node:fs';
+import process from 'node:process';
 
-// eslint-disable-next-line no-undef
 const isLokal = process.argv.includes('lokal');
 
+/**
+ * @typedef {{ name: string, url: string, localUrl: string, aud: string }} Source
+ */
+
+/** @type {Source[]} */
 const SOURCES = [
   {
     name: 'fpsak',
@@ -14,12 +19,16 @@ const SOURCES = [
   },
   {
     name: 'fplos',
-    url: 'https://fplos.dev-fss-pub.nais.io/fplos/api/openapi.json',
+    url: 'https://fplos.intern.dev.nav.no/fplos/api/openapi.json',
     localUrl: 'http://localhost:8071/fplos/api/openapi.json',
-    aud: 'dev-fss:teamforeldrepenger:fplos',
+    aud: 'dev-gcp:teamforeldrepenger:fplos',
   },
 ];
 
+/**
+ * @param {string} aud
+ * @returns {Promise<string>}
+ */
 async function hentToken(aud) {
   if (isLokal) {
     console.log('Henter token fra VTP.');
@@ -35,12 +44,10 @@ async function hentToken(aud) {
         scope: 'api://vtp.teamforeldrepenger.vtp/.default',
       }).toString(),
     });
+    /** @type {{ id_token?: string }} */
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const data = await res.json();
-    if ('id_token' in data) {
-      return data.id_token;
-    } else {
-      throw new Error('Could not extract id_token from response');
-    }
+    return data.id_token;
   } else {
     console.log('Henter remote token fra Azure Token Generator.');
     const res = await fetch('https://azure-token-generator.intern.dev.nav.no/api/public/m2m', {
@@ -56,6 +63,10 @@ async function hentToken(aud) {
   }
 }
 
+/**
+ * @param {Source} source
+ * @param {string} token
+ */
 async function hentOpenAPISpec(source, token) {
   const fileName = `${source.name}-swagger.json`;
   const url = isLokal ? source.localUrl : source.url;
@@ -81,6 +92,5 @@ try {
   }
 } catch (error) {
   console.error(error);
-  // eslint-disable-next-line no-undef
   process.exit(1);
 }

--- a/packages/types/scripts/tsconfig.json
+++ b/packages/types/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@navikt/fp-config-typescript",
+  "compilerOptions": {
+    "moduleResolution": "node16",
+    "module": "node16",
+    "types": ["node"],
+    "allowImportingTsExtensions": false
+  },
+  "include": ["./**/*.js"]
+}


### PR DESCRIPTION
## Kva er gjort

- Legg til `import process from 'node:process'` i staden for `eslint-disable no-undef`
- Legg til JSDoc-typar (`@typedef`, `@type`, `@param`, `@returns`) for `Source`-typen, `SOURCES`-arrayen og funksjonane
- Legg til `packages/types/scripts/tsconfig.json` med `moduleResolution: node16` og `types: ["node"]` slik at `node:*`-importar (som `node:fs` og `node:process`) løysest skikkeleg under linting med TypeScript ESLint

## Bakgrunn

Den delte tsconfig-en bruker `moduleResolution: "bundler"` som ikkje kan løyse `node:*`-importar frå `@types/node`. Scriptet er ein Node.js-fil og treng difor eigen tsconfig med `node16`-resolusjon.