### PR TITLE
Chore: pin external GitHub Actions to SHA with ratchet comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     outputs:
       build-version: ${{ steps.generate-build-version.outputs.build-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
         with:
           ref: ${{ (inputs.branch != '' && inputs.branch) || '' }}
 
@@ -61,14 +61,14 @@ jobs:
         with:
           npmAuthToken: ${{ secrets.READER_TOKEN }}
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: 'yarn'
 
       - name: Use turbo cache
         id: hent-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('yarn.lock') }}-${{ inputs.app }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Lagre alltid turbo cache
         if: always() && steps.hent-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/save@v5.0.5
         with:
           key: ${{ steps.hent-cache.outputs.cache-primary-key }}
           path: .turbo

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -6,19 +6,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
       - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
         with:
           npmAuthToken: ${{ secrets.READER_TOKEN }}
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: 'yarn'
 
       - name: Use turbo cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
         with:
           path: ~/work/fp-frontend/fp-frontend/.turbo
           key: turbo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Pin actions/checkout, actions/setup-node, and actions/cache to full commit SHAs for supply-chain security. Nais dependencies remain on workflow tags.