### PR TITLE
TFP-6942: refaktor tilrettelegging perioder og velferdspermisjon-komponentar

### DIFF
--- a/packages/fakta/tilrettelegging/i18n/nb_NO.json
+++ b/packages/fakta/tilrettelegging/i18n/nb_NO.json
@@ -30,7 +30,6 @@
   "TilretteleggingForm.Oppdater": "Oppdater",
   "TilretteleggingForm.Avbryt": "Avbryt",
   "TilretteleggingForm.ProsentSvp": "Prosent svangerskapspenger",
-  "TilretteleggingForm.SlettPeriode": "Slett periode",
   "TilretteleggingForm.DuplikateDatoer": "Flere perioder med samme Fra og med",
   "TilretteleggingForm.EtterTermindato": "Dato kan ikke være senere enn tre uker før termindato",
   "TilretteleggingForm.ForForsteDato": "Dato kan ikke være før dato for tilrettelegging fra lege eller jordmor",
@@ -51,7 +50,6 @@
   "TilretteleggingOgOppholdPerioderPanel.Perioder": "Perioder",
   "TilretteleggingOgOppholdPerioderPanel.Kilde": "Kilde",
 
-  "OppholdForm.SlettPeriode": "Slett periode",
   "OppholdForm.LeggTil": "Legg til ny periode",
   "OppholdForm.AvsluttOgSlett": "Avbryt",
   "OppholdForm.Oppdater": "Oppdater",
@@ -83,10 +81,12 @@
   "Kilde.Inntektsmelding": "Inntektsmelding",
   "Kilde.Soknad": "Søknad",
 
+  "TilretteleggingPeriodeTabellRad.SlettPeriode": "Slett periode",
   "TilretteleggingPeriodeTabellRad.IkkeSatt": "Ikke satt",
   "TilretteleggingPeriodeTabellRad.Tilrettelegging": "Tilrettelegging",
   "TilretteleggingPeriodeTabellRad.SVPprosent": "{prosent}% svangerskapspenger",
 
+  "OppholdPeriodeTabellRad.SlettPeriode": "Slett periode",
   "OppholdPeriodeTabellRad.IkkeSatt": "Ikke satt",
   "OppholdPeriodeTabellRad.Opphold": "Opphold",
   "OppholdPeriodeTabellRad.Sykepenger": "Sykepenger 100%",

--- a/packages/fakta/tilrettelegging/i18n/nb_NO.json
+++ b/packages/fakta/tilrettelegging/i18n/nb_NO.json
@@ -73,7 +73,7 @@
   "VelferdspermisjonForm.Ja": "Ja",
   "VelferdspermisjonForm.Nei": "Nei",
   "VelferdspermisjonForm.Oppdater": "Oppdater",
-  "VelferdspermisjonForm.Permisjon100ProsentOgGyldig": "Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapsenger for arbeidsforholdet.",
+  "VelferdspermisjonForm.Permisjon100ProsentOgGyldig": "Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapspenger for arbeidsforholdet.",
 
   "Kilde.Saksbehandler": "Saksbehandler",
   "Kilde.EndretAvSaksbehandler": "Endret av saksbehandler",

--- a/packages/fakta/tilrettelegging/i18n/nb_NO.json
+++ b/packages/fakta/tilrettelegging/i18n/nb_NO.json
@@ -18,10 +18,7 @@
 
   "ArbeidsforholdPanel.TilretteleggingTidligereEnn": "Tilrettelegging fra og med må være tidligere enn {dato}",
   "ArbeidsforholdPanel.DatoForTilrettelegging": "Dato for tilrettelegging fra lege eller jordmor",
-  "ArbeidsforholdPanel.Perioder": "Perioder",
   "ArbeidsforholdPanel.SkalHaSvpForArbeidsforhold": "Skal ha svangerskapspenger for arbeidsforholdet",
-  "VelferdspermisjonPanel.Velferdspermisjon": "Registrerte velferdspermisjoner",
-  "VelferdspermisjonPanel.ErPermisjonGyldg": "Er permisjoner gyldige?",
 
   "TilretteleggingForm.Tilretteleggingsbehov": "Tilretteleggingsbehov",
   "TilretteleggingForm.FraOgMed": "Fra og med",
@@ -51,6 +48,9 @@
   "TilretteleggingInfoPanel.AvStillingsprosent": "Av stillingsprosent {stillingsprosent}%",
   "TilretteleggingInfoPanel.Saksbehandler": "Saksbehandler",
 
+  "TilretteleggingOgOppholdPerioderPanel.Perioder": "Perioder",
+  "TilretteleggingOgOppholdPerioderPanel.Kilde": "Kilde",
+
   "OppholdForm.SlettPeriode": "Slett periode",
   "OppholdForm.LeggTil": "Legg til ny periode",
   "OppholdForm.AvsluttOgSlett": "Avbryt",
@@ -68,24 +68,27 @@
   "TilretteleggingFieldArray.LeggTilTilrettelegging": "Periode med svangerskapspenger",
   "TilretteleggingFieldArray.LeggTilOpphold": "Opphold",
 
-  "VelferdspermisjonPanel.Permisjon": "{permisjon}% {type}",
-  "VelferdspermisjonPanel.PermisjonGyldig": "Er permisjon gyldig?",
-  "VelferdspermisjonPanel.PermisjonGyldigDetaljer": "Hvis den er gyldig vil utbetalingsgraden for alle perioder for denne arbeidsgiveren reduseres med permisjonsprosent.",
-  "VelferdspermisjonPanel.Ja": "Ja",
-  "VelferdspermisjonPanel.Nei": "Nei",
-  "VelferdspermisjonPanel.Oppdater": "Oppdater",
-  "VelferdspermisjonPanel.AaRegisteret": "Aa-registeret",
-  "VelferdspermisjonPanel.Permisjon100ProsentOgGyldig": "Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapsenger for arbeidsforholdet.",
+  "VelferdspermisjonTabell.RegistrerteVelferdspermisjoner": "Registrerte velferdspermisjoner fra Aa-registeret",
+  "VelferdspermisjonTabellRad.Permisjon": "{permisjon}% {type}",
+  "VelferdspermisjonForm.PermisjonGyldig": "Er permisjon gyldig?",
+  "VelferdspermisjonForm.PermisjonGyldigDetaljer": "Hvis den er gyldig vil utbetalingsgraden for alle perioder for denne arbeidsgiveren reduseres med permisjonsprosent.",
+  "VelferdspermisjonForm.Ja": "Ja",
+  "VelferdspermisjonForm.Nei": "Nei",
+  "VelferdspermisjonForm.Oppdater": "Oppdater",
+  "VelferdspermisjonForm.Permisjon100ProsentOgGyldig": "Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapsenger for arbeidsforholdet.",
 
-  "TilretteleggingPerioderTabellRad.Periode": "Periode",
-  "TilretteleggingPerioderTabellRad.Saksbehandler": "Saksbehandler",
-  "TilretteleggingPerioderTabellRad.EndretAvSaksbehandler": "Endret av saksbehandler",
-  "TilretteleggingPerioderTabellRad.TidligereVedtak": "Tidligere vedtak",
-  "TilretteleggingPerioderTabellRad.Inntektsmelding": "Inntektsmelding",
-  "TilretteleggingPerioderTabellRad.Soknad": "Søknad",
-  "TilretteleggingPerioderTabellRad.Tilrettelegging": "Tilrettelegging",
-  "TilretteleggingPerioderTabellRad.Opphold": "Opphold",
-  "TilretteleggingPerioderTabellRad.Sykepenger": "Sykepenger 100%",
-  "TilretteleggingPerioderTabellRad.Ferie": "Ferie",
-  "TilretteleggingPerioderTabellRad.SVPprosent": "{prosent}% svangerskapspenger"
+  "Kilde.Saksbehandler": "Saksbehandler",
+  "Kilde.EndretAvSaksbehandler": "Endret av saksbehandler",
+  "Kilde.TidligereVedtak": "Tidligere vedtak",
+  "Kilde.Inntektsmelding": "Inntektsmelding",
+  "Kilde.Soknad": "Søknad",
+
+  "TilretteleggingPeriodeTabellRad.IkkeSatt": "Ikke satt",
+  "TilretteleggingPeriodeTabellRad.Tilrettelegging": "Tilrettelegging",
+  "TilretteleggingPeriodeTabellRad.SVPprosent": "{prosent}% svangerskapspenger",
+
+  "OppholdPeriodeTabellRad.IkkeSatt": "Ikke satt",
+  "OppholdPeriodeTabellRad.Opphold": "Opphold",
+  "OppholdPeriodeTabellRad.Sykepenger": "Sykepenger 100%",
+  "OppholdPeriodeTabellRad.Ferie": "Ferie"
 }

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -528,7 +528,7 @@ describe('TilretteleggingFaktaIndex', () => {
 
     expect(
       await screen.findByText(
-        'Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapsenger for arbeidsforholdet.',
+        'Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapspenger for arbeidsforholdet.',
       ),
     ).toBeInTheDocument();
 

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -35,10 +35,9 @@ describe('TilretteleggingFaktaIndex', () => {
     expect(screen.getByText('Skal ha svangerskapspenger for arbeidsforholdet')).toBeInTheDocument();
     expect(screen.getByText('Dato for tilrettelegging fra lege eller jordmor')).toBeInTheDocument();
 
-    expect(screen.getByText('Registrerte velferdspermisjoner')).toBeInTheDocument();
+    expect(screen.getByText('Registrerte velferdspermisjoner fra Aa-registeret')).toBeInTheDocument();
     expect(screen.getByText('17.02.2020 - 12.07.2020')).toBeInTheDocument();
     expect(screen.getByText('50% velferdspermisjon')).toBeInTheDocument();
-    expect(screen.getByText('Aa-registeret')).toBeInTheDocument();
 
     expect(screen.getByText('Perioder')).toBeInTheDocument();
     expect(screen.getByText('17.03.2020 - 14.08.2020')).toBeInTheDocument();
@@ -248,7 +247,7 @@ describe('TilretteleggingFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Periode med svangerskapspenger'));
 
-    expect(await screen.findByText('Periode')).toBeInTheDocument();
+    expect(await screen.findByText('Ikke satt')).toBeInTheDocument();
     expect(screen.getByText('Tilrettelegging')).toBeInTheDocument();
     expect(screen.getByText('Saksbehandler')).toBeInTheDocument();
     expect(screen.getByText('Legg til ny periode')).toBeInTheDocument();
@@ -301,7 +300,7 @@ describe('TilretteleggingFaktaIndex', () => {
 
     await userEvent.click(screen.getByText('Opphold'));
 
-    expect(await screen.findByText('Periode')).toBeInTheDocument();
+    expect(await screen.findByText('Ikke satt')).toBeInTheDocument();
     expect(screen.getAllByText('Opphold')).toHaveLength(2);
     expect(screen.getByText('Saksbehandler')).toBeInTheDocument();
     expect(screen.getByText('Legg til ny periode')).toBeInTheDocument();

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -281,7 +281,7 @@ describe('TilretteleggingFaktaIndex', () => {
     await userEvent.click(screen.getByText('Ja'));
     await userEvent.click(screen.getByText('Oppdater'));
 
-    await userEvent.click(screen.getAllByText('Slett periode')[1]!);
+    await userEvent.click(screen.getAllByTitle('Slett periode')[1]!);
 
     expect(await screen.findByText('17.03.2020 - 15.10.2020')).toBeInTheDocument();
   });
@@ -403,7 +403,7 @@ describe('TilretteleggingFaktaIndex', () => {
 
     expect(await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver')).toBeInTheDocument();
 
-    await userEvent.click(screen.getAllByText('Slett periode')[1]!);
+    await userEvent.click(screen.getAllByTitle('Slett periode')[1]!);
 
     await waitFor(() => expect(screen.queryByText('15.09.2020 - 20.09.2020')).not.toBeInTheDocument());
   });
@@ -492,8 +492,9 @@ describe('TilretteleggingFaktaIndex', () => {
     // Kun for manuelt lagt til opphold kan en velge "sykepenger...". Derfor kun ett innslag i DOM
     expect(screen.getAllByText('Sykepenger 100% i perioden med svangerskapspenger')).toHaveLength(3);
 
+    const sletteKnapper = screen.getAllByRole<HTMLButtonElement>('button', { name: 'Slett periode' });
     // Kun for tilretteleggingene og manuelt lagt til opphold kan en slette.
-    expect(screen.getAllByText('Slett periode')).toHaveLength(4);
+    expect(sletteKnapper.filter(btn => !btn.disabled)).toHaveLength(4);
   });
 
   it('skal vise advarsel når søker ikke var ansatt da behovet for tilrettelegging oppstod', async () => {

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdFieldArray.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdFieldArray.tsx
@@ -115,10 +115,10 @@ export const ArbeidsforholdFieldArray = ({
                     )}
                   </HStack>
                   <HStack gap="space-16" align="center">
-                    <Tag data-color="neutral" size="small" variant="moderate">
+                    <Tag data-color="neutral" size="small">
                       <FormattedMessage id="ArbeidsforholdFieldArray.Stillingsprosent" values={{ stillingsprosent }} />
                     </Tag>
-                    <Tag data-color="neutral" size="small" variant="moderate">
+                    <Tag data-color="neutral" size="small">
                       {finnSvpTagTekst(arbeidsforhold.skalBrukes, visInfoAlert)}
                     </Tag>
                     {arbeidsforhold.skalBrukes && visInfoAlert && (

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdPanel.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdPanel.tsx
@@ -108,10 +108,10 @@ export const ArbeidsforholdPanel = ({
           validate={[required, hasValidDate, validerTidligereEnn(intl, getValues, tilretteleggingBehovFom)]}
           readOnly={readOnly}
         />
+
         {filtrerteVelferdspermisjoner.length > 0 && (
           <VelferdspermisjonTabell
             filtrerteVelferdspermisjoner={filtrerteVelferdspermisjoner}
-            harUavklartVelferdspermisjon={harUavklartVelferdspermisjon}
             arbeidsforholdIndex={arbeidsforholdIndex}
             readOnly={readOnly}
             oppdaterOverstyrtUtbetalingsgrad={oppdaterOverstyrtUtbetalingsgrad}

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdPanel.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdPanel.tsx
@@ -121,7 +121,8 @@ export const ArbeidsforholdPanel = ({
         <TilretteleggingOgOppholdPerioderPanel
           arbeidsforhold={arbeidsforhold}
           arbeidsforholdIndex={arbeidsforholdIndex}
-          readOnly={readOnly || harUavklartVelferdspermisjon}
+          readOnly={readOnly}
+          disabled={harUavklartVelferdspermisjon}
           stillingsprosentArbeidsforhold={stillingsprosentArbeidsforhold}
           termindato={termindato}
         />

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/TilretteleggingOgOppholdPerioderPanel.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/TilretteleggingOgOppholdPerioderPanel.tsx
@@ -105,9 +105,13 @@ export const TilretteleggingOgOppholdPerioderPanel = ({
       <Table size="small">
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell colSpan={4} textSize="small">
-              <FormattedMessage id="ArbeidsforholdPanel.Perioder" />
+            <Table.HeaderCell colSpan={3} textSize="small">
+              <FormattedMessage id="TilretteleggingOgOppholdPerioderPanel.Perioder" />
             </Table.HeaderCell>
+            <Table.HeaderCell textSize="small">
+              <FormattedMessage id="TilretteleggingOgOppholdPerioderPanel.Kilde" />
+            </Table.HeaderCell>
+            <Table.HeaderCell />
           </Table.Row>
         </Table.Header>
         <Table.Body>

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/TilretteleggingOgOppholdPerioderPanel.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/TilretteleggingOgOppholdPerioderPanel.tsx
@@ -36,6 +36,7 @@ interface Props {
   arbeidsforhold: ArbeidsforholdFodselOgTilrettelegging;
   arbeidsforholdIndex: number;
   readOnly: boolean;
+  disabled: boolean;
   stillingsprosentArbeidsforhold: number;
   termindato: string;
 }
@@ -44,6 +45,7 @@ export const TilretteleggingOgOppholdPerioderPanel = ({
   arbeidsforhold,
   arbeidsforholdIndex,
   readOnly,
+  disabled,
   stillingsprosentArbeidsforhold,
   termindato,
 }: Props) => {
@@ -130,6 +132,7 @@ export const TilretteleggingOgOppholdPerioderPanel = ({
                   key={`${tilretteleggingStateName}.${tilretteleggingIndex}`}
                   navn={`${tilretteleggingStateName}.${tilretteleggingIndex}`}
                   tilrettelegging={rad}
+                  disabled={disabled}
                   readOnly={readOnly}
                   index={arbeidsforholdIndex + tilretteleggingIndex}
                   openRad={rad.fom === ''}
@@ -152,6 +155,7 @@ export const TilretteleggingOgOppholdPerioderPanel = ({
                 navn={`${oppholdPerioderStateName}.${oppholdIndex}`}
                 opphold={rad}
                 readOnly={readOnly}
+                disabled={disabled}
                 index={arbeidsforholdIndex + oppholdIndex}
                 openRad={rad.fom === ''}
                 fjernOpphold={fjernOpphold}

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
@@ -1,7 +1,7 @@
 import { FormProvider, useForm, type UseFormGetValues } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
-import { Button, HStack, Radio, Spacer, VStack } from '@navikt/ds-react';
+import { Button, HStack, Radio, VStack } from '@navikt/ds-react';
 import { RhfDatepicker, RhfRadioGroup } from '@navikt/ft-form-hooks';
 import { dateRangesNotOverlapping, hasValidDate, required } from '@navikt/ft-form-validators';
 import dayjs from 'dayjs';
@@ -76,8 +76,8 @@ interface Props {
   opphold: SvpAvklartOppholdPeriode;
   index: number;
   readOnly: boolean;
+  disabled: boolean;
   oppdaterOpphold: (values: SvpAvklartOppholdPeriode) => void;
-  slettOpphold: (opphold: SvpAvklartOppholdPeriode) => void;
   avbrytEditering: () => void;
   alleTilrettelegginger: ArbeidsforholdTilretteleggingDato[];
   alleOpphold: SvpAvklartOppholdPeriode[];
@@ -88,9 +88,9 @@ export const OppholdForm = ({
   opphold,
   index,
   readOnly,
+  disabled,
   oppdaterOpphold,
   avbrytEditering,
-  slettOpphold,
   alleTilrettelegginger,
   alleOpphold,
   termindato,
@@ -111,11 +111,6 @@ export const OppholdForm = ({
     return Promise.resolve();
   };
 
-  const slett = () => {
-    slettOpphold(opphold);
-    return Promise.resolve();
-  };
-
   const avbryt = () => {
     avbrytEditering();
     formMethods.reset();
@@ -125,97 +120,77 @@ export const OppholdForm = ({
 
   return (
     <FormProvider {...formMethods}>
-      <div
-        style={{
-          backgroundColor: 'var(--ax-bg-default)',
-          padding: '24px',
-          marginTop: '-8px',
-          marginBottom: '-8px',
-          marginLeft: '-8px',
-          marginRight: '-8px',
-        }}
-      >
-        <VStack gap="space-40">
-          <HStack gap="space-16">
-            <RhfDatepicker
-              name={`${index}.fom`}
-              control={formMethods.control}
-              label={intl.formatMessage({
-                id: 'OppholdForm.FraOgMed',
-              })}
-              validate={[
-                required,
-                hasValidDate,
-                validerAtDatoErUnik(intl, alleOpphold, alleTilrettelegginger, opphold),
-                validerAtPeriodeErGyldig(intl, alleTilrettelegginger, termindato),
-              ]}
-              readOnly={forVisning}
-            />
-            <RhfDatepicker
-              name={`${index}.tom`}
-              control={formMethods.control}
-              label={intl.formatMessage({
-                id: 'OppholdForm.TilOgMed',
-              })}
-              validate={[
-                required,
-                hasValidDate,
-                validerTomEtterFom(intl, index, formMethods.getValues),
-                validerAtPeriodeErGyldig(intl, alleTilrettelegginger, termindato),
-                validerAtPeriodeIkkeOverlapper(formMethods.getValues, index, opphold, alleOpphold),
-              ]}
-              readOnly={forVisning}
-            />
-          </HStack>
-          <RhfRadioGroup
-            name={`${index}.oppholdÅrsak`}
+      <VStack gap="space-16" paddingBlock="space-8">
+        <HStack gap="space-16">
+          <RhfDatepicker
+            name={`${index}.fom`}
             control={formMethods.control}
-            legend={intl.formatMessage({ id: 'OppholdForm.GrunnTilOpphold' })}
-            validate={[required]}
+            label={<FormattedMessage id="OppholdForm.FraOgMed" />}
+            validate={[
+              required,
+              hasValidDate,
+              validerAtDatoErUnik(intl, alleOpphold, alleTilrettelegginger, opphold),
+              validerAtPeriodeErGyldig(intl, alleTilrettelegginger, termindato),
+            ]}
             readOnly={forVisning}
-          >
-            <Radio value="SYKEPENGER" size="small">
-              <FormattedMessage id="OppholdForm.Sykepenger" />
-            </Radio>
-            <Radio value="FERIE" size="small">
-              <FormattedMessage id="OppholdForm.Ferie" />
-            </Radio>
-          </RhfRadioGroup>
-          {!forVisning && (
-            <HStack gap="space-8">
-              <Button
-                size="small"
-                variant="primary"
-                type="button"
-                disabled={!formMethods.formState.isDirty || false}
-                loading={false}
-                onClick={formMethods.handleSubmit((values: FormValues) => lagreIForm(values))}
-              >
-                {erNyPeriode ? (
-                  <FormattedMessage id="OppholdForm.LeggTil" />
-                ) : (
-                  <FormattedMessage id="OppholdForm.Oppdater" />
-                )}
-              </Button>
-              <Button size="small" variant="secondary" onClick={avbryt} type="button">
-                {erNyPeriode ? (
-                  <FormattedMessage id="OppholdForm.AvsluttOgSlett" />
-                ) : (
-                  <FormattedMessage id="OppholdForm.Avbryt" />
-                )}
-              </Button>
-              {!erNyPeriode && (
-                <>
-                  <Spacer />
-                  <Button size="small" variant="secondary" onClick={slett} type="button">
-                    <FormattedMessage id="OppholdForm.SlettPeriode" />
-                  </Button>
-                </>
+            disabled={disabled}
+          />
+          <RhfDatepicker
+            name={`${index}.tom`}
+            control={formMethods.control}
+            label={<FormattedMessage id="OppholdForm.TilOgMed" />}
+            validate={[
+              required,
+              hasValidDate,
+              validerTomEtterFom(intl, index, formMethods.getValues),
+              validerAtPeriodeErGyldig(intl, alleTilrettelegginger, termindato),
+              validerAtPeriodeIkkeOverlapper(formMethods.getValues, index, opphold, alleOpphold),
+            ]}
+            readOnly={forVisning}
+            disabled={disabled}
+          />
+        </HStack>
+        <RhfRadioGroup
+          name={`${index}.oppholdÅrsak`}
+          control={formMethods.control}
+          legend={<FormattedMessage id="OppholdForm.GrunnTilOpphold" />}
+          validate={[required]}
+          readOnly={forVisning}
+          disabled={disabled}
+        >
+          <Radio value="SYKEPENGER" size="small">
+            <FormattedMessage id="OppholdForm.Sykepenger" />
+          </Radio>
+          <Radio value="FERIE" size="small">
+            <FormattedMessage id="OppholdForm.Ferie" />
+          </Radio>
+        </RhfRadioGroup>
+        {!(forVisning || disabled) && (
+          <HStack gap="space-8">
+            <Button
+              size="small"
+              variant="primary"
+              type="button"
+              disabled={!formMethods.formState.isDirty || false}
+              loading={false}
+              onClick={formMethods.handleSubmit((values: FormValues) => lagreIForm(values))}
+            >
+              {erNyPeriode ? (
+                <FormattedMessage id="OppholdForm.LeggTil" />
+              ) : (
+                <FormattedMessage id="OppholdForm.Oppdater" />
               )}
-            </HStack>
-          )}
-        </VStack>
-      </div>
+            </Button>
+            <Button size="small" variant="secondary" type="button" onClick={avbryt}>
+              {erNyPeriode ? (
+                <FormattedMessage id="OppholdForm.AvsluttOgSlett" />
+              ) : (
+                <FormattedMessage id="OppholdForm.Avbryt" />
+              )}
+            </Button>
+          </HStack>
+        )}
+      </VStack>
     </FormProvider>
   );
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
@@ -181,7 +181,7 @@ export const OppholdForm = ({
                 <FormattedMessage id="OppholdForm.Oppdater" />
               )}
             </Button>
-            <Button size="small" variant="secondary" type="button" onClick={avbryt}>
+            <Button size="small" variant="secondary" type="button" data-color="accent" onClick={avbryt}>
               {erNyPeriode ? (
                 <FormattedMessage id="OppholdForm.AvsluttOgSlett" />
               ) : (

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdPeriodeTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdPeriodeTabellRad.tsx
@@ -85,8 +85,13 @@ export const OppholdPeriodeTabellRad = ({
           <FormattedMessage id="OppholdPeriodeTabellRad.IkkeSatt" />
         )}
       </Table.DataCell>
-      <Table.DataCell>{utledTypeTekst(opphold)}</Table.DataCell>
-      <Table.DataCell>{utledKilde(opphold)}</Table.DataCell>
+
+      <Table.DataCell>
+        <OppholdType opphold={opphold} />
+      </Table.DataCell>
+      <Table.DataCell>
+        <OppholdKilde opphold={opphold} />
+      </Table.DataCell>
       <Table.DataCell width={48}>
         {!readOnly && !disabled && opphold.fom && (
           <Button
@@ -105,7 +110,7 @@ export const OppholdPeriodeTabellRad = ({
   );
 };
 
-const utledTypeTekst = (opphold: Partial<SvpAvklartOppholdPeriode>) => {
+const OppholdType = ({ opphold }: { opphold: Partial<SvpAvklartOppholdPeriode> }) => {
   if (opphold.oppholdÅrsak === undefined) {
     return <FormattedMessage id="OppholdPeriodeTabellRad.Opphold" />;
   }
@@ -117,7 +122,7 @@ const utledTypeTekst = (opphold: Partial<SvpAvklartOppholdPeriode>) => {
   );
 };
 
-const utledKilde = (opphold: SvpAvklartOppholdPeriode) => {
+const OppholdKilde = ({ opphold }: { opphold: SvpAvklartOppholdPeriode }) => {
   switch (opphold.oppholdKilde) {
     case 'SØKNAD':
       return <FormattedMessage id="Kilde.Soknad" />;

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdPeriodeTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdPeriodeTabellRad.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Table } from '@navikt/ds-react';
+import { XMarkIcon } from '@navikt/aksel-icons';
+import { Button, Table } from '@navikt/ds-react';
 import { PeriodLabel } from '@navikt/ft-ui-komponenter';
 
 import type { ArbeidsforholdFodselOgTilrettelegging, SvpAvklartOppholdPeriode } from '@navikt/fp-types';
@@ -16,6 +17,7 @@ interface Props {
   navn: `arbeidsforhold.${number}.avklarteOppholdPerioder.${number}`;
   opphold: SvpAvklartOppholdPeriode;
   readOnly: boolean;
+  disabled: boolean;
   index: number;
   openRad: boolean;
   fjernOpphold: (opphold?: SvpAvklartOppholdPeriode) => void;
@@ -29,12 +31,14 @@ export const OppholdPeriodeTabellRad = ({
   opphold,
   index,
   readOnly,
+  disabled,
   openRad,
   fjernOpphold,
   setLeggTilKnapperDisablet,
   arbeidsforhold,
   termindato,
 }: Props) => {
+  const intl = useIntl();
   const [open, setOpen] = useState(openRad);
 
   const { setValue } = useFormContext<TilretteleggingFormValues>();
@@ -59,7 +63,6 @@ export const OppholdPeriodeTabellRad = ({
       expandOnRowClick
       onOpenChange={() => setOpen(!open)}
       onClick={() => setOpen(!open)}
-      contentGutter="none"
       content={
         <OppholdForm
           opphold={opphold}
@@ -67,13 +70,12 @@ export const OppholdPeriodeTabellRad = ({
           oppdaterOpphold={oppdaterOpphold}
           avbrytEditering={avbrytEditering}
           readOnly={readOnly}
+          disabled={disabled}
           alleTilrettelegginger={arbeidsforhold.tilretteleggingDatoer}
           alleOpphold={arbeidsforhold.avklarteOppholdPerioder}
           termindato={termindato}
-          slettOpphold={fjernOpphold}
         />
       }
-      togglePlacement="right"
       className={open ? styles['openRow'] : undefined}
     >
       <Table.DataCell>
@@ -85,6 +87,20 @@ export const OppholdPeriodeTabellRad = ({
       </Table.DataCell>
       <Table.DataCell>{utledTypeTekst(opphold)}</Table.DataCell>
       <Table.DataCell>{utledKilde(opphold)}</Table.DataCell>
+      <Table.DataCell width={48}>
+        {!readOnly && !disabled && opphold.fom && (
+          <Button
+            size="small"
+            variant="tertiary-neutral"
+            icon={<XMarkIcon aria-hidden />}
+            aria-label={intl.formatMessage({ id: 'OppholdPeriodeTabellRad.SlettPeriode' })}
+            title={intl.formatMessage({ id: 'OppholdPeriodeTabellRad.SlettPeriode' })}
+            onClick={() => fjernOpphold(opphold)}
+            type="button"
+            disabled={opphold.oppholdKilde === 'INNTEKTSMELDING'}
+          />
+        )}
+      </Table.DataCell>
     </Table.ExpandableRow>
   );
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdPeriodeTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdPeriodeTabellRad.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { Table, Tag } from '@navikt/ds-react';
+import { Table } from '@navikt/ds-react';
 import { PeriodLabel } from '@navikt/ft-ui-komponenter';
 
 import type { ArbeidsforholdFodselOgTilrettelegging, SvpAvklartOppholdPeriode } from '@navikt/fp-types';
@@ -11,33 +11,6 @@ import type { TilretteleggingFormValues } from '../../../../types/Tilretteleggin
 import { OppholdForm } from './OppholdForm';
 
 import styles from './oppholdPeriodeTabellRad.module.css';
-
-const utledTypeTekst = (intl: IntlShape, opphold: Partial<SvpAvklartOppholdPeriode>) => {
-  if (opphold.oppholdÅrsak === undefined) {
-    return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Opphold' });
-  }
-
-  return opphold.oppholdÅrsak === 'FERIE'
-    ? intl.formatMessage({
-        id: 'TilretteleggingPerioderTabellRad.Ferie',
-      })
-    : intl.formatMessage({
-        id: 'TilretteleggingPerioderTabellRad.Sykepenger',
-      });
-};
-
-const utledKilde = (intl: IntlShape, opphold: SvpAvklartOppholdPeriode) => {
-  switch (opphold.oppholdKilde) {
-    case 'SØKNAD':
-      return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Soknad' });
-    case 'INNTEKTSMELDING':
-      return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Inntektsmelding' });
-    case 'TIDLIGERE_VEDTAK':
-      return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.TidligereVedtak' });
-    default:
-      return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Saksbehandler' });
-  }
-};
 
 interface Props {
   navn: `arbeidsforhold.${number}.avklarteOppholdPerioder.${number}`;
@@ -62,7 +35,6 @@ export const OppholdPeriodeTabellRad = ({
   arbeidsforhold,
   termindato,
 }: Props) => {
-  const intl = useIntl();
   const [open, setOpen] = useState(openRad);
 
   const { setValue } = useFormContext<TilretteleggingFormValues>();
@@ -108,15 +80,36 @@ export const OppholdPeriodeTabellRad = ({
         {opphold.fom ? (
           <PeriodLabel dateStringFom={opphold.fom} dateStringTom={opphold.tom} />
         ) : (
-          <FormattedMessage id="TilretteleggingPerioderTabellRad.Periode" />
+          <FormattedMessage id="OppholdPeriodeTabellRad.IkkeSatt" />
         )}
       </Table.DataCell>
-      <Table.DataCell>{utledTypeTekst(intl, opphold)}</Table.DataCell>
-      <Table.DataCell>
-        <Tag data-color="neutral" size="small" variant="moderate">
-          {utledKilde(intl, opphold)}
-        </Tag>
-      </Table.DataCell>
+      <Table.DataCell>{utledTypeTekst(opphold)}</Table.DataCell>
+      <Table.DataCell>{utledKilde(opphold)}</Table.DataCell>
     </Table.ExpandableRow>
   );
+};
+
+const utledTypeTekst = (opphold: Partial<SvpAvklartOppholdPeriode>) => {
+  if (opphold.oppholdÅrsak === undefined) {
+    return <FormattedMessage id="OppholdPeriodeTabellRad.Opphold" />;
+  }
+
+  return opphold.oppholdÅrsak === 'FERIE' ? (
+    <FormattedMessage id="OppholdPeriodeTabellRad.Ferie" />
+  ) : (
+    <FormattedMessage id="OppholdPeriodeTabellRad.Sykepenger" />
+  );
+};
+
+const utledKilde = (opphold: SvpAvklartOppholdPeriode) => {
+  switch (opphold.oppholdKilde) {
+    case 'SØKNAD':
+      return <FormattedMessage id="Kilde.Soknad" />;
+    case 'INNTEKTSMELDING':
+      return <FormattedMessage id="Kilde.Inntektsmelding" />;
+    case 'TIDLIGERE_VEDTAK':
+      return <FormattedMessage id="Kilde.TidligereVedtak" />;
+    default:
+      return <FormattedMessage id="Kilde.Saksbehandler" />;
+  }
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/oppholdPeriodeTabellRad.module.css
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/oppholdPeriodeTabellRad.module.css
@@ -1,3 +1,7 @@
 .openRow {
   background-color: var(--ax-bg-neutral-moderate);
 }
+
+.openRow + tr[data-state='open'] {
+  background-color: var(--ax-bg-default);
+}

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
-import { Button, HStack, Radio, Spacer, VStack } from '@navikt/ds-react';
+import { Button, HStack, Radio, VStack } from '@navikt/ds-react';
 import { RhfDatepicker, RhfNumericField, RhfRadioGroup } from '@navikt/ft-form-hooks';
 import { hasValidDate, hasValidDecimal, maxValue, minValue, required } from '@navikt/ft-form-validators';
 import dayjs from 'dayjs';
@@ -97,12 +97,12 @@ interface Props {
   termindato: string;
   index: number;
   readOnly: boolean;
+  disabled: boolean;
   oppdaterTilrettelegging: (values: ArbeidsforholdTilretteleggingDato) => void;
   avbrytEditering: () => void;
   stillingsprosentArbeidsforhold: number;
   arbeidsforhold: ArbeidsforholdFodselOgTilrettelegging;
   tomDatoForTilrettelegging: string;
-  slettTilrettelegging: (fomDato: string) => void;
 }
 
 export const TilretteleggingForm = ({
@@ -110,12 +110,12 @@ export const TilretteleggingForm = ({
   termindato,
   index,
   readOnly,
+  disabled,
   oppdaterTilrettelegging,
   avbrytEditering,
   stillingsprosentArbeidsforhold,
   arbeidsforhold,
   tomDatoForTilrettelegging,
-  slettTilrettelegging,
 }: Props) => {
   const intl = useIntl();
 
@@ -188,152 +188,129 @@ export const TilretteleggingForm = ({
     formMethods.reset();
   };
 
-  const slett = () => {
-    slettTilrettelegging(tilrettelegging.fom);
-    return Promise.resolve();
-  };
-
   return (
     <FormProvider {...formMethods}>
-      <div
-        style={{
-          backgroundColor: 'var(--ax-bg-default)',
-          padding: '24px',
-          marginTop: '-8px',
-          marginBottom: '-8px',
-          marginLeft: '-8px',
-          marginRight: '-8px',
-        }}
-      >
-        <VStack gap="space-32">
-          {!erNyPeriode && (
-            <TilretteleggingInfoPanel
-              tilrettelegging={formValues}
-              termindato={termindato}
-              erTomDatoTreUkerFørTermin={erTomDatoTreUkerFørTermin}
-              stillingsprosentArbeidsforhold={stillingsprosentArbeidsforhold}
-              tomDato={tomDatoForTilrettelegging}
-            />
-          )}
-          <RhfDatepicker
-            name={`${index}.fom`}
-            control={formMethods.control}
-            label={intl.formatMessage({
-              id: 'TilretteleggingForm.FraOgMed',
-            })}
-            validate={[
-              required,
-              hasValidDate,
-              validerAtDatoErUnik(
-                intl,
-                arbeidsforhold.tilretteleggingDatoer,
-                arbeidsforhold.avklarteOppholdPerioder,
-                tilrettelegging,
-              ),
-              validerAtPeriodeErGyldig(intl, arbeidsforhold.tilretteleggingBehovFom, termindato),
-            ]}
-            readOnly={readOnly}
+      <VStack gap="space-16" paddingBlock="space-8">
+        {!erNyPeriode && (
+          <TilretteleggingInfoPanel
+            tilrettelegging={formValues}
+            termindato={termindato}
+            erTomDatoTreUkerFørTermin={erTomDatoTreUkerFørTermin}
+            stillingsprosentArbeidsforhold={stillingsprosentArbeidsforhold}
+            tomDato={tomDatoForTilrettelegging}
           />
-          <RhfRadioGroup
-            name={`${index}.type`}
-            control={formMethods.control}
-            legend={intl.formatMessage({ id: 'TilretteleggingForm.Tilretteleggingsbehov' })}
-            validate={[required]}
-            readOnly={readOnly}
-          >
-            <Radio value="HEL_TILRETTELEGGING" size="small">
-              <FormattedMessage id="TilretteleggingForm.KanGjennomfores" />
-            </Radio>
-            <Radio value="DELVIS_TILRETTELEGGING" size="small">
-              <FormattedMessage id="TilretteleggingForm.RedusertArbeid" />
-            </Radio>
-            <Radio value="INGEN_TILRETTELEGGING" size="small">
-              <FormattedMessage id="TilretteleggingForm.KanIkkeGjennomfores" />
-            </Radio>
-          </RhfRadioGroup>
-          {formValues.type === 'DELVIS_TILRETTELEGGING' && (
-            <>
-              {(tilrettelegging.stillingsprosent === undefined ||
-                tilrettelegging.type !== 'DELVIS_TILRETTELEGGING' ||
-                erNyPeriode ||
-                formValues.kilde === 'REGISTRERT_AV_SAKSBEHANDLER') && (
-                <RhfNumericField
-                  name={`${index}.stillingsprosent`}
-                  control={formMethods.control}
-                  htmlSize={10}
-                  readOnly={readOnly}
-                  label={intl.formatMessage({ id: 'TilretteleggingForm.Arbeidsprosent' })}
-                  description={intl.formatMessage({ id: 'TilretteleggingForm.ArbeidsprosentBeskrivelse' })}
-                  validate={[required, minValue0, maxValue100, hasValidDecimal]}
-                  forceTwoDecimalDigits
-                  onChange={value => {
-                    const utbetalingsgrad = finnUtbetalingsgradForTilrettelegging(
-                      stillingsprosentArbeidsforhold,
-                      velferdspermisjonprosent,
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- [JOHANNES] bedre typede forms
-                      value,
-                    );
-                    formMethods.setValue(`${index}.overstyrtUtbetalingsgrad`, utbetalingsgrad, { shouldDirty: true });
-                  }}
-                />
-              )}
+        )}
+        <RhfDatepicker
+          name={`${index}.fom`}
+          control={formMethods.control}
+          label={<FormattedMessage id="TilretteleggingForm.FraOgMed" />}
+          validate={[
+            required,
+            hasValidDate,
+            validerAtDatoErUnik(
+              intl,
+              arbeidsforhold.tilretteleggingDatoer,
+              arbeidsforhold.avklarteOppholdPerioder,
+              tilrettelegging,
+            ),
+            validerAtPeriodeErGyldig(intl, arbeidsforhold.tilretteleggingBehovFom, termindato),
+          ]}
+          readOnly={readOnly}
+          disabled={disabled}
+        />
+        <RhfRadioGroup
+          name={`${index}.type`}
+          control={formMethods.control}
+          legend={<FormattedMessage id="TilretteleggingForm.Tilretteleggingsbehov" />}
+          validate={[required]}
+          readOnly={readOnly}
+          disabled={disabled}
+        >
+          <Radio value="HEL_TILRETTELEGGING" size="small">
+            <FormattedMessage id="TilretteleggingForm.KanGjennomfores" />
+          </Radio>
+          <Radio value="DELVIS_TILRETTELEGGING" size="small">
+            <FormattedMessage id="TilretteleggingForm.RedusertArbeid" />
+          </Radio>
+          <Radio value="INGEN_TILRETTELEGGING" size="small">
+            <FormattedMessage id="TilretteleggingForm.KanIkkeGjennomfores" />
+          </Radio>
+        </RhfRadioGroup>
+        {formValues.type === 'DELVIS_TILRETTELEGGING' && (
+          <>
+            {(tilrettelegging.stillingsprosent === undefined ||
+              tilrettelegging.type !== 'DELVIS_TILRETTELEGGING' ||
+              erNyPeriode ||
+              formValues.kilde === 'REGISTRERT_AV_SAKSBEHANDLER') && (
               <RhfNumericField
-                name={`${index}.overstyrtUtbetalingsgrad`}
+                name={`${index}.stillingsprosent`}
                 control={formMethods.control}
                 htmlSize={10}
                 readOnly={readOnly}
-                label={intl.formatMessage({ id: 'TilretteleggingForm.ProsentSvp' })}
-                description={intl.formatMessage({ id: 'TilretteleggingForm.ProsentSvpBeskrivelse' })}
-                validate={[
-                  required,
-                  minValue0,
-                  maxValue100,
-                  hasValidDecimal,
-                  (verdi: number) =>
-                    !stillingsprosentArbeidsforhold && verdi === 0
-                      ? intl.formatMessage({ id: 'TilretteleggingForm.AngiUtbetalingsgrad' })
-                      : null,
-                ]}
+                disabled={disabled}
+                label={<FormattedMessage id="TilretteleggingForm.Arbeidsprosent" />}
+                description={<FormattedMessage id="TilretteleggingForm.ArbeidsprosentBeskrivelse" />}
+                validate={[required, minValue0, maxValue100, hasValidDecimal]}
                 forceTwoDecimalDigits
-                disabled={formValues.stillingsprosent === undefined}
+                onChange={value => {
+                  const utbetalingsgrad = finnUtbetalingsgradForTilrettelegging(
+                    stillingsprosentArbeidsforhold,
+                    velferdspermisjonprosent,
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- [JOHANNES] bedre typede forms
+                    value,
+                  );
+                  formMethods.setValue(`${index}.overstyrtUtbetalingsgrad`, utbetalingsgrad, { shouldDirty: true });
+                }}
               />
-            </>
-          )}
-          {!readOnly && (
-            <HStack gap="space-8">
-              <Button
-                size="small"
-                variant="primary"
-                type="button"
-                disabled={!formMethods.formState.isDirty || false}
-                loading={false}
-                onClick={formMethods.handleSubmit((values: FormValues) => lagreIForm(values))}
-              >
-                {erNyPeriode ? (
-                  <FormattedMessage id="TilretteleggingForm.LeggTil" />
-                ) : (
-                  <FormattedMessage id="TilretteleggingForm.Oppdater" />
-                )}
-              </Button>
-              <Button size="small" variant="secondary" onClick={avbryt} type="button">
-                {erNyPeriode ? (
-                  <FormattedMessage id="TilretteleggingForm.AvsluttOgSlett" />
-                ) : (
-                  <FormattedMessage id="TilretteleggingForm.Avbryt" />
-                )}
-              </Button>
-              {!erNyPeriode && (
-                <>
-                  <Spacer />
-                  <Button size="small" variant="secondary" onClick={slett} type="button">
-                    <FormattedMessage id="TilretteleggingForm.SlettPeriode" />
-                  </Button>
-                </>
+            )}
+            <RhfNumericField
+              name={`${index}.overstyrtUtbetalingsgrad`}
+              control={formMethods.control}
+              htmlSize={10}
+              readOnly={readOnly}
+              disabled={disabled || formValues.stillingsprosent === undefined}
+              label={intl.formatMessage({ id: 'TilretteleggingForm.ProsentSvp' })}
+              description={intl.formatMessage({ id: 'TilretteleggingForm.ProsentSvpBeskrivelse' })}
+              validate={[
+                required,
+                minValue0,
+                maxValue100,
+                hasValidDecimal,
+                (verdi: number) =>
+                  !stillingsprosentArbeidsforhold && verdi === 0
+                    ? intl.formatMessage({ id: 'TilretteleggingForm.AngiUtbetalingsgrad' })
+                    : null,
+              ]}
+              forceTwoDecimalDigits
+            />
+          </>
+        )}
+        {!(readOnly || disabled) && (
+          <HStack gap="space-8">
+            <Button
+              size="small"
+              variant="primary"
+              type="button"
+              disabled={!formMethods.formState.isDirty || false}
+              loading={false}
+              onClick={formMethods.handleSubmit(lagreIForm)}
+            >
+              {erNyPeriode ? (
+                <FormattedMessage id="TilretteleggingForm.LeggTil" />
+              ) : (
+                <FormattedMessage id="TilretteleggingForm.Oppdater" />
               )}
-            </HStack>
-          )}
-        </VStack>
-      </div>
+            </Button>
+            <Button size="small" variant="secondary" type="button" onClick={avbryt}>
+              {erNyPeriode ? (
+                <FormattedMessage id="TilretteleggingForm.AvsluttOgSlett" />
+              ) : (
+                <FormattedMessage id="TilretteleggingForm.Avbryt" />
+              )}
+            </Button>
+          </HStack>
+        )}
+      </VStack>
     </FormProvider>
   );
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
@@ -148,7 +148,7 @@ export const TilretteleggingForm = ({
         overstyrtUtbetalingsgrad: prosentSvangerskapspenger,
       },
     });
-  }, [prosentSvangerskapspenger]);
+  }, [formMethods, index, prosentSvangerskapspenger, tilrettelegging]);
 
   const formValuesRecord = formMethods.watch();
   const formValues = formValuesRecord[index];

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
@@ -301,7 +301,7 @@ export const TilretteleggingForm = ({
                 <FormattedMessage id="TilretteleggingForm.Oppdater" />
               )}
             </Button>
-            <Button size="small" variant="secondary" type="button" onClick={avbryt}>
+            <Button size="small" variant="secondary" type="button" data-color="accent" onClick={avbryt}>
               {erNyPeriode ? (
                 <FormattedMessage id="TilretteleggingForm.AvsluttOgSlett" />
               ) : (

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingInfoPanel.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingInfoPanel.tsx
@@ -57,84 +57,71 @@ export const TilretteleggingInfoPanel = ({
   const registrertAvSaksbehandler = tilrettelegging.kilde === 'REGISTRERT_AV_SAKSBEHANDLER';
 
   return (
-    <div
-      style={{
-        background: 'var(--ax-bg-neutral-soft)',
-        marginLeft: '-24px',
-        marginTop: '-24px',
-        marginRight: '-24px',
-        paddingBottom: '10px',
-        paddingLeft: '20px',
-        paddingRight: '50px',
-        paddingTop: '10px',
-      }}
-    >
-      <HStack justify="space-between">
-        <HStack gap="space-16">
-          <PersonPregnantIcon title="a11y-title" fontSize="1.5rem" />
+    <HStack justify="space-between" paddingInline="space-0 space-96">
+      <HStack gap="space-8">
+        <PersonPregnantIcon aria-hidden fontSize="2rem" />
+        <div>
+          <BodyShort size="small">
+            <FormattedMessage
+              id="TilretteleggingInfoPanel.SvpOgArbeid"
+              values={{
+                svp: finnProsentSvangerskapspenger(tilrettelegging),
+                arbeid: finnProsentArbeid(tilrettelegging),
+              }}
+            />
+          </BodyShort>
+          <Detail>
+            <FormattedMessage
+              id="TilretteleggingInfoPanel.AvStillingsprosent"
+              values={{
+                stillingsprosent: stillingsprosentArbeidsforhold,
+              }}
+            />
+          </Detail>
+        </div>
+      </HStack>
+      <HStack gap="space-8">
+        <CalendarIcon aria-hidden fontSize="2rem" />
+        <div>
+          <BodyShort size="small">
+            <FormattedMessage
+              id="TilretteleggingInfoPanel.Periode"
+              values={{
+                periode: dagerOgUker.formattedString,
+              }}
+            />
+          </BodyShort>
+          <Detail>{fremTilTidspunkt}</Detail>
+        </div>
+      </HStack>
+      {!registrertAvSaksbehandler && (
+        <HStack gap="space-8">
+          <BranchingIcon aria-hidden fontSize="2rem" />
           <div>
             <BodyShort size="small">
-              <FormattedMessage
-                id="TilretteleggingInfoPanel.SvpOgArbeid"
-                values={{
-                  svp: finnProsentSvangerskapspenger(tilrettelegging),
-                  arbeid: finnProsentArbeid(tilrettelegging),
-                }}
-              />
+              <FormattedMessage id="TilretteleggingInfoPanel.FraSoknad" />
             </BodyShort>
             <Detail>
-              <FormattedMessage
-                id="TilretteleggingInfoPanel.AvStillingsprosent"
-                values={{
-                  stillingsprosent: stillingsprosentArbeidsforhold,
-                }}
-              />
+              {tilrettelegging.mottattDato && (
+                <FormattedMessage
+                  id="TilretteleggingInfoPanel.Sendt"
+                  values={{
+                    dato: dateFormat(tilrettelegging.mottattDato),
+                  }}
+                />
+              )}
             </Detail>
           </div>
         </HStack>
-        <HStack gap="space-16">
-          <CalendarIcon title="a11y-title" fontSize="1.5rem" />
-          <div>
-            <BodyShort size="small">
-              <FormattedMessage
-                id="TilretteleggingInfoPanel.Periode"
-                values={{
-                  periode: dagerOgUker.formattedString,
-                }}
-              />
-            </BodyShort>
-            <Detail>{fremTilTidspunkt}</Detail>
-          </div>
+      )}
+      {registrertAvSaksbehandler && (
+        <HStack gap="space-8">
+          <BranchingIcon aria-hidden fontSize="2rem" />
+          <BodyShort size="small">
+            <FormattedMessage id="TilretteleggingInfoPanel.Saksbehandler" />
+          </BodyShort>
         </HStack>
-        {!registrertAvSaksbehandler && (
-          <HStack gap="space-16">
-            <BranchingIcon title="a11y-title" fontSize="1.5rem" />
-            <div>
-              <BodyShort size="small">
-                <FormattedMessage id="TilretteleggingInfoPanel.FraSoknad" />
-              </BodyShort>
-              <Detail>
-                {tilrettelegging.mottattDato && (
-                  <FormattedMessage
-                    id="TilretteleggingInfoPanel.Sendt"
-                    values={{
-                      dato: dateFormat(tilrettelegging.mottattDato),
-                    }}
-                  />
-                )}
-              </Detail>
-            </div>
-          </HStack>
-        )}
-        {registrertAvSaksbehandler && (
-          <HStack gap="space-16">
-            <BranchingIcon title="a11y-title" fontSize="1.5rem" />
-            <BodyShort size="small">
-              <FormattedMessage id="TilretteleggingInfoPanel.Saksbehandler" />
-            </BodyShort>
-          </HStack>
-        )}
-      </HStack>
-    </div>
+      )}
+    </HStack>
   );
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingPeriodeTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingPeriodeTabellRad.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Table } from '@navikt/ds-react';
+import { XMarkIcon } from '@navikt/aksel-icons';
+import { Button, Table } from '@navikt/ds-react';
 import { PeriodLabel } from '@navikt/ft-ui-komponenter';
 
 import { type ArbeidsforholdFodselOgTilrettelegging, type ArbeidsforholdTilretteleggingDato } from '@navikt/fp-types';
@@ -20,6 +21,7 @@ interface Props {
   navn: `arbeidsforhold.${number}.tilretteleggingDatoer.${number}`;
   tilrettelegging: ArbeidsforholdTilretteleggingDato;
   readOnly: boolean;
+  disabled: boolean;
   index: number;
   openRad: boolean;
   fjernTilrettelegging: (fomDato?: string) => void;
@@ -35,6 +37,7 @@ export const TilretteleggingPeriodeTabellRad = ({
   tilrettelegging,
   index,
   readOnly,
+  disabled,
   openRad,
   fjernTilrettelegging,
   setLeggTilKnapperDisablet,
@@ -43,6 +46,7 @@ export const TilretteleggingPeriodeTabellRad = ({
   tomDatoForTilrettelegging,
   termindato,
 }: Props) => {
+  const intl = useIntl();
   const [open, setOpen] = useState(openRad);
 
   const { setValue } = useFormContext<TilretteleggingFormValues>();
@@ -67,7 +71,6 @@ export const TilretteleggingPeriodeTabellRad = ({
       expandOnRowClick
       onOpenChange={() => setOpen(!open)}
       onClick={() => setOpen(!open)}
-      contentGutter="none"
       content={
         <TilretteleggingForm
           tilrettelegging={tilrettelegging}
@@ -76,13 +79,12 @@ export const TilretteleggingPeriodeTabellRad = ({
           oppdaterTilrettelegging={oppdaterTilrettelegging}
           avbrytEditering={avbrytEditering}
           readOnly={readOnly}
+          disabled={disabled}
           stillingsprosentArbeidsforhold={stillingsprosentArbeidsforhold}
           arbeidsforhold={arbeidsforhold}
           tomDatoForTilrettelegging={tomDatoForTilrettelegging}
-          slettTilrettelegging={fjernTilrettelegging}
         />
       }
-      togglePlacement="right"
       className={open ? styles['openRow'] : undefined}
     >
       <Table.DataCell>
@@ -94,6 +96,19 @@ export const TilretteleggingPeriodeTabellRad = ({
       </Table.DataCell>
       <Table.DataCell>{utledTypeTekst(stillingsprosentArbeidsforhold, arbeidsforhold, tilrettelegging)}</Table.DataCell>
       <Table.DataCell>{utledKilde(tilrettelegging)}</Table.DataCell>
+      <Table.DataCell width={48}>
+        {tilrettelegging.fom && !(readOnly || disabled) && (
+          <Button
+            size="small"
+            variant="tertiary-neutral"
+            icon={<XMarkIcon aria-hidden />}
+            aria-label={intl.formatMessage({ id: 'TilretteleggingPeriodeTabellRad.SlettPeriode' })}
+            title={intl.formatMessage({ id: 'TilretteleggingPeriodeTabellRad.SlettPeriode' })}
+            onClick={() => fjernTilrettelegging(tilrettelegging.fom)}
+            type="button"
+          />
+        )}
+      </Table.DataCell>
     </Table.ExpandableRow>
   );
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingPeriodeTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingPeriodeTabellRad.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { Table, Tag } from '@navikt/ds-react';
+import { Table } from '@navikt/ds-react';
 import { PeriodLabel } from '@navikt/ft-ui-komponenter';
 
 import { type ArbeidsforholdFodselOgTilrettelegging, type ArbeidsforholdTilretteleggingDato } from '@navikt/fp-types';
@@ -15,36 +15,6 @@ import {
 } from './TilretteleggingForm';
 
 import styles from './tilretteleggingPeriodeTabellRad.module.css';
-
-const utledTypeTekst = (
-  intl: IntlShape,
-  stillingsprosentArbeidsforhold: number,
-  arbeidsforhold: ArbeidsforholdFodselOgTilrettelegging,
-  tilrettelegging: ArbeidsforholdTilretteleggingDato,
-): string => {
-  const velferdspermisjonsprosent = finnVelferdspermisjonprosent(arbeidsforhold);
-  const stillingsprosent = tilrettelegging.type === 'INGEN_TILRETTELEGGING' ? 100 : tilrettelegging.stillingsprosent;
-  const prosent =
-    tilrettelegging.fom && stillingsprosent
-      ? finnProsentSvangerskapspenger(tilrettelegging, stillingsprosentArbeidsforhold, velferdspermisjonsprosent)
-      : 0;
-  return tilrettelegging.fom
-    ? intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.SVPprosent' }, { prosent: prosent ?? '0' })
-    : intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Tilrettelegging' });
-};
-
-const utledKilde = (intl: IntlShape, tilrettelegging: ArbeidsforholdTilretteleggingDato): string => {
-  if (tilrettelegging.kilde === 'REGISTRERT_AV_SAKSBEHANDLER' || tilrettelegging.fom === '') {
-    return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Saksbehandler' });
-  }
-  if (tilrettelegging.kilde === 'ENDRET_AV_SAKSBEHANDLER') {
-    return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.EndretAvSaksbehandler' });
-  }
-  if (tilrettelegging.kilde === 'TIDLIGERE_VEDTAK') {
-    return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.TidligereVedtak' });
-  }
-  return intl.formatMessage({ id: 'TilretteleggingPerioderTabellRad.Soknad' });
-};
 
 interface Props {
   navn: `arbeidsforhold.${number}.tilretteleggingDatoer.${number}`;
@@ -73,7 +43,6 @@ export const TilretteleggingPeriodeTabellRad = ({
   tomDatoForTilrettelegging,
   termindato,
 }: Props) => {
-  const intl = useIntl();
   const [open, setOpen] = useState(openRad);
 
   const { setValue } = useFormContext<TilretteleggingFormValues>();
@@ -120,17 +89,42 @@ export const TilretteleggingPeriodeTabellRad = ({
         {tilrettelegging.fom ? (
           <PeriodLabel dateStringFom={tilrettelegging.fom} dateStringTom={tomDatoForTilrettelegging} />
         ) : (
-          <FormattedMessage id="TilretteleggingPerioderTabellRad.Periode" />
+          <FormattedMessage id="TilretteleggingPeriodeTabellRad.IkkeSatt" />
         )}
       </Table.DataCell>
-      <Table.DataCell>
-        {utledTypeTekst(intl, stillingsprosentArbeidsforhold, arbeidsforhold, tilrettelegging)}
-      </Table.DataCell>
-      <Table.DataCell>
-        <Tag data-color="neutral" size="small" variant="moderate">
-          {utledKilde(intl, tilrettelegging)}
-        </Tag>
-      </Table.DataCell>
+      <Table.DataCell>{utledTypeTekst(stillingsprosentArbeidsforhold, arbeidsforhold, tilrettelegging)}</Table.DataCell>
+      <Table.DataCell>{utledKilde(tilrettelegging)}</Table.DataCell>
     </Table.ExpandableRow>
   );
+};
+
+const utledTypeTekst = (
+  stillingsprosentArbeidsforhold: number,
+  arbeidsforhold: ArbeidsforholdFodselOgTilrettelegging,
+  tilrettelegging: ArbeidsforholdTilretteleggingDato,
+) => {
+  const velferdspermisjonsprosent = finnVelferdspermisjonprosent(arbeidsforhold);
+  const stillingsprosent = tilrettelegging.type === 'INGEN_TILRETTELEGGING' ? 100 : tilrettelegging.stillingsprosent;
+  const prosent =
+    tilrettelegging.fom && stillingsprosent
+      ? finnProsentSvangerskapspenger(tilrettelegging, stillingsprosentArbeidsforhold, velferdspermisjonsprosent)
+      : 0;
+  return tilrettelegging.fom ? (
+    <FormattedMessage id="TilretteleggingPeriodeTabellRad.SVPprosent" values={{ prosent: prosent ?? '0' }} />
+  ) : (
+    <FormattedMessage id="TilretteleggingPeriodeTabellRad.Tilrettelegging" />
+  );
+};
+
+const utledKilde = (tilrettelegging: ArbeidsforholdTilretteleggingDato) => {
+  switch (tilrettelegging.kilde) {
+    case 'ENDRET_AV_SAKSBEHANDLER':
+      return <FormattedMessage id="Kilde.EndretAvSaksbehandler" />;
+    case 'TIDLIGERE_VEDTAK':
+      return <FormattedMessage id="Kilde.TidligereVedtak" />;
+    case 'SØKNAD':
+      return <FormattedMessage id="Kilde.Soknad" />;
+    default:
+      return <FormattedMessage id="Kilde.Saksbehandler" />;
+  }
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingPeriodeTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingPeriodeTabellRad.tsx
@@ -94,8 +94,16 @@ export const TilretteleggingPeriodeTabellRad = ({
           <FormattedMessage id="TilretteleggingPeriodeTabellRad.IkkeSatt" />
         )}
       </Table.DataCell>
-      <Table.DataCell>{utledTypeTekst(stillingsprosentArbeidsforhold, arbeidsforhold, tilrettelegging)}</Table.DataCell>
-      <Table.DataCell>{utledKilde(tilrettelegging)}</Table.DataCell>
+      <Table.DataCell>
+        <TilretteleggingType
+          stillingsprosentArbeidsforhold={stillingsprosentArbeidsforhold}
+          arbeidsforhold={arbeidsforhold}
+          tilrettelegging={tilrettelegging}
+        />
+      </Table.DataCell>
+      <Table.DataCell>
+        <TilretteleggingKilde tilrettelegging={tilrettelegging} />
+      </Table.DataCell>
       <Table.DataCell width={48}>
         {tilrettelegging.fom && !(readOnly || disabled) && (
           <Button
@@ -113,11 +121,15 @@ export const TilretteleggingPeriodeTabellRad = ({
   );
 };
 
-const utledTypeTekst = (
-  stillingsprosentArbeidsforhold: number,
-  arbeidsforhold: ArbeidsforholdFodselOgTilrettelegging,
-  tilrettelegging: ArbeidsforholdTilretteleggingDato,
-) => {
+const TilretteleggingType = ({
+  stillingsprosentArbeidsforhold,
+  arbeidsforhold,
+  tilrettelegging,
+}: {
+  stillingsprosentArbeidsforhold: number;
+  arbeidsforhold: ArbeidsforholdFodselOgTilrettelegging;
+  tilrettelegging: ArbeidsforholdTilretteleggingDato;
+}) => {
   const velferdspermisjonsprosent = finnVelferdspermisjonprosent(arbeidsforhold);
   const stillingsprosent = tilrettelegging.type === 'INGEN_TILRETTELEGGING' ? 100 : tilrettelegging.stillingsprosent;
   const prosent =
@@ -131,7 +143,7 @@ const utledTypeTekst = (
   );
 };
 
-const utledKilde = (tilrettelegging: ArbeidsforholdTilretteleggingDato) => {
+const TilretteleggingKilde = ({ tilrettelegging }: { tilrettelegging: ArbeidsforholdTilretteleggingDato }) => {
   switch (tilrettelegging.kilde) {
     case 'ENDRET_AV_SAKSBEHANDLER':
       return <FormattedMessage id="Kilde.EndretAvSaksbehandler" />;

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/tilretteleggingPeriodeTabellRad.module.css
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/tilretteleggingPeriodeTabellRad.module.css
@@ -1,3 +1,6 @@
 .openRow {
   background-color: var(--ax-bg-neutral-moderate);
 }
+.openRow + tr[data-state='open'] {
+  background-color: var(--ax-bg-default);
+}

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonForm.tsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Alert, Button, Radio, VStack } from '@navikt/ds-react';
 import { RhfRadioGroup } from '@navikt/ft-form-hooks';
@@ -26,8 +26,6 @@ export const VelferdspermisjonForm = ({
   lukkRad,
   oppdaterOverstyrtUtbetalingsgrad,
 }: Props) => {
-  const intl = useIntl();
-
   const { setValue, getValues } = useFormContext<TilretteleggingFormValues>();
 
   const alleVelferdpermisjoner = getValues(`arbeidsforhold.${arbeidsforholdIndex}.velferdspermisjoner`);
@@ -92,21 +90,21 @@ export const VelferdspermisjonForm = ({
           <RhfRadioGroup
             name={`${permisjonIndex}.erGyldig`}
             control={formMethods.control}
-            legend={intl.formatMessage({ id: 'VelferdspermisjonPanel.PermisjonGyldig' })}
-            description={intl.formatMessage({ id: 'VelferdspermisjonPanel.PermisjonGyldigDetaljer' })}
+            legend={<FormattedMessage id="VelferdspermisjonForm.PermisjonGyldig" />}
+            description={<FormattedMessage id="VelferdspermisjonForm.PermisjonGyldigDetaljer" />}
             validate={[required]}
             readOnly={readOnly}
           >
             <Radio value={true} size="small">
-              <FormattedMessage id="VelferdspermisjonPanel.Ja" />
+              <FormattedMessage id="VelferdspermisjonForm.Ja" />
             </Radio>
             <Radio value={false} size="small">
-              <FormattedMessage id="VelferdspermisjonPanel.Nei" />
+              <FormattedMessage id="VelferdspermisjonForm.Nei" />
             </Radio>
           </RhfRadioGroup>
           {erGyldig && velferdspermisjon.permisjonsprosent === 100 && (
             <Alert variant="info" size="small">
-              <FormattedMessage id="VelferdspermisjonPanel.Permisjon100ProsentOgGyldig" />
+              <FormattedMessage id="VelferdspermisjonForm.Permisjon100ProsentOgGyldig" />
             </Alert>
           )}
           <div>
@@ -117,7 +115,7 @@ export const VelferdspermisjonForm = ({
               disabled={!formMethods.formState.isDirty || false}
               onClick={formMethods.handleSubmit(lagreForm)}
             >
-              <FormattedMessage id="VelferdspermisjonPanel.Oppdater" />
+              <FormattedMessage id="VelferdspermisjonForm.Oppdater" />
             </Button>
           </div>
         </VStack>

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonForm.tsx
@@ -1,7 +1,7 @@
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
-import { Alert, Button, Radio, VStack } from '@navikt/ds-react';
+import { Alert, Button, HStack, Radio, VStack } from '@navikt/ds-react';
 import { RhfRadioGroup } from '@navikt/ft-form-hooks';
 import { required } from '@navikt/ft-form-validators';
 
@@ -76,50 +76,41 @@ export const VelferdspermisjonForm = ({
 
   return (
     <FormProvider {...formMethods}>
-      <div
-        style={{
-          backgroundColor: 'var(--ax-bg-default)',
-          padding: '24px',
-          marginTop: '-8px',
-          marginBottom: '-8px',
-          marginLeft: '-8px',
-          marginRight: '-8px',
-        }}
-      >
-        <VStack gap="space-20">
-          <RhfRadioGroup
-            name={`${permisjonIndex}.erGyldig`}
-            control={formMethods.control}
-            legend={<FormattedMessage id="VelferdspermisjonForm.PermisjonGyldig" />}
-            description={<FormattedMessage id="VelferdspermisjonForm.PermisjonGyldigDetaljer" />}
-            validate={[required]}
-            readOnly={readOnly}
-          >
+      <VStack gap="space-16" paddingBlock="space-8">
+        <RhfRadioGroup
+          name={`${permisjonIndex}.erGyldig`}
+          control={formMethods.control}
+          legend={<FormattedMessage id="VelferdspermisjonForm.PermisjonGyldig" />}
+          description={<FormattedMessage id="VelferdspermisjonForm.PermisjonGyldigDetaljer" />}
+          validate={[required]}
+          readOnly={readOnly}
+        >
+          <HStack gap="space-16">
             <Radio value={true} size="small">
               <FormattedMessage id="VelferdspermisjonForm.Ja" />
             </Radio>
             <Radio value={false} size="small">
               <FormattedMessage id="VelferdspermisjonForm.Nei" />
             </Radio>
-          </RhfRadioGroup>
-          {erGyldig && velferdspermisjon.permisjonsprosent === 100 && (
-            <Alert variant="info" size="small">
-              <FormattedMessage id="VelferdspermisjonForm.Permisjon100ProsentOgGyldig" />
-            </Alert>
-          )}
-          <div>
-            <Button
-              size="small"
-              variant="primary"
-              type="button"
-              disabled={!formMethods.formState.isDirty || false}
-              onClick={formMethods.handleSubmit(lagreForm)}
-            >
-              <FormattedMessage id="VelferdspermisjonForm.Oppdater" />
-            </Button>
-          </div>
-        </VStack>
-      </div>
+          </HStack>
+        </RhfRadioGroup>
+        {erGyldig && velferdspermisjon.permisjonsprosent === 100 && (
+          <Alert variant="info" size="small" className="self-start">
+            <FormattedMessage id="VelferdspermisjonForm.Permisjon100ProsentOgGyldig" />
+          </Alert>
+        )}
+        <div>
+          <Button
+            size="small"
+            variant="primary"
+            type="button"
+            disabled={!formMethods.formState.isDirty || false}
+            onClick={formMethods.handleSubmit(lagreForm)}
+          >
+            <FormattedMessage id="VelferdspermisjonForm.Oppdater" />
+          </Button>
+        </div>
+      </VStack>
     </FormProvider>
   );
 };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabell.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabell.tsx
@@ -8,7 +8,6 @@ import { VelferdspermisjonTabellRad } from './VelferdspermisjonTabellRad';
 
 interface Props {
   filtrerteVelferdspermisjoner: Permisjon[];
-  harUavklartVelferdspermisjon: boolean;
   arbeidsforholdIndex: number;
   readOnly: boolean;
   oppdaterOverstyrtUtbetalingsgrad: (velferdspermisjonprosent: number) => void;

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabell.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabell.tsx
@@ -1,6 +1,5 @@
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { HStack, Table } from '@navikt/ds-react';
 
 import type { Permisjon } from '@navikt/fp-types';
@@ -17,27 +16,17 @@ interface Props {
 
 export const VelferdspermisjonTabell = ({
   filtrerteVelferdspermisjoner,
-  harUavklartVelferdspermisjon,
   arbeidsforholdIndex,
   readOnly,
   oppdaterOverstyrtUtbetalingsgrad,
 }: Props) => {
-  const intl = useIntl();
-
   return (
     <Table size="small">
       <Table.Header>
         <Table.Row>
-          <Table.HeaderCell colSpan={4} textSize="small">
+          <Table.HeaderCell colSpan={3} textSize="small">
             <HStack gap="space-8">
-              <FormattedMessage tagName="span" id="VelferdspermisjonPanel.Velferdspermisjon" />
-              {harUavklartVelferdspermisjon && (
-                <ExclamationmarkTriangleFillIcon
-                  title={intl.formatMessage({ id: 'VelferdspermisjonPanel.ErPermisjonGyldg' })}
-                  fontSize="1.25rem"
-                  color="var(--ax-warning-700)"
-                />
-              )}
+              <FormattedMessage tagName="span" id="VelferdspermisjonTabell.RegistrerteVelferdspermisjoner" />
             </HStack>
           </Table.HeaderCell>
         </Table.Row>

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabell.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabell.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { HStack, Table } from '@navikt/ds-react';
+import { Table } from '@navikt/ds-react';
 
 import type { Permisjon } from '@navikt/fp-types';
 
@@ -19,29 +19,25 @@ export const VelferdspermisjonTabell = ({
   arbeidsforholdIndex,
   readOnly,
   oppdaterOverstyrtUtbetalingsgrad,
-}: Props) => {
-  return (
-    <Table size="small">
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell colSpan={3} textSize="small">
-            <HStack gap="space-8">
-              <FormattedMessage tagName="span" id="VelferdspermisjonTabell.RegistrerteVelferdspermisjoner" />
-            </HStack>
-          </Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {filtrerteVelferdspermisjoner.map(permisjon => (
-          <VelferdspermisjonTabellRad
-            key={permisjon.permisjonFom}
-            velferdspermisjon={permisjon}
-            readOnly={readOnly}
-            arbeidsforholdIndex={arbeidsforholdIndex}
-            oppdaterOverstyrtUtbetalingsgrad={oppdaterOverstyrtUtbetalingsgrad}
-          />
-        ))}
-      </Table.Body>
-    </Table>
-  );
-};
+}: Props) => (
+  <Table size="small">
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell colSpan={3} textSize="small">
+          <FormattedMessage id="VelferdspermisjonTabell.RegistrerteVelferdspermisjoner" />
+        </Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      {filtrerteVelferdspermisjoner.map(permisjon => (
+        <VelferdspermisjonTabellRad
+          key={permisjon.permisjonFom}
+          velferdspermisjon={permisjon}
+          readOnly={readOnly}
+          arbeidsforholdIndex={arbeidsforholdIndex}
+          oppdaterOverstyrtUtbetalingsgrad={oppdaterOverstyrtUtbetalingsgrad}
+        />
+      ))}
+    </Table.Body>
+  </Table>
+);

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabellRad.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { Table, Tag } from '@navikt/ds-react';
+import { Table } from '@navikt/ds-react';
 import { PeriodLabel } from '@navikt/ft-ui-komponenter';
 
 import type { Permisjon } from '@navikt/fp-types';
@@ -58,17 +58,12 @@ export const VelferdspermisjonTabellRad = ({
       </Table.DataCell>
       <Table.DataCell>
         <FormattedMessage
-          id="VelferdspermisjonPanel.Permisjon"
+          id="VelferdspermisjonTabellRad.Permisjon"
           values={{
             type: velferdspermisjon.type.toLowerCase(),
             permisjon: velferdspermisjon.permisjonsprosent,
           }}
         />
-      </Table.DataCell>
-      <Table.DataCell>
-        <Tag data-color="neutral" variant="moderate" size="small">
-          <FormattedMessage id="VelferdspermisjonPanel.AaRegisteret" />
-        </Tag>
       </Table.DataCell>
     </Table.ExpandableRow>
   );

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabellRad.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/VelferdspermisjonTabellRad.tsx
@@ -40,7 +40,6 @@ export const VelferdspermisjonTabellRad = ({
       expandOnRowClick
       onOpenChange={() => setOpen(!open)}
       onClick={() => setOpen(!open)}
-      contentGutter="none"
       content={
         <VelferdspermisjonForm
           velferdspermisjon={velferdspermisjon}
@@ -50,7 +49,6 @@ export const VelferdspermisjonTabellRad = ({
           oppdaterOverstyrtUtbetalingsgrad={oppdaterOverstyrtUtbetalingsgrad}
         />
       }
-      togglePlacement="right"
       className={utledStyleForRad(open, erIkkeValgt)}
     >
       <Table.DataCell>

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/velferdspermisjonTabellRad.module.css
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/velferdspermisjon/velferdspermisjonTabellRad.module.css
@@ -2,6 +2,14 @@
   background-color: var(--ax-bg-neutral-moderate);
 }
 
+.openRow + tr[data-state='open'] {
+  background-color: var(--ax-bg-default);
+}
+
 .apRow {
   background-color: var(--ax-warning-200);
+}
+
+.apRow + tr[data-state='open'] {
+  background-color: var(--ax-bg-default);
 }


### PR DESCRIPTION
## Kva er gjort

Refaktorering av komponentar og i18n-nøklar i tilrettelegging-fakta-pakka.

**Endringer:**
- Reorganisert i18n-nøklar til å vere spesifikke per komponent (VelferdspermisjonTabell, VelferdspermisjonForm, VelferdspermisjonTabellRad, TilretteleggingPeriodeTabellRad, OppholdPeriodeTabellRad)
- Lagt til Kilde-kolonne i `TilretteleggingOgOppholdPerioderPanel`
- Skilt ut `VelferdspermisjonTabell`, `VelferdspermisjonForm` og `VelferdspermisjonTabellRad` som eigne komponentar
- Gjeve nytt namn til `TilretteleggingPeriodeTabellRad` og `OppholdPeriodeTabellRad`
- Oppdatert testar

Relatert til: TFP-6942