### PR TITLE
TFP-6979 mellomlagre papirsøknad og hente på nytt

### DIFF
--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -45,7 +45,9 @@ const BehandlingPapirsoknadIndex = () => {
   // Hent mellomlagret utkast (om det finnes)
   const { data: mellomlagretResponse, isLoading: mellomlagringLaster } = useQuery(api.mellomlagretPapirsøknadOptions(behandling));
   const mellomlagretData = (() => {
-    if (!mellomlagretResponse?.innhold) return undefined;
+    if (!mellomlagretResponse?.innhold) {
+      return undefined;
+    }
     try {
       const parsed = JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>;
       return isPapirsøknadMellomlagring(parsed) ? parsed : undefined;

--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -46,8 +46,12 @@ const BehandlingPapirsoknadIndex = () => {
   const { data: mellomlagretResponse, isLoading: mellomlagringLaster } = useQuery(api.mellomlagretPapirsøknadOptions(behandling));
   const mellomlagretData = (() => {
     if (!mellomlagretResponse?.innhold) return undefined;
-    const parsed = JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>;
-    return isPapirsøknadMellomlagring(parsed) ? parsed : undefined;
+    try {
+      const parsed = JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>;
+      return isPapirsøknadMellomlagring(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
   })();
 
   const queryClient = useQueryClient();

--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import {
@@ -13,7 +13,7 @@ import {
 } from '@navikt/fp-papirsoknad';
 import type { Aksjonspunkt, FagsakYtelseType, FamilieHendelseType } from '@navikt/fp-types';
 
-import { useBehandlingApi } from '../../data/behandlingApi';
+import { BehandlingRel, useBehandlingApi } from '../../data/behandlingApi';
 import { useBehandlingDataContext } from '../felles/context/BehandlingDataContext';
 
 /**
@@ -46,6 +46,8 @@ const BehandlingPapirsoknadIndex = () => {
     ? (JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>)
     : undefined;
 
+  const queryClient = useQueryClient();
+
   // Mellomlagring-mutation
   const { mutate: mellomlagreMutation } = useMutation({
     mutationFn: (innhold: string | null) =>
@@ -54,6 +56,11 @@ const BehandlingPapirsoknadIndex = () => {
         type: 'PAPIRSØKNAD',
         innhold,
       }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: [BehandlingRel.HENT_MELLOMLAGRING, 'PAPIRSØKNAD', behandling.uuid],
+      });
+    },
   });
 
   const onMellomlagre = useCallback(

--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import {
@@ -11,6 +13,7 @@ import {
 } from '@navikt/fp-papirsoknad';
 import type { Aksjonspunkt, FagsakYtelseType, FamilieHendelseType } from '@navikt/fp-types';
 
+import { useBehandlingApi } from '../../data/behandlingApi';
 import { useBehandlingDataContext } from '../felles/context/BehandlingDataContext';
 
 /**
@@ -25,6 +28,7 @@ const BehandlingPapirsoknadIndex = () => {
 
   const { alleKodeverk, behandling, rettigheter, fagsak, setSkalOppdatereEtterBekreftelseAvAp } =
     useBehandlingDataContext();
+  const api = useBehandlingApi(behandling);
 
   const isReadOnly = !rettigheter.writeAccess.isEnabled || behandling.behandlingPåVent;
 
@@ -33,6 +37,39 @@ const BehandlingPapirsoknadIndex = () => {
   const erEndringssøknad = behandling.aksjonspunkt.some(
     ap => ap.definisjon === AksjonspunktKode.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER,
   );
+
+  const apKode = getAktivPapirsøknadApKode(behandling.aksjonspunkt);
+
+  // Hent mellomlagret utkast (om det finnes)
+  const { data: mellomlagretResponse, isPending: mellomlagringLaster } = useQuery(api.mellomlagretPapirsøknadOptions(behandling));
+  const mellomlagretData = mellomlagretResponse?.innhold
+    ? (JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>)
+    : undefined;
+
+  // Mellomlagring-mutation
+  const { mutate: mellomlagreMutation } = useMutation({
+    mutationFn: (innhold: string | null) =>
+      api.mellomlagring({
+        behandlingUuid: behandling.uuid,
+        type: 'PAPIRSØKNAD',
+        innhold,
+      }),
+  });
+
+  const onMellomlagre = useCallback(
+    (formValues: EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues) => {
+      const payload = JSON.stringify({
+        '@type': apKode,
+        ...formValues,
+      });
+      mellomlagreMutation(payload);
+    },
+    [mellomlagreMutation, apKode],
+  );
+
+  if (mellomlagringLaster) {
+    return null;
+  }
 
   return (
     <>
@@ -43,6 +80,8 @@ const BehandlingPapirsoknadIndex = () => {
         readOnly={isReadOnly}
         lagrePapirsøknad={lagrePapirsøknad}
         erEndringssøknad={erEndringssøknad}
+        mellomlagretData={mellomlagretData}
+        onMellomlagre={onMellomlagre}
       />
     </>
   );

--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -7,6 +7,8 @@ import {
   type EngangsstønadValues,
   type ForeldrepengerEndringssøknadValues,
   type ForeldrepengerValues,
+  isPapirsøknadMellomlagring,
+  type PapirsøknadMellomlagring,
   RegistrerPapirsoknadPanel,
   SoknadRegistrertModal,
   type SvangerskapsValues,
@@ -41,10 +43,12 @@ const BehandlingPapirsoknadIndex = () => {
   const apKode = getAktivPapirsøknadApKode(behandling.aksjonspunkt);
 
   // Hent mellomlagret utkast (om det finnes)
-  const { data: mellomlagretResponse, isPending: mellomlagringLaster } = useQuery(api.mellomlagretPapirsøknadOptions(behandling));
-  const mellomlagretData = mellomlagretResponse?.innhold
-    ? (JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>)
-    : undefined;
+  const { data: mellomlagretResponse, isLoading: mellomlagringLaster } = useQuery(api.mellomlagretPapirsøknadOptions(behandling));
+  const mellomlagretData = (() => {
+    if (!mellomlagretResponse?.innhold) return undefined;
+    const parsed = JSON.parse(mellomlagretResponse.innhold) as Record<string, unknown>;
+    return isPapirsøknadMellomlagring(parsed) ? parsed : undefined;
+  })();
 
   const queryClient = useQueryClient();
 
@@ -64,7 +68,7 @@ const BehandlingPapirsoknadIndex = () => {
   });
 
   const onMellomlagre = useCallback(
-    (formValues: EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues) => {
+    (formValues: PapirsøknadMellomlagring) => {
       const payload = JSON.stringify({
         '@type': apKode,
         ...formValues,

--- a/apps/fp-frontend/src/data/behandlingApi.ts
+++ b/apps/fp-frontend/src/data/behandlingApi.ts
@@ -203,6 +203,7 @@ export const BehandlingRel = {
   FERDIGSTILL_OPPGAVE: 'ferdigstill-oppgave',
   HENT_BREV_HTML: 'hent-brev-html',
   MELLOMLAGRING: 'mellomlagring',
+  HENT_MELLOMLAGRING: 'hent-mellomlagring',
 };
 
 const getArbeidsgiverOversiktOptions =
@@ -672,12 +673,26 @@ const getHentBrevHtml =
       .json<BrevOverstyring>();
 
 const getMellomlagring =
-  (links: ApiLink[]) => (params: { behandlingUuid: string; dokumentMal?: string; innhold?: string }) =>
+  (links: ApiLink[]) => (params: { behandlingUuid: string; type?: string; dokumentMal?: string; innhold?: string | null }) =>
     kyExtended
       .post(getUrlFromRel('MELLOMLAGRING', links), {
         json: params,
       })
       .then(() => {});
+
+const getMellomlagretPapirsøknadOptions =
+  (links: ApiLink[]) => (behandling: Behandling) =>
+    queryOptions({
+      queryKey: [BehandlingRel.HENT_MELLOMLAGRING, 'PAPIRSØKNAD', behandling.uuid, behandling.versjon],
+      queryFn: () =>
+        jsonEllerNull<{ innhold: string }>(
+          kyExtended.post(getUrlFromRel('HENT_MELLOMLAGRING', links), {
+            json: { behandlingUuid: behandling.uuid, type: 'PAPIRSØKNAD' },
+          }),
+        ),
+      enabled: harLenke(behandling, 'HENT_MELLOMLAGRING'),
+      staleTime: Infinity,
+    });
 
 const getFjernVergeV2 = (links: ApiLink[]) => () => kyExtended.post(getUrlFromRel('VERGE_FJERN_V2', links));
 
@@ -797,6 +812,7 @@ export const useBehandlingApi = (behandling: Behandling) => {
     vergeOptions: getVergeOptions(links),
     hentBrevHtml: getHentBrevHtml(links),
     mellomlagring: getMellomlagring(links),
+    mellomlagretPapirsøknadOptions: getMellomlagretPapirsøknadOptions(links),
     merkSomHaster: getMerkSomHaster(links),
     verge: {
       hent: getVerge(links),

--- a/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
+++ b/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
@@ -60,6 +60,7 @@
   "Registrering.SaveApplication.OpplysningspliktErIkkeOverholdt": "Søkers opplysningsplikt er ikke overholdt",
   "Registrering.SaveApplication.EndButton": "Bekreft og fortsett til avslag",
   "Registrering.SaveApplication.SaveButton": "Bekreft og fortsett",
+  "Registrering.SaveApplication.MellomlagreButton": "Mellomlagre",
   "Registrering.Verge": "Verge/fullmektig skal knyttes til saken",
 
   "Registrering.Omsoknaden.MottattDato": "Mottatt dato",

--- a/packages/papirsoknad-ui-komponenter/src/andreYtelserPanel/components/AndreYtelserPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/andreYtelserPanel/components/AndreYtelserPanel.tsx
@@ -80,7 +80,7 @@ const CheckboxWithInfo = ({
   readOnly: boolean;
 }) => {
   const { watch } = useFormContext<AndreYtelserFormValue>();
-  const valgteArbeidstyper = watch(`${ANDRE_YTELSER_NAME_PREFIX}.${ANDRE_YTELSER_TYPER_NAME}`);
+  const valgteArbeidstyper = watch(`${ANDRE_YTELSER_NAME_PREFIX}.${ANDRE_YTELSER_TYPER_NAME}`, []);
 
   const [visPerioder, setVisPerioder] = useState(valgteArbeidstyper.includes(arbeidstype.kode));
 

--- a/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/LagreSoknadPapirsoknadIndex.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/LagreSoknadPapirsoknadIndex.tsx
@@ -11,6 +11,7 @@ const intl = createIntl(messages);
 interface Props {
   readOnly: boolean;
   onSubmitUfullstendigsoknad: () => Promise<void>;
+  onMellomlagre?: () => void;
   submitting: boolean;
   erEndringssøknad: boolean;
 }

--- a/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/components/LagreSoknadPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/components/LagreSoknadPanel.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Button, Heading, VStack } from '@navikt/ds-react';
+import { Button, Heading, HStack, VStack } from '@navikt/ds-react';
 import { RhfCheckbox, RhfTextarea } from '@navikt/ft-form-hooks';
 import { hasValidText, maxLength } from '@navikt/ft-form-validators';
 import { BorderBox } from '@navikt/ft-ui-komponenter';
@@ -16,6 +16,7 @@ type LagreSoknadFormValues = {
 
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
+  onMellomlagre?: () => void;
   readOnly?: boolean;
   submitting: boolean;
   erEndringssøknad: boolean;
@@ -24,6 +25,7 @@ interface Props {
 export const LagreSoknadPanel = ({
   submitting,
   onSubmitUfullstendigsoknad,
+  onMellomlagre,
   readOnly = true,
   erEndringssøknad,
 }: Props) => {
@@ -63,7 +65,7 @@ export const LagreSoknadPanel = ({
             />
           </div>
         )}
-        <div>
+        <HStack gap="space-8">
           {!ufullstendigSøknad && (
             <Button
               id="saveButton"
@@ -88,7 +90,19 @@ export const LagreSoknadPanel = ({
               <FormattedMessage id="Registrering.SaveApplication.EndButton" />
             </Button>
           )}
-        </div>
+          {!ufullstendigSøknad && onMellomlagre && (
+            <Button
+              id="mellomlagreButton"
+              onClick={onMellomlagre}
+              size="small"
+              variant="secondary"
+              disabled={readOnly || submitting}
+              type="button"
+            >
+              <FormattedMessage id="Registrering.SaveApplication.MellomlagreButton" />
+            </Button>
+          )}
+        </HStack>
       </VStack>
     </BorderBox>
   );

--- a/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/components/LagreSoknadPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/components/LagreSoknadPanel.tsx
@@ -65,7 +65,7 @@ export const LagreSoknadPanel = ({
             />
           </div>
         )}
-        <HStack gap="space-8">
+        <HStack justify="space-between">
           {!ufullstendigSøknad && (
             <Button
               id="saveButton"

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetStartetEndretPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetStartetEndretPanel.tsx
@@ -129,7 +129,7 @@ const CheckboxWithInfo = ({
   index: number;
 }) => {
   const { watch, control } = useFormContext<VirksomhetFormValues>();
-  const valgteÅrsaker = watch(`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.varigEndretEllerStartetSisteFireArArsak`);
+  const valgteÅrsaker = watch(`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.varigEndretEllerStartetSisteFireArArsak`, []);
 
   const [visPerioder, setVisPerioder] = useState(valgteÅrsaker.includes(value));
 

--- a/packages/papirsoknad/index.ts
+++ b/packages/papirsoknad/index.ts
@@ -1,3 +1,4 @@
+export { isPapirsøknadMellomlagring, type PapirsøknadMellomlagring } from './src/PapirsøknadMellomlagring';
 export { RegistrerPapirsoknadPanel } from './src/RegistrerPapirsoknadPanel';
 export { SoknadRegistrertModal } from './src/modal/SoknadRegistrertModal';
 export type { EngangsstønadValues } from './src/engangsstonad/components/EngangsstonadForm';

--- a/packages/papirsoknad/src/PapirsøknadMellomlagring.ts
+++ b/packages/papirsoknad/src/PapirsøknadMellomlagring.ts
@@ -1,0 +1,20 @@
+import type { FagsakYtelseType, FamilieHendelseType, ForeldreType } from '@navikt/fp-types';
+
+/**
+ * Kontrakt for mellomlagret papirsøknad-data.
+ *
+ * Metadata-feltene (fagsakYtelseType, familieHendelseType, foreldreType) identifiserer skjematype.
+ * Øvrige felter er rå form-verdier som varierer per skjema.
+ */
+export interface PapirsøknadMellomlagring {
+  fagsakYtelseType: FagsakYtelseType;
+  familieHendelseType: FamilieHendelseType;
+  foreldreType?: ForeldreType;
+  [key: string]: unknown;
+}
+
+/**
+ * Type guard som verifiserer at et parset JSON-objekt har påkrevde metadata-felter.
+ */
+export const isPapirsøknadMellomlagring = (data: Record<string, unknown>): data is PapirsøknadMellomlagring =>
+  typeof data['fagsakYtelseType'] === 'string' && typeof data['familieHendelseType'] === 'string';

--- a/packages/papirsoknad/src/RegistrerPapirsoknadPanel.tsx
+++ b/packages/papirsoknad/src/RegistrerPapirsoknadPanel.tsx
@@ -20,6 +20,7 @@ import { EngangsstonadPapirsoknadIndex } from './engangsstonad/EngangsstonadPapi
 import type { ForeldrepengerEndringssøknadValues } from './foreldrepenger/components/ForeldrepengerEndringssøknadForm';
 import type { ForeldrepengerValues } from './foreldrepenger/components/ForeldrepengerForm';
 import { ForeldrepengerPapirsoknadIndex } from './foreldrepenger/ForeldrepengerPapirsoknadIndex';
+import type { PapirsøknadMellomlagring } from './PapirsøknadMellomlagring';
 import { SoknadTypePickerForm } from './SoknadTypePickerForm';
 import type { SvangerskapsValues } from './svangerskapspenger/components/SvangerskapspengerForm';
 import { SvangerskapspengerPapirsoknadIndex } from './svangerskapspenger/SvangerskapspengerPapirsoknadIndex';
@@ -41,8 +42,8 @@ interface Props {
     formValues?: AllFormValues,
   ) => Promise<BehandlingFpSak>;
   erEndringssøknad: boolean;
-  mellomlagretData?: Record<string, unknown>;
-  onMellomlagre?: (formValues: AllFormValues) => void;
+  mellomlagretData?: PapirsøknadMellomlagring;
+  onMellomlagre?: (values: PapirsøknadMellomlagring) => void;
 }
 
 export const RegistrerPapirsoknadPanel = ({
@@ -55,17 +56,9 @@ export const RegistrerPapirsoknadPanel = ({
   onMellomlagre,
 }: Props) => {
   const [soknadData, setSoknadData] = useState<SoknadData | undefined>(() => {
-    if (mellomlagretData?.['soknadstype'] && mellomlagretData['tema']) {
-      return new SoknadData(
-        mellomlagretData['soknadstype'] as FagsakYtelseType,
-        mellomlagretData['tema'] as FamilieHendelseType,
-        (mellomlagretData['foreldretype'] ?? 'MOR') as ForeldreType,
-      );
-    }
-    return undefined;
+    if (!mellomlagretData) return undefined;
+    return new SoknadData(mellomlagretData.fagsakYtelseType, mellomlagretData.familieHendelseType, mellomlagretData.foreldreType ?? 'MOR');
   });
-
-  const harMellomlagretSoknadData = !!mellomlagretData?.['soknadstype'];
 
   const lagreFullstendigSøknad = (
     formValues: EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues,
@@ -89,12 +82,12 @@ export const RegistrerPapirsoknadPanel = ({
   };
 
   const mellomlagreWrapped = onMellomlagre && soknadData
-    ? (formValues: AllFormValues) => {
-        const payload = {
+    ? (formValues: Record<string, unknown>) => {
+        const payload: PapirsøknadMellomlagring = {
           ...formValues,
-          soknadstype: soknadData.fagsakYtelseType,
-          tema: soknadData.familieHendelseType,
-          foreldretype: soknadData.foreldreType,
+          fagsakYtelseType: soknadData.fagsakYtelseType,
+          familieHendelseType: soknadData.familieHendelseType,
+          foreldreType: soknadData.foreldreType,
         };
         onMellomlagre(payload);
       }
@@ -119,9 +112,8 @@ export const RegistrerPapirsoknadPanel = ({
           setSoknadData={setSoknadData}
           fagsakYtelseType={fagsak.fagsakYtelseType}
           alleKodeverk={kodeverk}
-          initialFamilieHendelseType={mellomlagretData?.['tema'] as FamilieHendelseType | undefined}
-          initialForeldreType={mellomlagretData?.['foreldretype'] as ForeldreType | undefined}
-          confirmed={harMellomlagretSoknadData}
+          initialFamilieHendelseType={soknadData?.familieHendelseType}
+          initialForeldreType={soknadData?.foreldreType}
         />
         {soknadData?.getFagsakYtelseType() === 'ES' && (
           <EngangsstonadPapirsoknadIndex

--- a/packages/papirsoknad/src/RegistrerPapirsoknadPanel.tsx
+++ b/packages/papirsoknad/src/RegistrerPapirsoknadPanel.tsx
@@ -56,7 +56,9 @@ export const RegistrerPapirsoknadPanel = ({
   onMellomlagre,
 }: Props) => {
   const [soknadData, setSoknadData] = useState<SoknadData | undefined>(() => {
-    if (!mellomlagretData) return undefined;
+    if (!mellomlagretData) {
+      return undefined;
+    }
     return new SoknadData(mellomlagretData.fagsakYtelseType, mellomlagretData.familieHendelseType, mellomlagretData.foreldreType ?? 'MOR');
   });
 

--- a/packages/papirsoknad/src/RegistrerPapirsoknadPanel.tsx
+++ b/packages/papirsoknad/src/RegistrerPapirsoknadPanel.tsx
@@ -28,6 +28,8 @@ import messages from '../i18n/nb_NO.json';
 
 const intl = createIntl(messages);
 
+type AllFormValues = EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues;
+
 interface Props {
   fagsak: Fagsak;
   kodeverk: AlleKodeverk;
@@ -36,9 +38,11 @@ interface Props {
     fagsakYtelseType: FagsakYtelseType,
     familieHendelseType: FamilieHendelseType,
     foreldreType: ForeldreType,
-    formValues?: EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues,
+    formValues?: AllFormValues,
   ) => Promise<BehandlingFpSak>;
   erEndringssøknad: boolean;
+  mellomlagretData?: Record<string, unknown>;
+  onMellomlagre?: (formValues: AllFormValues) => void;
 }
 
 export const RegistrerPapirsoknadPanel = ({
@@ -47,8 +51,21 @@ export const RegistrerPapirsoknadPanel = ({
   readOnly,
   lagrePapirsøknad,
   erEndringssøknad,
+  mellomlagretData,
+  onMellomlagre,
 }: Props) => {
-  const [soknadData, setSoknadData] = useState<SoknadData>();
+  const [soknadData, setSoknadData] = useState<SoknadData | undefined>(() => {
+    if (mellomlagretData?.['soknadstype'] && mellomlagretData['tema']) {
+      return new SoknadData(
+        mellomlagretData['soknadstype'] as FagsakYtelseType,
+        mellomlagretData['tema'] as FamilieHendelseType,
+        (mellomlagretData['foreldretype'] ?? 'MOR') as ForeldreType,
+      );
+    }
+    return undefined;
+  });
+
+  const harMellomlagretSoknadData = !!mellomlagretData?.['soknadstype'];
 
   const lagreFullstendigSøknad = (
     formValues: EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues,
@@ -71,6 +88,18 @@ export const RegistrerPapirsoknadPanel = ({
     return Promise.resolve();
   };
 
+  const mellomlagreWrapped = onMellomlagre && soknadData
+    ? (formValues: AllFormValues) => {
+        const payload = {
+          ...formValues,
+          soknadstype: soknadData.fagsakYtelseType,
+          tema: soknadData.familieHendelseType,
+          foreldretype: soknadData.foreldreType,
+        };
+        onMellomlagre(payload);
+      }
+    : undefined;
+
   return (
     <RawIntlProvider value={intl}>
       <VStack gap="space-16" padding="space-16">
@@ -90,11 +119,16 @@ export const RegistrerPapirsoknadPanel = ({
           setSoknadData={setSoknadData}
           fagsakYtelseType={fagsak.fagsakYtelseType}
           alleKodeverk={kodeverk}
+          initialFamilieHendelseType={mellomlagretData?.['tema'] as FamilieHendelseType | undefined}
+          initialForeldreType={mellomlagretData?.['foreldretype'] as ForeldreType | undefined}
+          confirmed={harMellomlagretSoknadData}
         />
         {soknadData?.getFagsakYtelseType() === 'ES' && (
           <EngangsstonadPapirsoknadIndex
             onSubmitUfullstendigsoknad={lagreUfullstendigSøknadOgAvslutt}
             onSubmit={lagreFullstendigSøknad}
+            onMellomlagre={mellomlagreWrapped}
+            mellomlagretData={mellomlagretData}
             readOnly={readOnly}
             soknadData={soknadData}
             alleKodeverk={kodeverk}
@@ -104,6 +138,8 @@ export const RegistrerPapirsoknadPanel = ({
           <ForeldrepengerPapirsoknadIndex
             onSubmitUfullstendigsoknad={lagreUfullstendigSøknadOgAvslutt}
             onSubmit={lagreFullstendigSøknad}
+            onMellomlagre={mellomlagreWrapped}
+            mellomlagretData={mellomlagretData}
             readOnly={readOnly}
             soknadData={soknadData}
             alleKodeverk={kodeverk}
@@ -115,6 +151,8 @@ export const RegistrerPapirsoknadPanel = ({
           <SvangerskapspengerPapirsoknadIndex
             onSubmitUfullstendigsoknad={lagreUfullstendigSøknadOgAvslutt}
             onSubmit={lagreFullstendigSøknad}
+            onMellomlagre={mellomlagreWrapped}
+            mellomlagretData={mellomlagretData}
             readOnly={readOnly}
             soknadData={soknadData}
             alleKodeverk={kodeverk}

--- a/packages/papirsoknad/src/SoknadTypePickerForm.tsx
+++ b/packages/papirsoknad/src/SoknadTypePickerForm.tsx
@@ -26,6 +26,9 @@ interface Props {
   setSoknadData: (soknadData: SoknadData) => void;
   fagsakYtelseType: FagsakYtelseType;
   alleKodeverk: AlleKodeverk;
+  initialFamilieHendelseType?: FamilieHendelseType;
+  initialForeldreType?: ForeldreType;
+  confirmed?: boolean;
 }
 
 /**
@@ -33,12 +36,12 @@ interface Props {
  *
  * Toppkomponent for registrering av papirsøknad der søknadstype, tema og søker/foreldretype blir valgt.
  */
-export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKodeverk }: Props) => {
+export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKodeverk, initialFamilieHendelseType, initialForeldreType, confirmed }: Props) => {
   const formMethods = useForm<FormValues>({
     defaultValues: {
       fagsakYtelseType,
-      familieHendelseType: undefined,
-      foreldreType: undefined,
+      familieHendelseType: initialFamilieHendelseType ?? undefined,
+      foreldreType: initialForeldreType ?? undefined,
     },
   });
 
@@ -86,7 +89,7 @@ export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKode
                 {familieHendelseTyper
                   .filter(({ kode }) => SØKNAD_TYPER.has(kode))
                   .map(bmt => (
-                    <Radio key={bmt.kode} value={bmt.kode} size="small">
+                    <Radio key={bmt.kode} value={bmt.kode} size="small" disabled={confirmed}>
                       {bmt.navn}
                     </Radio>
                   ))}
@@ -100,18 +103,20 @@ export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKode
               validate={[required]}
             >
               {utledForeldreTyper(foreldreTyper, selectedFagsakYtelseType).map(ft => (
-                <Radio key={ft.kode} value={ft.kode} size="small">
+                <Radio key={ft.kode} value={ft.kode} size="small" disabled={confirmed}>
                   {ft.navn}
                 </Radio>
               ))}
             </RhfRadioGroup>
           </HStack>
 
-          <Box style={{ textAlign: 'end' }}>
-            <Button type="submit" disabled={!formMethods.formState.isDirty}>
-              <FormattedMessage id="Registrering.Omsoknaden.VisSkjema" />
-            </Button>
-          </Box>
+          {!confirmed && (
+            <Box style={{ textAlign: 'end' }}>
+              <Button type="submit" disabled={!formMethods.formState.isDirty}>
+                <FormattedMessage id="Registrering.Omsoknaden.VisSkjema" />
+              </Button>
+            </Box>
+          )}
         </VStack>
       </Box>
     </RhfForm>

--- a/packages/papirsoknad/src/SoknadTypePickerForm.tsx
+++ b/packages/papirsoknad/src/SoknadTypePickerForm.tsx
@@ -28,7 +28,6 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   initialFamilieHendelseType?: FamilieHendelseType;
   initialForeldreType?: ForeldreType;
-  skjemaErForhåndsutfylt?: boolean;
 }
 
 /**

--- a/packages/papirsoknad/src/SoknadTypePickerForm.tsx
+++ b/packages/papirsoknad/src/SoknadTypePickerForm.tsx
@@ -28,7 +28,7 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   initialFamilieHendelseType?: FamilieHendelseType;
   initialForeldreType?: ForeldreType;
-  confirmed?: boolean;
+  skjemaErForhåndsutfylt?: boolean;
 }
 
 /**
@@ -36,7 +36,13 @@ interface Props {
  *
  * Toppkomponent for registrering av papirsøknad der søknadstype, tema og søker/foreldretype blir valgt.
  */
-export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKodeverk, initialFamilieHendelseType, initialForeldreType, confirmed }: Props) => {
+export const SoknadTypePickerForm = ({
+  setSoknadData,
+  fagsakYtelseType,
+  alleKodeverk,
+  initialFamilieHendelseType,
+  initialForeldreType,
+}: Props) => {
   const formMethods = useForm<FormValues>({
     defaultValues: {
       fagsakYtelseType,
@@ -89,7 +95,7 @@ export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKode
                 {familieHendelseTyper
                   .filter(({ kode }) => SØKNAD_TYPER.has(kode))
                   .map(bmt => (
-                    <Radio key={bmt.kode} value={bmt.kode} size="small" disabled={confirmed}>
+                    <Radio key={bmt.kode} value={bmt.kode} size="small">
                       {bmt.navn}
                     </Radio>
                   ))}
@@ -103,20 +109,18 @@ export const SoknadTypePickerForm = ({ setSoknadData, fagsakYtelseType, alleKode
               validate={[required]}
             >
               {utledForeldreTyper(foreldreTyper, selectedFagsakYtelseType).map(ft => (
-                <Radio key={ft.kode} value={ft.kode} size="small" disabled={confirmed}>
+                <Radio key={ft.kode} value={ft.kode} size="small">
                   {ft.navn}
                 </Radio>
               ))}
             </RhfRadioGroup>
           </HStack>
 
-          {!confirmed && (
-            <Box style={{ textAlign: 'end' }}>
-              <Button type="submit" disabled={!formMethods.formState.isDirty}>
-                <FormattedMessage id="Registrering.Omsoknaden.VisSkjema" />
-              </Button>
-            </Box>
-          )}
+          <Box style={{ textAlign: 'end' }}>
+            <Button type="submit" disabled={!formMethods.formState.isDirty}>
+              <FormattedMessage id="Registrering.Omsoknaden.VisSkjema" />
+            </Button>
+          </Box>
         </VStack>
       </Box>
     </RhfForm>

--- a/packages/papirsoknad/src/engangsstonad/EngangsstonadPapirsoknadIndex.tsx
+++ b/packages/papirsoknad/src/engangsstonad/EngangsstonadPapirsoknadIndex.tsx
@@ -8,7 +8,7 @@ import { EngangsstonadForm, type EngangsstønadValues } from './components/Engan
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: EngangsstønadValues) => Promise<void>;
-  onMellomlagre?: (values: EngangsstønadValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
   readOnly: boolean;
   soknadData: SoknadData;

--- a/packages/papirsoknad/src/engangsstonad/EngangsstonadPapirsoknadIndex.tsx
+++ b/packages/papirsoknad/src/engangsstonad/EngangsstonadPapirsoknadIndex.tsx
@@ -8,6 +8,8 @@ import { EngangsstonadForm, type EngangsstønadValues } from './components/Engan
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: EngangsstønadValues) => Promise<void>;
+  onMellomlagre?: (values: EngangsstønadValues) => void;
+  mellomlagretData?: Record<string, unknown>;
   readOnly: boolean;
   soknadData: SoknadData;
   alleKodeverk: AlleKodeverk;

--- a/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
+++ b/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
@@ -19,7 +19,7 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: EngangsstønadValues) => Promise<void>;
-  onMellomlagre?: (values: EngangsstønadValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
 }
 
@@ -59,7 +59,7 @@ export const EngangsstonadForm = ({
         readOnly={readOnly}
         submitting={formMethods.formState.isSubmitting}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
-        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as EngangsstønadValues) : undefined}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues()) : undefined}
         erEndringssøknad={false}
       />
     </RhfForm>

--- a/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
+++ b/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
@@ -19,6 +19,8 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: EngangsstønadValues) => Promise<void>;
+  onMellomlagre?: (values: EngangsstønadValues) => void;
+  mellomlagretData?: Record<string, unknown>;
 }
 
 export type EngangsstønadValues = ReturnType<typeof transformValues>;
@@ -29,11 +31,13 @@ export const EngangsstonadForm = ({
   alleKodeverk,
   onSubmitUfullstendigsoknad,
   onSubmit,
+  onMellomlagre,
+  mellomlagretData,
 }: Props) => {
   const ComponentForFamilieHendelse = getComponentForFamiliehendelse(soknadData.getFamilieHendelseType());
 
   const formMethods = useForm({
-    defaultValues: initialValues(),
+    defaultValues: { ...initialValues(), ...mellomlagretData },
   });
 
   const foedselsDatoFraTerminOgFodelsPanel = formMethods.watch('fødselsdato');
@@ -55,6 +59,7 @@ export const EngangsstonadForm = ({
         readOnly={readOnly}
         submitting={formMethods.formState.isSubmitting}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as EngangsstønadValues) : undefined}
         erEndringssøknad={false}
       />
     </RhfForm>

--- a/packages/papirsoknad/src/foreldrepenger/ForeldrepengerPapirsoknadIndex.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/ForeldrepengerPapirsoknadIndex.tsx
@@ -10,6 +10,8 @@ import { ForeldrepengerForm, type ForeldrepengerValues } from './components/Fore
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: ForeldrepengerValues | ForeldrepengerEndringssøknadValues) => Promise<void>;
+  onMellomlagre?: (values: ForeldrepengerValues | ForeldrepengerEndringssøknadValues) => void;
+  mellomlagretData?: Record<string, unknown>;
   readOnly: boolean;
   soknadData: SoknadData;
   alleKodeverk: AlleKodeverk;
@@ -20,6 +22,8 @@ interface Props {
 export const ForeldrepengerPapirsoknadIndex = ({
   onSubmitUfullstendigsoknad,
   onSubmit,
+  onMellomlagre,
+  mellomlagretData,
   readOnly,
   soknadData,
   alleKodeverk,
@@ -30,6 +34,8 @@ export const ForeldrepengerPapirsoknadIndex = ({
     <ForeldrepengerEndringssøknadForm
       onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
       onSubmit={onSubmit}
+      onMellomlagre={onMellomlagre}
+      mellomlagretData={mellomlagretData}
       readOnly={readOnly}
       soknadData={soknadData}
       alleKodeverk={alleKodeverk}
@@ -38,6 +44,8 @@ export const ForeldrepengerPapirsoknadIndex = ({
     <ForeldrepengerForm
       onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
       onSubmit={onSubmit}
+      onMellomlagre={onMellomlagre}
+      mellomlagretData={mellomlagretData}
       readOnly={readOnly}
       soknadData={soknadData}
       alleKodeverk={alleKodeverk}

--- a/packages/papirsoknad/src/foreldrepenger/ForeldrepengerPapirsoknadIndex.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/ForeldrepengerPapirsoknadIndex.tsx
@@ -10,7 +10,7 @@ import { ForeldrepengerForm, type ForeldrepengerValues } from './components/Fore
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: ForeldrepengerValues | ForeldrepengerEndringssøknadValues) => Promise<void>;
-  onMellomlagre?: (values: ForeldrepengerValues | ForeldrepengerEndringssøknadValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
   readOnly: boolean;
   soknadData: SoknadData;

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerEndringssøknadForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerEndringssøknadForm.tsx
@@ -38,7 +38,7 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   onSubmit: (values: ForeldrepengerEndringssøknadValues) => Promise<void>;
   onSubmitUfullstendigsoknad: () => Promise<void>;
-  onMellomlagre?: (values: ForeldrepengerEndringssøknadValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
 }
 
@@ -75,7 +75,7 @@ export const ForeldrepengerEndringssøknadForm = ({
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
-        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as ForeldrepengerEndringssøknadValues) : undefined}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues()) : undefined}
         submitting={formMethods.formState.isSubmitting}
         erEndringssøknad
       />

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerEndringssøknadForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerEndringssøknadForm.tsx
@@ -38,6 +38,8 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   onSubmit: (values: ForeldrepengerEndringssøknadValues) => Promise<void>;
   onSubmitUfullstendigsoknad: () => Promise<void>;
+  onMellomlagre?: (values: ForeldrepengerEndringssøknadValues) => void;
+  mellomlagretData?: Record<string, unknown>;
 }
 
 /**
@@ -51,9 +53,11 @@ export const ForeldrepengerEndringssøknadForm = ({
   alleKodeverk,
   onSubmit,
   onSubmitUfullstendigsoknad,
+  onMellomlagre,
+  mellomlagretData,
 }: Props) => {
   const formMethods = useForm<FormValues>({
-    defaultValues: buildInitialValues(),
+    defaultValues: { ...buildInitialValues(), ...mellomlagretData },
   });
 
   return (
@@ -71,6 +75,7 @@ export const ForeldrepengerEndringssøknadForm = ({
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as ForeldrepengerEndringssøknadValues) : undefined}
         submitting={formMethods.formState.isSubmitting}
         erEndringssøknad
       />

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
@@ -72,7 +72,7 @@ interface Props {
   fagsakPersonnummer: string;
   onSubmit: (values: ForeldrepengerValues) => Promise<void>;
   onSubmitUfullstendigsoknad: () => Promise<void>;
-  onMellomlagre?: (values: ForeldrepengerValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
 }
 
@@ -147,7 +147,7 @@ export const ForeldrepengerForm = ({
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
-        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as ForeldrepengerValues) : undefined}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues()) : undefined}
         submitting={formMethods.formState.isSubmitting}
         erEndringssøknad={false}
       />

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
@@ -72,6 +72,8 @@ interface Props {
   fagsakPersonnummer: string;
   onSubmit: (values: ForeldrepengerValues) => Promise<void>;
   onSubmitUfullstendigsoknad: () => Promise<void>;
+  onMellomlagre?: (values: ForeldrepengerValues) => void;
+  mellomlagretData?: Record<string, unknown>;
 }
 
 /**
@@ -85,10 +87,12 @@ export const ForeldrepengerForm = ({
   alleKodeverk,
   onSubmit,
   onSubmitUfullstendigsoknad,
+  onMellomlagre,
+  mellomlagretData,
   fagsakPersonnummer,
 }: Props) => {
   const formMethods = useForm<FormValues>({
-    defaultValues: buildInitialValues(),
+    defaultValues: { ...buildInitialValues(), ...mellomlagretData },
   });
 
   const søkerHarAleneomsorg = formMethods.watch(`annenForelder.søkerHarAleneomsorg`);
@@ -143,6 +147,7 @@ export const ForeldrepengerForm = ({
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as ForeldrepengerValues) : undefined}
         submitting={formMethods.formState.isSubmitting}
         erEndringssøknad={false}
       />

--- a/packages/papirsoknad/src/svangerskapspenger/SvangerskapspengerPapirsoknadIndex.tsx
+++ b/packages/papirsoknad/src/svangerskapspenger/SvangerskapspengerPapirsoknadIndex.tsx
@@ -8,6 +8,8 @@ import { SvangerskapspengerForm, type SvangerskapsValues } from './components/Sv
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: SvangerskapsValues) => Promise<void>;
+  onMellomlagre?: (values: SvangerskapsValues) => void;
+  mellomlagretData?: Record<string, unknown>;
   readOnly: boolean;
   soknadData: SoknadData;
   alleKodeverk: AlleKodeverk;
@@ -16,6 +18,8 @@ interface Props {
 export const SvangerskapspengerPapirsoknadIndex = ({
   onSubmitUfullstendigsoknad,
   onSubmit,
+  onMellomlagre,
+  mellomlagretData,
   readOnly,
   soknadData,
   alleKodeverk,
@@ -23,6 +27,8 @@ export const SvangerskapspengerPapirsoknadIndex = ({
   <SvangerskapspengerForm
     onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
     onSubmit={onSubmit}
+    onMellomlagre={onMellomlagre}
+    mellomlagretData={mellomlagretData}
     readOnly={readOnly}
     soknadData={soknadData}
     alleKodeverk={alleKodeverk}

--- a/packages/papirsoknad/src/svangerskapspenger/SvangerskapspengerPapirsoknadIndex.tsx
+++ b/packages/papirsoknad/src/svangerskapspenger/SvangerskapspengerPapirsoknadIndex.tsx
@@ -8,7 +8,7 @@ import { SvangerskapspengerForm, type SvangerskapsValues } from './components/Sv
 interface Props {
   onSubmitUfullstendigsoknad: () => Promise<void>;
   onSubmit: (values: SvangerskapsValues) => Promise<void>;
-  onMellomlagre?: (values: SvangerskapsValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
   readOnly: boolean;
   soknadData: SoknadData;

--- a/packages/papirsoknad/src/svangerskapspenger/components/SvangerskapspengerForm.tsx
+++ b/packages/papirsoknad/src/svangerskapspenger/components/SvangerskapspengerForm.tsx
@@ -54,7 +54,7 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   onSubmit: (values: SvangerskapsValues) => Promise<void>;
   onSubmitUfullstendigsoknad: () => Promise<void>;
-  onMellomlagre?: (values: SvangerskapsValues) => void;
+  onMellomlagre?: (values: Record<string, unknown>) => void;
   mellomlagretData?: Record<string, unknown>;
 }
 
@@ -99,7 +99,7 @@ export const SvangerskapspengerForm = ({
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
-        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as SvangerskapsValues) : undefined}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues()) : undefined}
         submitting={formMethods.formState.isSubmitting}
         erEndringssøknad={false}
       />

--- a/packages/papirsoknad/src/svangerskapspenger/components/SvangerskapspengerForm.tsx
+++ b/packages/papirsoknad/src/svangerskapspenger/components/SvangerskapspengerForm.tsx
@@ -54,6 +54,8 @@ interface Props {
   alleKodeverk: AlleKodeverk;
   onSubmit: (values: SvangerskapsValues) => Promise<void>;
   onSubmitUfullstendigsoknad: () => Promise<void>;
+  onMellomlagre?: (values: SvangerskapsValues) => void;
+  mellomlagretData?: Record<string, unknown>;
 }
 
 /**
@@ -67,9 +69,11 @@ export const SvangerskapspengerForm = ({
   alleKodeverk,
   onSubmit,
   onSubmitUfullstendigsoknad,
+  onMellomlagre,
+  mellomlagretData,
 }: Props) => {
   const formMethods = useForm<FormValues>({
-    defaultValues: buildInitialValues(),
+    defaultValues: { ...buildInitialValues(), ...mellomlagretData },
   });
 
   const mottattDato = formMethods.watch('mottattDato');
@@ -95,6 +99,7 @@ export const SvangerskapspengerForm = ({
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}
         onSubmitUfullstendigsoknad={onSubmitUfullstendigsoknad}
+        onMellomlagre={onMellomlagre ? () => onMellomlagre(formMethods.getValues() as unknown as SvangerskapsValues) : undefined}
         submitting={formMethods.formState.isSubmitting}
         erEndringssøknad={false}
       />


### PR DESCRIPTION
Legger på en mellomlagre-knapp nederst i papirsøknaden som vil lagre ned form-values.
Når man henter opp saken neste gang vil forrige verdier være synlig. 
En effektiv dialog med CLI og meg som tester lokalt ....