### PR TITLE
fix(fakta-fodsel): valider termin/fødsel-avvik likt som backend

### DIFF
--- a/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
+++ b/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
@@ -154,6 +154,29 @@ describe('FodselFaktaIndex', () => {
       });
     });
 
+    it('skal vise feilmelding når fødselsdato er for langt unna termindato', async () => {
+      const lagre = vi.fn(() => Promise.resolve());
+
+      render(<APSjekkManglendeFødselPåForeldrepenger submitCallback={lagre} />);
+
+      const apBoks = within(screen.getByLabelText('Kontroller opplysninger om fødsel'));
+
+      await userEvent.click(apBoks.getByText('Ja'));
+
+      const alleDatofelt = apBoks.getAllByRole('textbox', { hidden: true });
+      const fødselsdatoFelt = alleDatofelt[0]!;
+
+      await userEvent.clear(fødselsdatoFelt);
+      await userEvent.type(fødselsdatoFelt, '02.06.2025');
+      fireEvent.blur(fødselsdatoFelt);
+
+      expect(
+        await apBoks.findByText(
+          'For stort avvik mellom termin og fødsel. Fødsel må være tidligst 19 uker før og senest 6 uker etter termin.',
+        ),
+      ).toBeInTheDocument();
+    });
+
     it('skal bekrefte aksjonspunkt for manglende fødsel ved å velge at dokumentasjon ikke foreligger', async () => {
       const lagre = vi.fn(() => Promise.resolve());
       render(<APSjekkManglendeFødselPåEngangstønad submitCallback={lagre} />);

--- a/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
+++ b/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
@@ -12,11 +12,17 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { BodyShort, Detail, ErrorMessage, HelpText, HStack, Table, VStack } from '@navikt/ds-react';
 import { RhfDatepicker, RhfFieldArrayAppendButton, RhfFieldArrayRemoveButton } from '@navikt/ft-form-hooks';
 import { dateAfterOrEqual, dateBeforeOrEqualToToday, hasValidDate, required } from '@navikt/ft-form-validators';
+import { ISO_DATE_FORMAT } from '@navikt/ft-utils';
 import dayjs from 'dayjs';
 
 import { type FaktaKilde, getLabelForFaktaKilde } from '@navikt/fp-fakta-felles';
 import type { FødselGjeldende } from '@navikt/fp-types';
-import { dødsdatoAfterOrEqualFødselsdato, maxFodselsdato, minFodselsdato } from '@navikt/fp-utils';
+import {
+  dødsdatoAfterOrEqualFødselsdato,
+  fødselErINærhetenAvTermin,
+  maxFodselsdato,
+  minFodselsdato,
+} from '@navikt/fp-utils';
 
 import styles from './barnFieldArray.module.css';
 
@@ -40,6 +46,8 @@ export type BarnFormValues = {
   [FIELD_ARRAY_NAME]: FieldArrayRow[];
 };
 
+type FormValuesMedTermin = BarnFormValues & { termindato?: string };
+
 interface Props {
   isReadOnly: boolean;
 }
@@ -53,17 +61,21 @@ export const BarnFieldArray = ({ isReadOnly }: Props) => {
     setError,
     clearErrors,
     formState: { dirtyFields, errors },
-  } = useFormContext<BarnFormValues>();
+  } = useFormContext<FormValuesMedTermin>();
   const { fields, remove, append } = useFieldArray({ control, name: FIELD_ARRAY_NAME });
 
   const barn = useWatch({
     control,
     name: FIELD_ARRAY_NAME,
   });
+  const termindato = useWatch({
+    control,
+    name: 'termindato',
+  });
 
   useEffect(() => {
     validateAlleFødselsdatoer(getValues, setError, clearErrors);
-  }, [barn]);
+  }, [barn, termindato]);
 
   const today = dayjs().toDate();
 
@@ -211,14 +223,17 @@ const validerDødsdato = (getValues: UseFormGetValues<BarnFormValues>, index: nu
 };
 
 const validateAlleFødselsdatoer = (
-  getValues: UseFormGetValues<BarnFormValues>,
-  setError: UseFormSetError<BarnFormValues>,
-  clearErrors: (name: FieldPath<BarnFormValues>) => void,
+  getValues: UseFormGetValues<FormValuesMedTermin>,
+  setError: UseFormSetError<FormValuesMedTermin>,
+  clearErrors: (name: FieldPath<FormValuesMedTermin>) => void,
 ) => {
   const barn = getValues('barn');
+  const termindato = getValues('termindato');
 
   const { minDate, maxDate } = barn.reduce<{ minDate?: dayjs.Dayjs; maxDate?: dayjs.Dayjs }>((acc, b) => {
+    if (!b.fødselsdato) return acc;
     const date = dayjs(b.fødselsdato);
+    if (!date.isValid()) return acc;
     if (!acc.minDate || date.isBefore(acc.minDate)) acc.minDate = date;
     if (!acc.maxDate || date.isAfter(acc.maxDate)) acc.maxDate = date;
     return acc;
@@ -227,6 +242,14 @@ const validateAlleFødselsdatoer = (
   if (minDate && maxDate && maxDate.diff(minDate, 'day') > 2) {
     setError(FIELD_ARRAY_NAME, { type: 'manual', message: 'Fødseldatoer må være innenfor 2 dager av hverandre' });
     return false;
+  }
+
+  if (minDate) {
+    const avvikFeil = fødselErINærhetenAvTermin(minDate.format(ISO_DATE_FORMAT), termindato);
+    if (avvikFeil) {
+      setError(FIELD_ARRAY_NAME, { type: 'manual', message: avvikFeil });
+      return false;
+    }
   }
 
   clearErrors(FIELD_ARRAY_NAME);

--- a/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
+++ b/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
@@ -230,14 +230,7 @@ const validateAlleFødselsdatoer = (
   const barn = getValues('barn');
   const termindato = getValues('termindato');
 
-  const { minDate, maxDate } = barn.reduce<{ minDate?: dayjs.Dayjs; maxDate?: dayjs.Dayjs }>((acc, b) => {
-    if (!b.fødselsdato) return acc;
-    const date = dayjs(b.fødselsdato);
-    if (!date.isValid()) return acc;
-    if (!acc.minDate || date.isBefore(acc.minDate)) acc.minDate = date;
-    if (!acc.maxDate || date.isAfter(acc.maxDate)) acc.maxDate = date;
-    return acc;
-  }, {});
+  const { minDate, maxDate } = finnMaksOgMinDato(barn);
 
   if (minDate && maxDate && maxDate.diff(minDate, 'day') > 2) {
     setError(FIELD_ARRAY_NAME, { type: 'manual', message: 'Fødseldatoer må være innenfor 2 dager av hverandre' });
@@ -255,3 +248,18 @@ const validateAlleFødselsdatoer = (
   clearErrors(FIELD_ARRAY_NAME);
   return true;
 };
+
+type MaksOgMinDato = { minDate: dayjs.Dayjs | undefined; maxDate: dayjs.Dayjs | undefined };
+
+const finnMaksOgMinDato = (barn: FieldArrayRow[]) =>
+  barn.reduce<MaksOgMinDato>(
+    (acc, b) => {
+      if (!b.fødselsdato) return acc;
+      const date = dayjs(b.fødselsdato);
+      if (!date.isValid()) return acc;
+      if (!acc.minDate || date.isBefore(acc.minDate)) acc.minDate = date;
+      if (!acc.maxDate || date.isAfter(acc.maxDate)) acc.maxDate = date;
+      return acc;
+    },
+    { minDate: undefined, maxDate: undefined },
+  );

--- a/packages/utils/i18n/nb_NO.json
+++ b/packages/utils/i18n/nb_NO.json
@@ -1,4 +1,5 @@
 {
   "ValidationMessage.ForTidligTermin": "Termin kan ikke være mer enn 3 uker før fødsel",
-  "ValidationMessage.ForSenTermin": "Termin kan ikke være mer enn 5 måneder etter fødsel"
+  "ValidationMessage.ForSenTermin": "Termin kan ikke være mer enn 5 måneder etter fødsel",
+  "ValidationMessage.ForStortAvvikTerminFødsel": "For stort avvik mellom termin og fødsel. Fødsel må være tidligst 19 uker før og senest 6 uker etter termin."
 }

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -14,6 +14,7 @@ export {
   maxTerminbekreftelseDato,
   terminBekreftelseBeforeTodayOrTermindato,
   terminErRundtFodselsdato,
+  fødselErINærhetenAvTermin,
   dødsdatoAfterOrEqualFødselsdato,
   validateMinAntallBarn,
   validateMaxAntallBarn,

--- a/packages/utils/src/fødselOgTerminValidator.spec.ts
+++ b/packages/utils/src/fødselOgTerminValidator.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'vitest';
 
 import {
   dødsdatoAfterOrEqualFødselsdato,
+  fødselErINærhetenAvTermin,
   terminBekreftelseBeforeTodayOrTermindato,
   terminErRundtFodselsdato,
 } from './fødselOgTerminValidator';
@@ -116,6 +117,45 @@ describe('fødselOgTerminValidator', () => {
     it('skal feile for dødsdato etter i dag', () => {
       const result = dødsdatoAfterOrEqualFødselsdato(undefined, dayjs().add(1, 'week').format(ISO_DATE_FORMAT));
       expect(result).toEqual(`Dato må være før eller lik ${dayjs().format(DDMMYYYY_DATE_FORMAT)}`);
+    });
+  });
+
+  describe('fødselErINærhetenAvTermin', () => {
+    const termin = dayjs('2025-06-01');
+    const termindato = termin.format(ISO_DATE_FORMAT);
+    const avvikMelding =
+      'For stort avvik mellom termin og fødsel. Fødsel må være tidligst 19 uker før og senest 6 uker etter termin.';
+
+    it('skal godta fødsel på termindato', () => {
+      expect(fødselErINærhetenAvTermin(termindato, termindato)).toBeNull();
+    });
+
+    it('skal godta fødsel akkurat 19 uker før termin', () => {
+      const fødsel = termin.subtract(19, 'weeks').format(ISO_DATE_FORMAT);
+      expect(fødselErINærhetenAvTermin(fødsel, termindato)).toBeNull();
+    });
+
+    it('skal godta fødsel akkurat 6 uker etter termin', () => {
+      const fødsel = termin.add(6, 'weeks').format(ISO_DATE_FORMAT);
+      expect(fødselErINærhetenAvTermin(fødsel, termindato)).toBeNull();
+    });
+
+    it('skal feile for fødsel mer enn 19 uker før termin', () => {
+      const fødsel = termin.subtract(19, 'weeks').subtract(1, 'day').format(ISO_DATE_FORMAT);
+      expect(fødselErINærhetenAvTermin(fødsel, termindato)).toEqual(avvikMelding);
+    });
+
+    it('skal feile for fødsel mer enn 6 uker etter termin', () => {
+      const fødsel = termin.add(6, 'weeks').add(1, 'day').format(ISO_DATE_FORMAT);
+      expect(fødselErINærhetenAvTermin(fødsel, termindato)).toEqual(avvikMelding);
+    });
+
+    it('skal returnere null når termindato mangler', () => {
+      expect(fødselErINærhetenAvTermin(termindato, undefined)).toBeNull();
+    });
+
+    it('skal returnere null når fødselsdato mangler', () => {
+      expect(fødselErINærhetenAvTermin(undefined, termindato)).toBeNull();
     });
   });
 });

--- a/packages/utils/src/fødselOgTerminValidator.spec.ts
+++ b/packages/utils/src/fødselOgTerminValidator.spec.ts
@@ -42,17 +42,17 @@ describe('fødselOgTerminValidator', () => {
 
     it('skal feile for passert terminbekreftelsedato etter overgått termin', () => {
       const result = terminBekreftelseBeforeTodayOrTermindato(terminPassert, terminbekreftelse2ukerPassert);
-      expect(result).toEqual(`Dato må være før eller lik ${dayjs(terminPassert).format('DD.MM.YYYY')}`);
+      expect(result).toEqual(`Dato må være før eller lik ${dayjs(terminPassert).format(DDMMYYYY_DATE_FORMAT)}`);
     });
 
     it('skal feile for foranliggende terminbekreftelsedato etter overgått termin', () => {
       const result = terminBekreftelseBeforeTodayOrTermindato(terminPassert, terminbekreftelseFremtid);
-      expect(result).toEqual(`Dato må være før eller lik ${dayjs(terminPassert).format('DD.MM.YYYY')}`);
+      expect(result).toEqual(`Dato må være før eller lik ${dayjs(terminPassert).format(DDMMYYYY_DATE_FORMAT)}`);
     });
 
     it('skal feile for foranliggende terminbekreftelsedato etter dagens dato', () => {
       const result = terminBekreftelseBeforeTodayOrTermindato(terminFremtidig, terminbekreftelseFremtid);
-      expect(result).toEqual(`Dato må være før eller lik ${dayjs(dagensDato).format('DD.MM.YYYY')}`);
+      expect(result).toEqual(`Dato må være før eller lik ${dayjs(dagensDato).format(DDMMYYYY_DATE_FORMAT)}`);
     });
   });
 

--- a/packages/utils/src/fødselOgTerminValidator.ts
+++ b/packages/utils/src/fødselOgTerminValidator.ts
@@ -60,3 +60,26 @@ export const terminErRundtFodselsdato = (fodselsdato: string | undefined, termin
   if (senesteTermin.isSameOrBefore(termin)) return intl.formatMessage({ id: 'ValidationMessage.ForSenTermin' });
   return null;
 };
+
+// Speiler backend-validering i fpsak (FaktaFødselTjeneste / FamilieHendelseTjeneste.intervallForTermindato):
+// Fødselsdato må ligge i intervallet [termindato - 19 uker, termindato + 6 uker].
+// Hvis denne grensen brytes kaster backend FunksjonellException FP-076346 «For stort avvik termin/fødsel».
+const MAKS_UKER_FØDSEL_FØR_TERMIN = 19;
+const MAKS_UKER_FØDSEL_ETTER_TERMIN = 6;
+
+export const fødselErINærhetenAvTermin = (fødselsdato: string | undefined, termindato: string | undefined) => {
+  const fødsel = fødselsdato ? dayjs(fødselsdato, ISO_DATE_FORMAT) : undefined;
+  const termin = termindato ? dayjs(termindato, ISO_DATE_FORMAT) : undefined;
+
+  if (!fødsel?.isValid() || !termin?.isValid()) {
+    return null;
+  }
+
+  const tidligsteFødsel = termin.subtract(MAKS_UKER_FØDSEL_FØR_TERMIN, 'weeks');
+  const senesteFødsel = termin.add(MAKS_UKER_FØDSEL_ETTER_TERMIN, 'weeks');
+
+  if (fødsel.isBefore(tidligsteFødsel) || fødsel.isAfter(senesteFødsel)) {
+    return intl.formatMessage({ id: 'ValidationMessage.ForStortAvvikTerminFødsel' });
+  }
+  return null;
+};


### PR DESCRIPTION
## Bakgrunn

Backend (fpsak) har følgende validering i `FaktaFødselTjeneste.validerGyldigTerminFødsel`:

```
fødselsdato ∈ [termindato - 19 uker, termindato + 6 uker]
```

(Definert via `FamilieHendelseTjeneste.intervallForTermindato` med `MATCH_INTERVAlL_TERMIN = P19W` og `MATCH_INTERVAlL_FØDSEL = P6W`.)

Hvis grensen brytes kastes `FunksjonellException` **FP-076346** "For stort avvik termin/fødsel". Dette har dukket opp i prod-loggene fordi frontend ikke gjorde tilsvarende validering — saksbehandler kunne sende inn datoer som backend deretter avviste.

## Endringer

- Ny validator `fødselErINærhetenAvTermin` i `@navikt/fp-utils` som speiler backend-intervallet eksakt.
- Eksponert via `packages/utils/index.ts` og oversettelse `ValidationMessage.ForStortAvvikTerminFødsel`.
- Brukt i `BarnFieldArray` som cross-field-validering (leser `termindato` fra parent form context). Valideringen kjøres når enten termindato eller barnas fødselsdato endres, og virker dermed både i `SjekkManglendeFødselForm` og `OverstyringForm`.
- Lagt til `vitest`-oppsett i `fp-utils` slik at den eksisterende test-filen faktisk kjøres, og nye tester for grensetilfellene (akkurat 19 uker før / 6 uker etter termin, samt utenfor begge ender).

## Test

- `yarn turbo run tsc test eslint --filter=@navikt/fp-utils --filter=@navikt/fp-fakta-fodsel` ✅
- 24 tester for `fødselOgTerminValidator`, alle eksisterende fødsel-tester fortsatt grønne.