### PR TITLE
Konstruer 500-feilmelding med callId på frontend

### DIFF
--- a/packages/app-felles/src/app-shell/queryUtils.ts
+++ b/packages/app-felles/src/app-shell/queryUtils.ts
@@ -41,6 +41,14 @@ export const createQueryClient = (errorHandler: (error: Error) => void) =>
     }),
   });
 
+const lagServerfeilmelding = (feilmelding?: string, callId?: string): string => {
+  const melding = feilmelding ?? 'Ukjent feil';
+  if (callId) {
+    return `Det oppstod en serverfeil: ${melding}. Meld til support med referanse-id: ${callId}`;
+  }
+  return `Det oppstod en serverfeil: ${melding}`;
+};
+
 export const getErrorHandler =
   (
     addErrorMessage: (data: FpError) => void,
@@ -65,6 +73,15 @@ export const getErrorHandler =
           type: ErrorType.REQUEST_GATEWAY_TIMEOUT_OR_NOT_FOUND,
           location: error.response.url,
         });
+      } else if (status === 500) {
+        captureException(error);
+        try {
+          const feilDto = error.data as { feilmelding?: string; callId?: string } | undefined;
+          const melding = lagServerfeilmelding(feilDto?.feilmelding, feilDto?.callId);
+          addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: melding });
+        } catch {
+          addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: error.message });
+        }
       } else {
         captureException(error);
         try {

--- a/packages/app-felles/src/app-shell/queryUtils.ts
+++ b/packages/app-felles/src/app-shell/queryUtils.ts
@@ -6,6 +6,11 @@ import { ErrorType, type FpError } from '../restApiError/errorType';
 
 const ZERO_RETRIES = false;
 
+type FeilDto = {
+  feilmelding?: string;
+  callId?: string;
+};
+
 const retryHandler = () => {
   if (import.meta.env.MODE === 'test') {
     return ZERO_RETRIES;
@@ -41,10 +46,10 @@ export const createQueryClient = (errorHandler: (error: Error) => void) =>
     }),
   });
 
-const lagServerfeilmelding = (feilmelding?: string, callId?: string): string => {
-  const melding = feilmelding ?? 'Ukjent feil';
-  if (callId) {
-    return `Det oppstod en serverfeil: ${melding}. Meld til support med referanse-id: ${callId}`;
+const lagServerfeilmelding = (feilDto?: FeilDto): string => {
+  const melding = feilDto?.feilmelding ?? 'Ukjent feil';
+  if (feilDto?.callId) {
+    return `Det oppstod en serverfeil: ${melding}. Meld til support med referanse-id: ${feilDto.callId}`;
   }
   return `Det oppstod en serverfeil: ${melding}`;
 };
@@ -75,13 +80,8 @@ export const getErrorHandler =
         });
       } else if (status === 500) {
         captureException(error);
-        try {
-          const feilDto = error.data as { feilmelding?: string; callId?: string } | undefined;
-          const melding = lagServerfeilmelding(feilDto?.feilmelding, feilDto?.callId);
-          addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: melding });
-        } catch {
-          addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: error.message });
-        }
+        const feilDto = error.data as FeilDto | undefined;
+        addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: lagServerfeilmelding(feilDto) });
       } else {
         captureException(error);
         try {


### PR DESCRIPTION
Legg til håntering i fp-frontend rundt feil fra alle apiene (sak, tilbake, los, mottak)
Dersom status er 500: Hent ut feilmelding og callId fra feilDto og konstruer følgende tekst til visning i rød linje
"Det oppstod en serverfeil: <feilmelding>. Meld til support med referanse-id: <callId>"