### PR TITLE
Copilot: Oppdater med ref til fp-context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,10 +6,11 @@ Monorepo for NAV's foreldrepenger saksbehandler frontend (FPSAK). Built with Yar
 
 - [fp-context](https://github.com/navikt/fp-context) — Team Foreldrepenger
   domain, architecture, conventions. Source of truth for shared context.
-- Copilot Space: navikt / **TeamForeldrepenger** — same content attached for
-  AI grounding (chat, IDE agent, CLI).
-- Backend counterpart: [fp-sak](https://github.com/navikt/fp-sak); types are
-  generated from its OpenAPI spec (see `yarn generate`).
+- GitHub Copilot Space: `navikt/TeamForeldrepenger` — same content attached
+  for AI grounding (chat, IDE agent, CLI).
+- Backend counterparts: [fp-sak](https://github.com/navikt/fp-sak) and
+  fplos; types are generated from the fpsak and fplos OpenAPI specs (see
+  `yarn generate`).
 
 ## Setup
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,15 @@
 
 Monorepo for NAV's foreldrepenger saksbehandler frontend (FPSAK). Built with Yarn workspaces + Turborepo.
 
+## Team context
+
+- [fp-context](https://github.com/navikt/fp-context) — Team Foreldrepenger
+  domain, architecture, conventions. Source of truth for shared context.
+- Copilot Space: navikt / **TeamForeldrepenger** — same content attached for
+  AI grounding (chat, IDE agent, CLI).
+- Backend counterpart: [fp-sak](https://github.com/navikt/fp-sak); types are
+  generated from its OpenAPI spec (see `yarn generate`).
+
 ## Setup
 
 - Node version is pinned in `.tool-versions` (currently Node 24); package manager is Yarn 4 (declared via `packageManager` in `package.json`).


### PR DESCRIPTION
Refactor copilot-instructions.md to reference [fp-context](https://github.com/navikt/fp-context) and the **TeamForeldrepenger** Copilot Space, and remove content now covered by the shared hub.

Part of an ongoing effort to keep per-repo Copilot files token-efficient and free of duplication across the team's 40+ repos.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>