### PR TITLE
chore: fjern kopiering av .nojekyll i storybook-deploy-script

### DIFF
--- a/scripts/create-storybook-index.mjs
+++ b/scripts/create-storybook-index.mjs
@@ -120,9 +120,6 @@ const createIndexHtml = () => {
   // Kopier css fil til folder som skal deployes
   cpSync(join(scriptDir, 'storybook-monorepo-index.css'), join(scriptDir, DEPLOY_FOLDER, 'monorepo-index.css'));
 
-  // For å støtte filer med '_' (Skip Jekyll-prosessering)
-  cpSync(join(scriptDir, '.nojekyll'), join(scriptDir, DEPLOY_FOLDER, '.nojekyll'));
-
   // Kopier storybook fra pakkene og inn i folder som skal deployes
   const packages = [...findPackageDirs(join(origDir, 'apps')), ...findPackageDirs(join(origDir, 'packages'))]
     .map(copyFiles)


### PR DESCRIPTION
Fjerner kopiering av `.nojekyll`-filen i deploy-scriptet for Storybook. Denne filen ble brukt for å unngå Jekyll-prosessering av filer med `_` i navnet på GitHub Pages, men er ikke lenger nødvendig.