### PR TITLE
fix: remove socket-level timeout to prevent listener leak

### DIFF
--- a/server/src/reverse-proxy.ts
+++ b/server/src/reverse-proxy.ts
@@ -30,7 +30,6 @@ export const setupProxies = (router: Router) => {
       createProxyMiddleware({
         target: `${api.url}${api.path}`,
         changeOrigin: true,
-        timeout: 600_000,
         proxyTimeout: 60_000,
         logger: logger.logger,
         on: {


### PR DESCRIPTION
The timeout option sets socket.setTimeout() which adds a timeout listener per request to the underlying keep-alive socket. When many parallel requests share a socket (e.g. loading a behandling), this exceeds Node's MaxListeners limit and can cause request timeouts.

proxyTimeout (request-level) is sufficient and matches the behavior of the old express-http-proxy timeout option.