### PR TITLE
fix: trim organisasjonsnummer før innsending fra RegistrereVergeForm

### DIFF
--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -9,6 +9,33 @@ import * as stories from './VergeFaktaIndex.stories';
 const { Default } = composeStories(stories);
 
 describe('VergeFaktaIndex', () => {
+  it('skal trimme whitespace fra organisasjonsnummer ved innsending', async () => {
+    const lagre = vi.fn();
+
+    render(<Default submitCallback={lagre} />);
+
+    await userEvent.selectOptions(screen.getByLabelText('Type verge'), 'ADVOKAT');
+
+    await userEvent.type(screen.getByLabelText('Navn'), 'Espen Utvikler');
+
+    // Simulerer copy-paste med trailing space
+    await userEvent.type(screen.getByLabelText('Organisasjonsnummer'), '232232323 ');
+
+    const fomInput = screen.getByLabelText('Fra og med');
+    await userEvent.type(fomInput, '14.09.2022');
+    fireEvent.blur(fomInput);
+
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    expect(lagre).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organisasjonsnummer: '232232323', // skal være trimmet
+      }),
+    );
+  });
+
   it('skal velge vergetype og bekrefte aksjonspunkt', async () => {
     const lagre = vi.fn();
 

--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -9,7 +9,7 @@ import * as stories from './VergeFaktaIndex.stories';
 const { Default } = composeStories(stories);
 
 describe('VergeFaktaIndex', () => {
-  it('skal trimme whitespace fra organisasjonsnummer ved innsending', async () => {
+  it('skal trimme trailing whitespace fra organisasjonsnummer ved innsending', async () => {
     const lagre = vi.fn();
 
     render(<Default submitCallback={lagre} />);

--- a/packages/fakta/verge/src/components/RegistrereVergeForm.tsx
+++ b/packages/fakta/verge/src/components/RegistrereVergeForm.tsx
@@ -115,6 +115,6 @@ RegistrereVergeForm.transformValues = ({
   gyldigFom,
   gyldigTom: gyldigTom || undefined,
   ...(vergeType === 'ADVOKAT'
-    ? { organisasjonsnummer: notEmpty(values.organisasjonsnummer) }
+    ? { organisasjonsnummer: notEmpty(values.organisasjonsnummer).trim() }
     : { fnr: notEmpty(values.fnr) }),
 });


### PR DESCRIPTION
## Problem

Validatoren `hasValidOrgNumber` trimmer verdien før sjekk og godkjenner verdier som `"999999999 "` (med trailing space). Men `transformValues` sendte verdien **uten** trim til backend, som returnerte:

```
Det oppstod en valideringsfeil for felt VergeRestTjeneste.opprettVerge.body.organisasjonsnummer: must match "^\d{9}$"
```

Dette kan skje ved copy-paste, eller at tastaturet legger til et space etter siste siffer.

## Endring

```diff
- ? { organisasjonsnummer: notEmpty(values.organisasjonsnummer) }
+ ? { organisasjonsnummer: notEmpty(values.organisasjonsnummer).trim() }
```

## Test

Lagt til test som verifiserer at trailing/leading whitespace trimmes før innsending.