### PR TITLE
Add startup-hook, remove cpu-limit, scale faster

### DIFF
--- a/.deploy/fp-avdelingsleder/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/fp-avdelingsleder/dev-gcp-teamforeldrepenger.json
@@ -4,7 +4,6 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "limits": {
-    "cpu": "1000m",
     "mem": "256Mi"
   },
   "requests": {

--- a/.deploy/fp-avdelingsleder/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/fp-avdelingsleder/prod-gcp-teamforeldrepenger.json
@@ -4,7 +4,6 @@
   "minReplicas": "2",
   "maxReplicas": "4",
   "limits": {
-    "cpu": "1000m",
     "mem": "256Mi"
   },
   "requests": {

--- a/.deploy/fp-frontend/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/fp-frontend/dev-gcp-teamforeldrepenger.json
@@ -4,7 +4,6 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "limits": {
-    "cpu": "1000m",
     "mem": "256Mi"
   },
   "requests": {

--- a/.deploy/fp-frontend/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/fp-frontend/prod-gcp-teamforeldrepenger.json
@@ -4,7 +4,6 @@
   "minReplicas": "2",
   "maxReplicas": "4",
   "limits": {
-    "cpu": "1000m",
     "mem": "256Mi"
   },
   "requests": {

--- a/.deploy/fp-journalforing/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/fp-journalforing/dev-gcp-teamforeldrepenger.json
@@ -4,7 +4,6 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "limits": {
-    "cpu": "1000m",
     "mem": "256Mi"
   },
   "requests": {

--- a/.deploy/fp-journalforing/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/fp-journalforing/prod-gcp-teamforeldrepenger.json
@@ -4,7 +4,6 @@
   "minReplicas": "2",
   "maxReplicas": "4",
   "limits": {
-    "cpu": "1000m",
     "mem": "256Mi"
   },
   "requests": {

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -22,13 +22,16 @@ spec:
     path: /health/isReady
     initialDelay: 10
     timeout: 1
+  startup:
+    path: /health/isReady
+    initialDelay: 10
+    timeout: 1
   replicas:
     min: {{minReplicas}}
     max: {{maxReplicas}}
-    cpuThresholdPercentage: 80
+    cpuThresholdPercentage: 50
   resources:
     limits:
-      cpu: "{{limits.cpu}}"
       memory: "{{limits.mem}}"
     requests:
       cpu: "{{requests.cpu}}"


### PR DESCRIPTION
Setter standard skalering ved 50% - men kan godt hende vi skal gå for statisk antall noder og skippe autoscaling
Legger på startup-hook for å unngå at oppstart skalerer til max og så ned.