### PR TITLE
fix: resolve Node 26 localStorage conflict with jsdom in Vitest

### DIFF
--- a/packages/config/vite/vite.config.mjs
+++ b/packages/config/vite/vite.config.mjs
@@ -1,7 +1,6 @@
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, mergeConfig } from 'vite';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import compression from 'vite-plugin-compression2';
@@ -40,6 +39,5 @@ export const createConfig = setupFileDirName =>
       setupFiles: setupFileDirName || path.resolve(folder, './vitest-setup'),
       watch: false,
       testTimeout: 25000,
-      execArgv: ['--localstorage-file', path.resolve(os.tmpdir(), `vitest-${process.pid}.localstorage`)],
     },
   });

--- a/packages/config/vite/vitest-setup.ts
+++ b/packages/config/vite/vitest-setup.ts
@@ -4,6 +4,23 @@ import { beforeAll, expect, vi } from 'vitest';
 
 import * as globalStorybookConfig from '../../../.storybook/preview-storybook';
 
+// Node 26+ defines localStorage/sessionStorage as native getters on globalThis
+// that return undefined (unless --localstorage-file is provided). Vitest's
+// populateGlobal skips overriding properties already "in global", so jsdom's
+// implementations never get exposed. Manually wire them up from the jsdom window.
+const jsdomWindow = (globalThis as unknown as { jsdom?: { window: Window & typeof globalThis } }).jsdom?.window;
+if (jsdomWindow) {
+  for (const key of ['localStorage', 'sessionStorage'] as const) {
+    if (globalThis[key] === undefined) {
+      Object.defineProperty(globalThis, key, {
+        get: () => jsdomWindow[key],
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  }
+}
+
 expect.extend(matchers);
 
 const annotations = setProjectAnnotations(globalStorybookConfig);


### PR DESCRIPTION
## Problem

Node 26 defines native `localStorage`/`sessionStorage` getters on `globalThis` that return `undefined` unless `--localstorage-file` is provided. Vitest's `populateGlobal` skips overriding properties already present on global, so jsdom's implementations never get exposed.

This caused 22 tests to fail:
- 10 tests with `TypeError: Cannot read properties of undefined (reading 'getItem')`
- 12 tests with `Error: database is locked` (MSW CookieStore)

## Solution

- Remove the `execArgv` approach (all workers shared the same SQLite file → lock conflicts)
- Add a fix in `vitest-setup.ts` that wires `globalThis.localStorage` to jsdom's window using `Object.defineProperty`

## Files changed

- `packages/config/vite/vite.config.mjs` — removed `execArgv` and unused `os` import
- `packages/config/vite/vitest-setup.ts` — added localStorage/sessionStorage fix for Node 26+