### PR TITLE
Oppdater foreldrepenger.nav.no til ny URL i storybook brevmaler

### DIFF
--- a/packages/brev-editor/.storybook/brevmal/mal.html
+++ b/packages/brev-editor/.storybook/brevmal/mal.html
@@ -200,7 +200,7 @@
         <h2>Du har rett til innsyn</h2>
         <p>
           For å se dokumentene i saken din, logg inn på
-          <a href="https://foreldrepenger.nav.no/">foreldrepenger.nav.no</a>.
+          <a href="https://www.nav.no/foreldrepenger/oversikt">nav.no/foreldrepenger/oversikt</a>.
         </p>
         <div style="break-inside: avoid; page-break-inside: avoid">
           <h2>Har du spørsmål?</h2>

--- a/packages/brev-editor/.storybook/brevmal/redigertInnhold.html
+++ b/packages/brev-editor/.storybook/brevmal/redigertInnhold.html
@@ -6,7 +6,7 @@
   <h2>Du har rett til innsyn</h2>
   <p>
     For å se dokumentene i saken din, logg inn på
-    <a href="https://foreldrepenger.nav.no/">foreldrepenger.nav.no</a>.
+    <a href="https://www.nav.no/foreldrepenger/oversikt">nav.no/foreldrepenger/oversikt</a>.
   </p>
   <div style="break-inside: avoid; page-break-inside: avoid">
     <h2>Har du spørsmål?</h2>

--- a/packages/prosess/vedtak/.storybook/brevmal/mal.html
+++ b/packages/prosess/vedtak/.storybook/brevmal/mal.html
@@ -200,7 +200,7 @@
         <h2>Du har rett til innsyn</h2>
         <p>
           For å se dokumentene i saken din, logg inn på
-          <a href="https://foreldrepenger.nav.no/">foreldrepenger.nav.no</a>.
+          <a href="https://www.nav.no/foreldrepenger/oversikt">nav.no/foreldrepenger/oversikt</a>.
         </p>
         <div style="break-inside: avoid; page-break-inside: avoid">
           <h2>Har du spørsmål?</h2>

--- a/packages/prosess/vedtak/.storybook/brevmal/redigertInnhold.html
+++ b/packages/prosess/vedtak/.storybook/brevmal/redigertInnhold.html
@@ -6,7 +6,7 @@
   <h2>Du har rett til innsyn</h2>
   <p>
     For å se dokumentene i saken din, logg inn på
-    <a href="https://foreldrepenger.nav.no/">foreldrepenger.nav.no</a>.
+    <a href="https://www.nav.no/foreldrepenger/oversikt">nav.no/foreldrepenger/oversikt</a>.
   </p>
   <div style="break-inside: avoid; page-break-inside: avoid">
     <h2>Har du spørsmål?</h2>


### PR DESCRIPTION
Erstatter foreldrepenger.nav.no (som nå redirecter) med www.nav.no/foreldrepenger/oversikt i storybook brevmal-templates.