### PR TITLE
refactor: erstatt manuelle aksjonspunkt-typer med genererte DTO-er

### DIFF
--- a/apps/fp-frontend/src/behandling/fellesPaneler/fakta/BeregningFaktaInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/fellesPaneler/fakta/BeregningFaktaInitPanel.tsx
@@ -107,10 +107,12 @@ const lagModifisertCallback =
       ? aksjonspunkterSomSkalLagres
       : [aksjonspunkterSomSkalLagres];
 
-    const transformerteData = apListe.map<BeregningAp>(apData => ({
-      kode: mapBGKodeTilFpsakKode(apData.kode),
-      ...notEmpty(apData.grunnlag[0], 'Mangler grunnlag i be'),
-    }));
+    const transformerteData = apListe.map<BeregningAp>(apData =>
+      ({
+        kode: mapBGKodeTilFpsakKode(apData.kode),
+        ...notEmpty(apData.grunnlag[0], 'Mangler grunnlag i be'),
+      }) as BeregningAp,
+    );
     return submitCallback(transformerteData);
   };
 

--- a/apps/fp-frontend/src/behandling/fellesPaneler/prosess/BeregningsgrunnlagProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/fellesPaneler/prosess/BeregningsgrunnlagProsessStegInitPanel.tsx
@@ -68,28 +68,27 @@ const lagModifisertCallback =
         return {
           ...felles,
           inntektPrAndelList: grunnlag.inntektPrAndelList,
-          inntektFrilanser: grunnlag.inntektFrilanser,
-        };
+          inntektFrilanser: grunnlag.inntektFrilanser ?? undefined,
+        } as BeregningsgrunnlagAp;
       }
       if ('erVarigEndretNaering' in grunnlag) {
         return {
           ...felles,
           erVarigEndretNaering: grunnlag.erVarigEndretNaering,
-          erVarigEndret: grunnlag.erVarigEndret,
-          bruttoBeregningsgrunnlag: grunnlag.bruttoBeregningsgrunnlag,
-        };
+          bruttoBeregningsgrunnlag: grunnlag.bruttoBeregningsgrunnlag ?? undefined,
+        } as BeregningsgrunnlagAp;
       }
       if ('fastsatteTidsbegrensedePerioder' in grunnlag) {
         return {
           ...felles,
           fastsatteTidsbegrensedePerioder: grunnlag.fastsatteTidsbegrensedePerioder,
-          frilansInntekt: grunnlag.frilansInntekt,
-        };
+          frilansInntekt: grunnlag.frilansInntekt ?? undefined,
+        } as BeregningsgrunnlagAp;
       }
       return {
         ...felles,
-        bruttoBeregningsgrunnlag: grunnlag.bruttoBeregningsgrunnlag,
-      };
+        bruttoBeregningsgrunnlag: grunnlag.bruttoBeregningsgrunnlag ?? undefined,
+      } as BeregningsgrunnlagAp;
     });
 
     return submitCallback(transformerteData);

--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -15,6 +15,8 @@ import {
 } from '@navikt/fp-papirsoknad';
 import type { Aksjonspunkt, FagsakYtelseType, FamilieHendelseType } from '@navikt/fp-types';
 
+import type { PapirsøknarAp } from './PapirsøknarAp';
+
 import { BehandlingRel, useBehandlingApi } from '../../data/behandlingApi';
 import { useBehandlingDataContext } from '../felles/context/BehandlingDataContext';
 
@@ -119,7 +121,7 @@ const useLagrePapirsøknad = (
     formValues?: EngangsstønadValues | ForeldrepengerValues | ForeldrepengerEndringssøknadValues | SvangerskapsValues,
   ) => {
     const kode = getAktivPapirsøknadApKode(behandling.aksjonspunkt);
-    const bekreftedeAksjonspunktDtoer = [
+    const bekreftedeAksjonspunktDtoer: ({ '@type': string } & PapirsøknarAp)[] = [
       {
         '@type': kode,
         kode,
@@ -127,7 +129,7 @@ const useLagrePapirsøknad = (
         søknadstype: fagsakYtelseType,
         søker: foreldreType,
         ...formValues,
-      },
+      } as { '@type': string } & PapirsøknarAp,
     ];
 
     if (formValues) {

--- a/apps/fp-frontend/src/behandlingsupport/totrinnskontroll/TotrinnskontrollIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/totrinnskontroll/TotrinnskontrollIndex.tsx
@@ -6,7 +6,6 @@ import { forhandsvisDokument } from '@navikt/ft-utils';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { type TotrinnskontrollFormValues, TotrinnskontrollSakIndex } from '@navikt/fp-sak-totrinnskontroll';
-import type { FatterVedtakAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { notEmpty } from '@navikt/fp-utils';
 
 import { createLocationForSkjermlenke } from '../../app/paths';
@@ -19,7 +18,15 @@ import { BeslutterModalIndex } from './BeslutterModalIndex';
 type Values = {
   fatterVedtakAksjonspunktDto: {
     '@type': string;
-  } & FatterVedtakAp;
+    kode: string;
+    begrunnelse: undefined;
+    aksjonspunktGodkjenningDtos: {
+      aksjonspunktKode: string;
+      godkjent: boolean;
+      begrunnelse: string | undefined;
+      arsaker: string[];
+    }[];
+  };
   erAlleAksjonspunktGodkjent: boolean;
 };
 
@@ -77,7 +84,9 @@ export const TotrinnskontrollIndex = ({
     const params = {
       behandlingUuid: valgtBehandling.uuid,
       behandlingVersjon: valgtBehandling.versjon,
-      bekreftedeAksjonspunktDtoer: [totrinnskontrollData.fatterVedtakAksjonspunktDto],
+      bekreftedeAksjonspunktDtoer: [
+        totrinnskontrollData.fatterVedtakAksjonspunktDto as BekreftedeTotrinnsaksjonspunkter['bekreftedeAksjonspunktDtoer'][number],
+      ],
     };
     setErAlleAksjonspunktGodkjent(totrinnskontrollData.erAlleAksjonspunktGodkjent);
     setVisBeslutterModal(true);

--- a/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
+++ b/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
@@ -195,7 +195,7 @@ describe('FodselFaktaIndex', () => {
       await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
       expect(lagre).toHaveBeenNthCalledWith(1, {
         kode: '5027',
-        barn: null,
+        barn: undefined,
         termindato: '2025-05-06',
         begrunnelse: 'Dette er en begrunnelse',
       });

--- a/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
+++ b/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
@@ -137,7 +137,7 @@ const transformValues = (values: FormValues): SjekkTerminbekreftelseAp => ({
   kode: AksjonspunktKode.SJEKK_TERMINBEKREFTELSE,
   utstedtdato: notEmpty(values.utstedtdato, 'utstedtdato må være satt ved submit'),
   antallBarn: notEmpty(values.antallBarn, 'antallBarn må være satt ved submit'),
-  ...Termindato.transformValues(values),
+  termindato: notEmpty(values.termindato, 'termindato må være satt ved submit'),
   ...FaktaBegrunnelseTextField.transformValues(values),
 });
 

--- a/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
+++ b/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
@@ -198,7 +198,7 @@ BarnFieldArray.initialValues = ({ barn, antallBarn }: FødselGjeldende): BarnFor
 BarnFieldArray.transformValues = (
   values: BarnFormValues,
   erBarnFødt: boolean,
-): { barn: { fødselsdato: string; dødsdato: string | undefined }[] | null } =>
+): { barn: { fødselsdato: string; dødsdato: string | undefined }[] | undefined } =>
   erBarnFødt
     ? {
         barn: values.barn.map(({ fødselsdato, dødsdato }) => ({
@@ -206,7 +206,7 @@ BarnFieldArray.transformValues = (
           dødsdato: dødsdato || undefined,
         })),
       }
-    : { barn: null };
+    : { barn: undefined };
 
 const lagBarn = (antallBarnFraSoknad: number): FieldArrayRow[] => {
   const antallBarn = antallBarnFraSoknad > 0 ? antallBarnFraSoknad : 1;

--- a/packages/fakta/fodsel/src/components/form/Termindato.tsx
+++ b/packages/fakta/fodsel/src/components/form/Termindato.tsx
@@ -50,5 +50,5 @@ Termindato.initialValues = (gjeldende: FødselGjeldende) => ({
 });
 
 Termindato.transformValues = (values: TermindatoFormValues) => ({
-  termindato: values.termindato || null,
+  termindato: values.termindato || undefined,
 });

--- a/packages/fakta/fodsel/src/components/overstyring/OverstyringForm.tsx
+++ b/packages/fakta/fodsel/src/components/overstyring/OverstyringForm.tsx
@@ -8,7 +8,7 @@ import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmit
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import type { Aksjonspunkt, FødselGjeldende } from '@navikt/fp-types';
 import type { OverstyringFaktaFødselAp } from '@navikt/fp-types-avklar-aksjonspunkter';
-import { usePanelDataContext } from '@navikt/fp-utils';
+import { notEmpty, usePanelDataContext } from '@navikt/fp-utils';
 
 import { ErBarnFødt, type ErBarnFødtFormValues } from '../form/ErBarnFødt';
 import { Termindato, type TermindatoFormValues } from '../form/Termindato';
@@ -80,7 +80,7 @@ const initialValues = (gjeldende: FødselGjeldende, overstyringsAP?: Aksjonspunk
 
 const transformValues = (values: FormValues): OverstyringFaktaFødselAp => ({
   kode: AksjonspunktKode.OVERSTYRING_AV_FAKTA_OM_FØDSEL,
-  ...Termindato.transformValues(values),
+  termindato: notEmpty(values.termindato, 'termindato må være satt ved submit'),
   ...ErBarnFødt.transformValues(values),
   ...FaktaBegrunnelseTextField.transformValues(values),
 });

--- a/packages/fakta/medlemskap/src/components/aksjonspunkt/MedlemskapVurderinger.tsx
+++ b/packages/fakta/medlemskap/src/components/aksjonspunkt/MedlemskapVurderinger.tsx
@@ -6,7 +6,7 @@ import { RhfDatepicker, RhfRadioGroup, RhfSelect } from '@navikt/ft-form-hooks';
 import { hasValidDate, required } from '@navikt/ft-form-validators';
 import { createIntl } from '@navikt/ft-utils';
 
-import type { AlleKodeverk, ManuellBehandlingResultat, Vilkår } from '@navikt/fp-types';
+import type { AlleKodeverk, Avslagsarsak, ManuellBehandlingResultat, Vilkår } from '@navikt/fp-types';
 import { usePanelDataContext } from '@navikt/fp-utils';
 
 import { MedlemskapVurdering, SØKER_INNFLYTTET_FOR_SENT_KODE } from '../../types/vurderingMedlemskapForm';
@@ -20,7 +20,7 @@ export type MedlemskapVurderingerFormValues = {
   vurdering?: MedlemskapVurdering;
   opphørFom?: string;
   medlemFom?: string;
-  avslagskode?: string;
+  avslagskode?: Avslagsarsak;
 };
 
 interface Props {

--- a/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
+++ b/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
@@ -109,10 +109,18 @@ const createInitialValues = (
 const transformValues = (
   values: FormValues,
   erForutgåendeAksjonspunkt: boolean,
-): VurderMedlemskapAp | VurderForutgaendeMedlemskapAp => ({
-  kode: erForutgåendeAksjonspunkt
-    ? AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR
-    : AksjonspunktKode.VURDER_MEDLEMSKAPSVILKÅRET,
-  ...MedlemskapVurderinger.transformValues(values),
-  ...FaktaBegrunnelseTextField.transformValues(values),
-});
+): VurderMedlemskapAp | VurderForutgaendeMedlemskapAp => {
+  if (erForutgåendeAksjonspunkt) {
+    return {
+      kode: AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR,
+      ...MedlemskapVurderinger.transformValues(values),
+      ...FaktaBegrunnelseTextField.transformValues(values),
+    };
+  }
+
+  return {
+    kode: AksjonspunktKode.VURDER_MEDLEMSKAPSVILKÅRET,
+    ...MedlemskapVurderinger.transformValues(values),
+    ...FaktaBegrunnelseTextField.transformValues(values),
+  };
+};

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -14,11 +14,13 @@ import type {
   Opptjening,
   OpptjeningAktivitet,
 } from '@navikt/fp-types';
-import type { AvklarAktivitetsPerioderAp, OpptjeningAktivitetAp } from '@navikt/fp-types-avklar-aksjonspunkter';
+import type { AvklarAktivitetsPerioderAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
 import { type FormValues, ValgtAktivitetForm } from './aktivitet/ValgtAktivitetForm';
 import { OpptjeningTidslinje } from './tidslinje/OpptjeningTidslinje';
+
+type OpptjeningAktivitetAp = NonNullable<AvklarAktivitetsPerioderAp['opptjeningsaktiviteter']>[number];
 
 const getAksjonspunktHelpTexts = (opptjeningAktiviteter: OpptjeningAktivitet[]): ReactElement[] => {
   const texts = new Array<ReactElement>();

--- a/packages/fakta/permisjon/src/components/ArbeidsforholdField.tsx
+++ b/packages/fakta/permisjon/src/components/ArbeidsforholdField.tsx
@@ -14,9 +14,9 @@ import type {
   Arbeidsforhold,
   ArbeidsgiverOpplysningerPerId,
   Inntektsmelding,
+  BekreftetPermisjonStatus,
 } from '@navikt/fp-types';
 
-import { BekreftetPermisjonStatus } from '../kodeverk/BekreftetPermisjonStatus';
 import { ArbeidsforholdBoks } from './ArbeidsforholdBoks';
 import { InntektsmeldingOpplysningerPanel } from './InntektsmeldingOpplysningerPanel';
 import { InntektsposterPanel } from './InntektsposterPanel';
@@ -237,7 +237,7 @@ export const ArbeidsforholdField = ({
             validate={[required]}
             readOnly={isReadOnly}
           >
-            <Radio value={BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON} size="small">
+            <Radio value={'IKKE_BRUK_PERMISJON' satisfies BekreftetPermisjonStatus} size="small">
               <FormattedMessage
                 id={
                   inntektsmelding
@@ -246,7 +246,7 @@ export const ArbeidsforholdField = ({
                 }
               />
             </Radio>
-            <Radio value={BekreftetPermisjonStatus.BRUK_PERMISJON} size="small">
+            <Radio value={'BRUK_PERMISJON' satisfies BekreftetPermisjonStatus} size="small">
               <FormattedMessage id="ArbeidsforholdFieldArray.IkkeTaMedArbeidsforhold" />
             </Radio>
           </RhfRadioGroup>

--- a/packages/fakta/permisjon/src/components/PermisjonFaktaPanel.tsx
+++ b/packages/fakta/permisjon/src/components/PermisjonFaktaPanel.tsx
@@ -9,7 +9,7 @@ import { AksjonspunktHelpTextHTML } from '@navikt/ft-ui-komponenter';
 import { dateFormat } from '@navikt/ft-utils';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { ArbeidOgInntektsmelding, Arbeidsforhold, ArbeidsgiverOpplysningerPerId } from '@navikt/fp-types';
+import type { ArbeidOgInntektsmelding, Arbeidsforhold, ArbeidsgiverOpplysningerPerId, BekreftetPermisjonStatus} from '@navikt/fp-types';
 import type { VurderArbeidsforholdPermisjonAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
@@ -20,7 +20,7 @@ const maxLength1500 = maxLength(1500);
 
 type FormValues = {
   arbeidsforhold: {
-    permisjonStatus: string;
+    permisjonStatus: BekreftetPermisjonStatus;
   }[];
   begrunnelse: string;
 };
@@ -94,17 +94,7 @@ export const PermisjonFaktaPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysningerP
       )}
       <RhfForm
         formMethods={formMethods}
-        onSubmit={values =>
-          submitCallback({
-            kode: AksjonspunktKode.VURDER_PERMISJON_UTEN_SLUTTDATO,
-            arbeidsforhold: values.arbeidsforhold.map((a, index) => ({
-              internArbeidsforholdId: sorterteArbeidsforhold[index]?.internArbeidsforholdId,
-              arbeidsgiverIdent: sorterteArbeidsforhold[index]?.arbeidsgiverIdent ?? '',
-              permisjonStatus: a.permisjonStatus,
-            })),
-            begrunnelse: values.begrunnelse,
-          })
-        }
+        onSubmit={values => submitCallback(transformValues(values, sorterteArbeidsforhold))}
       >
         <VStack gap="space-24">
           <ArbeidsforholdFieldArray
@@ -146,3 +136,17 @@ export const PermisjonFaktaPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysningerP
     </VStack>
   );
 };
+
+const transformValues = (
+  values: FormValues,
+  sorterteArbeidsforhold: Arbeidsforhold[],
+): VurderArbeidsforholdPermisjonAp =>
+  ({
+    kode: AksjonspunktKode.VURDER_PERMISJON_UTEN_SLUTTDATO,
+    arbeidsforhold: values.arbeidsforhold.map((a, index) => ({
+      internArbeidsforholdId: sorterteArbeidsforhold[index]?.internArbeidsforholdId,
+      arbeidsgiverIdent: sorterteArbeidsforhold[index]?.arbeidsgiverIdent ?? '',
+      permisjonStatus: a.permisjonStatus,
+    })),
+    begrunnelse: values.begrunnelse,
+  });

--- a/packages/fakta/permisjon/src/kodeverk/BekreftetPermisjonStatus.ts
+++ b/packages/fakta/permisjon/src/kodeverk/BekreftetPermisjonStatus.ts
@@ -1,4 +1,0 @@
-export enum BekreftetPermisjonStatus {
-  BRUK_PERMISJON = 'BRUK_PERMISJON',
-  IKKE_BRUK_PERMISJON = 'IKKE_BRUK_PERMISJON',
-}

--- a/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
+++ b/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
@@ -96,7 +96,8 @@ export const InnhentDokOpptjeningUtlandAP = ({ aksjonspunkt, dokStatus }: Props)
   );
 };
 
-const transformValues = (values: FormValues): MerkOpptjeningUtlandAp => ({
-  kode: AksjonspunktKode.AUTOMATISK_MARKERING_AV_UTENLANDSSAK,
-  ...values,
-});
+const transformValues = (values: FormValues): MerkOpptjeningUtlandAp =>
+  ({
+    kode: AksjonspunktKode.AUTOMATISK_MARKERING_AV_UTENLANDSSAK,
+    ...values,
+  }) as MerkOpptjeningUtlandAp;

--- a/packages/prosess/innsyn/src/InnsynProsessIndex.spec.tsx
+++ b/packages/prosess/innsyn/src/InnsynProsessIndex.spec.tsx
@@ -49,7 +49,7 @@ describe('InnsynProsessIndex', () => {
       innsynResultatType: 'AVVIST',
       kode: '5037',
       mottattDato: '2021-12-23',
-      sattPaVent: undefined,
+      sattPåVent: undefined,
     });
   });
 
@@ -108,7 +108,7 @@ describe('InnsynProsessIndex', () => {
       innsynResultatType: 'INNV',
       kode: '5037',
       mottattDato: '2021-12-23',
-      sattPaVent: true,
+      sattPåVent: true,
     });
   });
 });

--- a/packages/prosess/innsyn/src/components/InnsynForm.tsx
+++ b/packages/prosess/innsyn/src/components/InnsynForm.tsx
@@ -35,7 +35,7 @@ const getDefaultValues = (
   mottattDato: innsyn?.innsynMottattDato,
   innsynResultatType: innsyn?.innsynResultatType,
   fristDato: fristBehandlingPåVent ?? dayjs().add(3, 'days').format(ISO_DATE_FORMAT),
-  sattPaVent: aksjonspunkter[0]?.status === 'OPPR' ? undefined : !!fristBehandlingPåVent,
+  sattPåVent: aksjonspunkter[0]?.status === 'OPPR' ? undefined : !!fristBehandlingPåVent,
   ...ProsessStegBegrunnelseTextField.buildInitialValues(aksjonspunkter),
   ...hentDokumenterMedNavnOgFikkInnsyn(innsyn?.dokumenter ?? []),
 });
@@ -53,7 +53,7 @@ const transformValues = (values: InnsynFormValues, documents: Dokument[]): Vurde
   mottattDato: notEmpty(values.mottattDato),
   innsynResultatType: notEmpty(values.innsynResultatType),
   fristDato: values.fristDato,
-  sattPaVent: values.sattPaVent,
+  sattPåVent: values.sattPåVent,
   begrunnelse: values.begrunnelse,
 });
 
@@ -101,7 +101,7 @@ export const InnsynForm = ({ innsyn, alleDokumenter = [] }: Props) => {
   const isApOpen = aksjonspunkterForPanel[0]?.status === 'OPPR';
 
   const innsynResultatTypeKode = formMethods.watch('innsynResultatType');
-  const sattPaVent = formMethods.watch('sattPaVent');
+  const sattPaVent = formMethods.watch('sattPåVent');
 
   return (
     <RhfForm
@@ -153,7 +153,7 @@ export const InnsynForm = ({ innsyn, alleDokumenter = [] }: Props) => {
             <ArrowBox alignOffset={innsynResultatTypeKode === 'INNV' ? 28 : 176}>
               <VStack gap="space-16">
                 <RhfRadioGroup
-                  name="sattPaVent"
+                  name="sattPåVent"
                   control={formMethods.control}
                   legend={<FormattedMessage id="InnsynForm.VelgVidereAksjon" />}
                   validate={[required]}

--- a/packages/prosess/innsyn/src/components/InnsynFormValues.ts
+++ b/packages/prosess/innsyn/src/components/InnsynFormValues.ts
@@ -5,6 +5,6 @@ export type InnsynFormValues = {
   mottattDato?: string;
   innsynResultatType?: InnsynResultatType;
   fristDato?: string;
-  sattPaVent?: boolean;
+  sattPåVent?: boolean;
   [key: `dokument_${string}`]: boolean;
 } & ProsessStegBegrunnelseTextFieldFormValues;

--- a/packages/prosess/klagevurdering/src/types/klageFormType.ts
+++ b/packages/prosess/klagevurdering/src/types/klageFormType.ts
@@ -1,10 +1,10 @@
-import type { KlageHjemmel, KlageVurderingOmgjørType, KlageVurderingType } from '@navikt/fp-types';
+import type { KlageHjemmel, KlageMedholdÅrsak, KlageVurderingOmgjørType, KlageVurderingType } from '@navikt/fp-types';
 
 export type KlageFormType = {
   begrunnelse?: string;
   fritekstTilBrev?: string;
   klageVurdering?: KlageVurderingType;
   klageVurderingOmgjør?: KlageVurderingOmgjørType;
-  klageMedholdÅrsak?: string;
+  klageMedholdÅrsak?: KlageMedholdÅrsak;
   klageHjemmel?: KlageHjemmel;
 };

--- a/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
+++ b/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
@@ -139,23 +139,21 @@ const transformValues = (perioder: PeriodeSoker[], aksjonspunkter: Aksjonspunkt[
         .filter(a => a.definisjon !== AksjonspunktKode.OVERSTYRING_AV_UTTAKPERIODER)
         .map(ap => ap.definisjon);
 
-  return apKoder.map(ap => ({
-    kode: validerApKodeOgHentApEnum(
-      ap,
-      AksjonspunktKode.FASTSETT_UTTAKPERIODER,
-      AksjonspunktKode.OVERSTYRING_AV_UTTAKPERIODER,
-      AksjonspunktKode.FASTSETT_UTTAK_STORTINGSREPRESENTANT,
-      AksjonspunktKode.UTGÅTT_5069,
-      AksjonspunktKode.UTGÅTT_5067,
-      AksjonspunktKode.KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE,
-      AksjonspunktKode.UTGÅTT_5075,
-      AksjonspunktKode.KONTROLLER_OPPLYSNINGER_OM_DØD,
-      AksjonspunktKode.KONTROLLER_OPPLYSNINGER_OM_SØKNADSFRIST,
-      AksjonspunktKode.UTGÅTT_5078,
-      AksjonspunktKode.UTGÅTT_5079,
-    ),
-    perioder,
-  }));
+  return apKoder.map(
+    ap =>
+      ({
+        kode: validerApKodeOgHentApEnum(
+          ap,
+          AksjonspunktKode.FASTSETT_UTTAKPERIODER,
+          AksjonspunktKode.OVERSTYRING_AV_UTTAKPERIODER,
+          AksjonspunktKode.FASTSETT_UTTAK_STORTINGSREPRESENTANT,
+          AksjonspunktKode.KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE,
+          AksjonspunktKode.KONTROLLER_OPPLYSNINGER_OM_DØD,
+          AksjonspunktKode.KONTROLLER_OPPLYSNINGER_OM_SØKNADSFRIST,
+        ),
+        perioder,
+      }) as UttakAp,
+  );
 };
 
 interface Props {

--- a/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
+++ b/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
@@ -25,18 +25,10 @@ export type ForhandsvisData = {
   fritekst?: string;
 };
 
-type FormValues = {
-  kode: AksjonspunktKode.UTGÅTT_5025 | AksjonspunktKode.VARSEL_REVURDERING_MANUELL;
-  begrunnelse?: string;
-  sendVarsel?: boolean;
-};
+type FormValues = VarselRevurderingAp;
 
 const buildInitialValues = (aksjonspunkter: Aksjonspunkt[]): FormValues => ({
-  kode: validerApKodeOgHentApEnum(
-    aksjonspunkter[0]?.definisjon,
-    AksjonspunktKode.UTGÅTT_5025,
-    AksjonspunktKode.VARSEL_REVURDERING_MANUELL,
-  ),
+  kode: validerApKodeOgHentApEnum(aksjonspunkter[0]?.definisjon, AksjonspunktKode.VARSEL_REVURDERING_MANUELL),
   begrunnelse: aksjonspunkter[0]?.begrunnelse ?? '',
   sendVarsel: undefined,
 });
@@ -95,7 +87,7 @@ export const VarselOmRevurderingForm = ({ previewCallback, hentVarselHtml, mello
         void submitCallback({
           ...formVerdier,
           ...modalValues,
-        });
+        } as VarselRevurderingAp);
       }
       setSkalVisePåVentModal(false);
     });

--- a/packages/prosess/vedtak/src/components/revurdering/VedtakRevurderingForm.tsx
+++ b/packages/prosess/vedtak/src/components/revurdering/VedtakRevurderingForm.tsx
@@ -24,14 +24,13 @@ import {
 import type {
   ForeslaVedtakAp,
   ForeslaVedtakManueltAp,
-  KontrollAvManueltOpprettetRevurderingsbehandlingAp,
   KontrollerRevurderingsBehandlingAp,
+  ProsessAksjonspunkt,
   VurdereAnnenYtelseForVedtakAp,
   VurdereDokumentForVedtakAp,
   VurdereInntektsmeldingKlageForVedtakAp,
 } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { isAvslag, isInnvilget, isOpphor, useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
-
 import { VedtakResultType } from '../../kodeverk/vedtakResultType';
 import type { VedtakForhåndsvisData } from '../../types/VedtakForhåndsvisData';
 import type { VedtakFormValues } from '../../types/VedtakFormValues';
@@ -42,6 +41,12 @@ import { buildInitialValues } from '../forstegang/VedtakForm';
 import { VedtakAvslagArsakOgBegrunnelsePanel } from './VedtakAvslagArsakOgBegrunnelsePanel';
 import { VedtakInnvilgetRevurderingPanel } from './VedtakInnvilgetRevurderingPanel';
 import { VedtakOpphorRevurderingPanel } from './VedtakOpphorRevurderingPanel';
+
+type KontrollAvManueltOpprettetRevurderingsbehandlingAp = {
+  kode: AksjonspunktKode.UTGÅTT_5056;
+  begrunnelse?: string;
+  skalBrukeOverstyrendeFritekstBrev?: boolean;
+};
 
 type RevurderingVedtakAksjonspunkter =
   | ForeslaVedtakAp
@@ -193,7 +198,7 @@ export const VedtakRevurderingForm = ({
   const intl = useIntl();
 
   const { behandling, fagsak, alleKodeverk, submitCallback, isReadOnly, aksjonspunkterForPanel } =
-    usePanelDataContext<RevurderingVedtakAksjonspunkter[]>();
+    usePanelDataContext<ProsessAksjonspunkt[]>();
 
   const { harRedigertBrev } = useVedtakEditeringContext();
 
@@ -236,7 +241,9 @@ export const VedtakRevurderingForm = ({
     <RhfForm
       formMethods={formMethods}
       onSubmit={(values: VedtakFormValues) =>
-        submitCallback(transformValues(values, aksjonspunkterForPanel, harValgtÅRedigereVedtaksbrev))
+        submitCallback(
+          transformValues(values, aksjonspunkterForPanel, harValgtÅRedigereVedtaksbrev) as unknown as ProsessAksjonspunkt[],
+        )
       }
       setDataOnUnmount={setMellomlagretFormData}
     >

--- a/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
+++ b/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
@@ -10,12 +10,12 @@ import { BTag, decodeHtmlEntity } from '@navikt/ft-utils';
 import { MedlemskapVurdering, MedlemskapVurderinger } from '@navikt/fp-fakta-medlemskap';
 import { AksjonspunktKode, type VilkårOverstyringAksjonspunkter } from '@navikt/fp-kodeverk';
 import { OverstyringPanel, VilkarResultPicker } from '@navikt/fp-prosess-felles';
-import type { Aksjonspunkt, BehandlingFpSak, ManuellBehandlingResultat, Vilkår } from '@navikt/fp-types';
+import type { Aksjonspunkt, Avslagsarsak, BehandlingFpSak, ManuellBehandlingResultat, Vilkår } from '@navikt/fp-types';
 import type {
   OverstyringAp,
   OverstyringMedlemskapsvilkaretAp,
-  OverstyringMedlemskapsvilkaretLopendeAp,
   OverstyringMedlemskapvilkaretForutgaendeAp,
+  ProsessAksjonspunkt,
 } from '@navikt/fp-types-avklar-aksjonspunkter';
 import {
   erAksjonspunktÅpent,
@@ -23,8 +23,15 @@ import {
   usePanelDataContext,
   usePanelOverstyring,
 } from '@navikt/fp-utils';
-
 import styles from './vilkarresultatMedOverstyringForm.module.css';
+
+type OverstyringMedlemskapsvilkaretLopendeAp = {
+  kode: AksjonspunktKode.UTGÅTT_6012;
+  begrunnelse?: string;
+  erVilkårOk?: boolean;
+  avslagskode?: string;
+  avslagDato?: string;
+};
 
 const isOverridden = (aksjonspunkter: Aksjonspunkt[], aksjonspunktCode: string): boolean =>
   aksjonspunkter.some(ap => ap.definisjon === aksjonspunktCode);
@@ -35,7 +42,7 @@ const isHidden = (kanOverstyre: boolean, aksjonspunkter: Aksjonspunkt[], aksjons
 type FormValues = {
   erVilkårOk?: boolean;
   vurdering?: MedlemskapVurdering;
-  avslagskode?: string;
+  avslagskode?: Avslagsarsak;
   opphørFom?: string;
   medlemFom?: string;
   begrunnelse?: string;
@@ -73,7 +80,7 @@ const createInitialValues = (
   return {
     ...felles,
     ...VilkarResultPicker.buildInitialValues(aksjonspunkt ? [aksjonspunkt] : [], status, behandlingsresultat),
-  };
+  } as FormValues;
 };
 
 type OverstyringVilkår =
@@ -83,21 +90,47 @@ type OverstyringVilkår =
   | OverstyringMedlemskapvilkaretForutgaendeAp;
 
 const transformValues = (values: FormValues, overstyringApKode: VilkårOverstyringAksjonspunkter): OverstyringVilkår => {
-  const felles = {
-    kode: overstyringApKode,
-    begrunnelse: values.begrunnelse,
-  };
-
   switch (overstyringApKode) {
     case AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET:
-    case AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR:
       return {
-        ...felles,
+        kode: AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET,
+        begrunnelse: values.begrunnelse,
         ...MedlemskapVurderinger.transformValues(values),
       };
-    default:
+    case AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR:
       return {
-        ...felles,
+        kode: AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR,
+        begrunnelse: values.begrunnelse,
+        ...MedlemskapVurderinger.transformValues(values),
+      };
+    case AksjonspunktKode.UTGÅTT_6012:
+      return {
+        kode: AksjonspunktKode.UTGÅTT_6012,
+        begrunnelse: values.begrunnelse,
+        ...VilkarResultPicker.transformValues(values),
+      };
+    case AksjonspunktKode.OVERSTYRING_AV_SØKNADSFRISTVILKÅRET:
+      return {
+        kode: AksjonspunktKode.OVERSTYRING_AV_SØKNADSFRISTVILKÅRET,
+        begrunnelse: values.begrunnelse,
+        ...VilkarResultPicker.transformValues(values),
+      };
+    case AksjonspunktKode.OVERSTYRING_AV_FØDSELSVILKÅRET:
+      return {
+        kode: AksjonspunktKode.OVERSTYRING_AV_FØDSELSVILKÅRET,
+        begrunnelse: values.begrunnelse,
+        ...VilkarResultPicker.transformValues(values),
+      };
+    case AksjonspunktKode.OVERSTYRING_AV_FØDSELSVILKÅRET_FAR_MEDMOR:
+      return {
+        kode: AksjonspunktKode.OVERSTYRING_AV_FØDSELSVILKÅRET_FAR_MEDMOR,
+        begrunnelse: values.begrunnelse,
+        ...VilkarResultPicker.transformValues(values),
+      };
+    case AksjonspunktKode.OVERSTYRING_AV_OPPTJENINGSVILKÅRET:
+      return {
+        kode: AksjonspunktKode.OVERSTYRING_AV_OPPTJENINGSVILKÅRET,
+        begrunnelse: values.begrunnelse,
         ...VilkarResultPicker.transformValues(values),
       };
   }
@@ -122,7 +155,7 @@ export const VilkarresultatMedOverstyringForm = ({
   medlemskapManuellBehandlingResultat,
   status,
 }: Props) => {
-  const { behandling, fagsak, submitCallback, alleMerknaderFraBeslutter } = usePanelDataContext<OverstyringVilkår>();
+  const { behandling, fagsak, submitCallback, alleMerknaderFraBeslutter } = usePanelDataContext<ProsessAksjonspunkt>();
 
   const { erOverstyrt, toggleOverstyring, overstyringApKode, overrideReadOnly, kanOverstyreAccess } =
     usePanelOverstyring<VilkårOverstyringAksjonspunkter>();
@@ -159,7 +192,9 @@ export const VilkarresultatMedOverstyringForm = ({
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values, overstyringApKode))}
+      onSubmit={(values: FormValues) =>
+        submitCallback(transformValues(values, overstyringApKode) as unknown as ProsessAksjonspunkt)
+      }
       setDataOnUnmount={setMellomlagretFormData}
     >
       <HStack gap="space-16">

--- a/packages/sak/risikoklassifisering/src/components/AvklarFaresignalerForm.tsx
+++ b/packages/sak/risikoklassifisering/src/components/AvklarFaresignalerForm.tsx
@@ -14,6 +14,8 @@ import {
   type Risikoklassifisering,
 } from '@navikt/fp-types';
 
+import { notEmpty } from '@navikt/fp-utils';
+
 import type { AvklartRisikoklassifiseringAp } from '../types/AvklartRisikoklassifiseringAp';
 
 const maxLength1500 = maxLength(1500);
@@ -137,9 +139,9 @@ const buildInitialValues = (
 
 const transformValues = (values: Values): AvklartRisikoklassifiseringAp => ({
   kode: AksjonspunktKode.VURDER_FARESIGNALER,
-  faresignalVurdering: utledFaresignalVurderingVerdi(
-    values[VURDERING_HOVEDKATEGORI],
-    values[IKKE_REELLE_VURDERINGER_UNDERKATEGORI],
+  faresignalVurdering: notEmpty(
+    utledFaresignalVurderingVerdi(values[VURDERING_HOVEDKATEGORI], values[IKKE_REELLE_VURDERINGER_UNDERKATEGORI]),
+    'faresignalVurdering må være satt ved submit',
   ),
   begrunnelse: values[begrunnelseFieldName],
 });

--- a/packages/sak/totrinnskontroll/src/TotrinnskontrollSakIndex.tsx
+++ b/packages/sak/totrinnskontroll/src/TotrinnskontrollSakIndex.tsx
@@ -12,8 +12,6 @@ import type {
   SkjermlenkeTypeFpTilbake,
   VurderÅrsak,
 } from '@navikt/fp-types';
-import type { FatterVedtakAp } from '@navikt/fp-types-avklar-aksjonspunkter';
-
 import { type AksjonspunktGodkjenningData } from './components/AksjonspunktGodkjenningFieldArray';
 import { type FormValues, TotrinnskontrollBeslutterForm } from './components/TotrinnskontrollBeslutterForm';
 import { TotrinnskontrollSaksbehandlerPanel } from './components/TotrinnskontrollSaksbehandlerPanel';
@@ -56,8 +54,15 @@ const finnFaktaOmBeregningTilfeller = (alleKodeverk: AlleKodeverk | AlleKodeverk
 
 type ApData = {
   fatterVedtakAksjonspunktDto: {
-    '@type': AksjonspunktKode.FATTER_VEDTAK | '5005';
-  } & FatterVedtakAp;
+    kode: AksjonspunktKode.FATTER_VEDTAK | '5005';
+    begrunnelse: undefined;
+    aksjonspunktGodkjenningDtos: {
+      aksjonspunktKode: string;
+      godkjent: boolean;
+      begrunnelse: string | undefined;
+      arsaker: VurderÅrsak[];
+    }[];
+  };
   erAlleAksjonspunktGodkjent: boolean;
 };
 

--- a/packages/types-avklar-aksjonspunkter/index.ts
+++ b/packages/types-avklar-aksjonspunkter/index.ts
@@ -21,13 +21,14 @@ export type { OverstyringDekningsgradAp } from './src/fakta/OverstyringDekningsg
 export type { OverstyringRettigheterAp } from './src/fakta/OverstyringRettigheterAp';
 export type { AvklarDekningsgradAp } from './src/fakta/AvklarDekningsgradAp';
 export type { VurderOmsorgsovertakelseVilkåretAp } from './src/fakta/VurderOmsorgsovertakelseVilkåretAp';
-export type { AvklarAktivitetsPerioderAp, OpptjeningAktivitetAp } from './src/fakta/AvklarAktivitetsPerioderAp';
+export type { AvklarAktivitetsPerioderAp } from './src/fakta/AvklarAktivitetsPerioderAp';
 export type { VurderDokumentasjonAp } from './src/fakta/VurderDokumentasjonAp';
 export type { VurderMedlemskapAp } from './src/fakta/VurderMedlemskapAp';
 export type { VurderForutgaendeMedlemskapAp } from './src/fakta/VurderForutgaendeMedlemskapAp';
 export type { BekreftAnnenpartsUttakEøsAp } from './src/fakta/BekreftAnnenpartsUttakEøsAp';
+export type { VurderArbeidsforholdInntektsmeldingAp } from './src/fakta/VurderArbeidsforholdInntektsmeldingAp';
 export type { BeregningAp } from './src/fakta/BeregningAp';
-export type { BesteberegningAP, ManuellKontrollBesteberegningAP } from './src/fakta/KontrollerBesteberegningAP';
+export type { BesteberegningAP, ManuellKontrollBesteberegningAP, KontrollerBesteberegningAP } from './src/fakta/KontrollerBesteberegningAP';
 
 export type { ProsessAksjonspunkt } from './src/ProsessAksjonspunkt';
 export type { BekreftSvangerskapspengervilkarAp } from './src/prosess/BekreftSvangerskapspengervilkarAp';

--- a/packages/types-avklar-aksjonspunkter/package.json
+++ b/packages/types-avklar-aksjonspunkter/package.json
@@ -14,28 +14,11 @@
     "clean": "rm -rf ./dist ./node_modules ./.turbo ./.storybook-static-build"
   },
   "dependencies": {
-    "@navikt/aksel-icons": "8.10.6",
-    "@navikt/ds-css": "8.10.6",
-    "@navikt/ds-react": "8.10.6",
     "@navikt/fp-config-typescript": "workspace:*",
     "@navikt/fp-kodeverk": "workspace:*",
     "@navikt/fp-types": "workspace:*",
-    "@navikt/ft-fakta-beregning": "14.0.10",
-    "@navikt/ft-fakta-fordel-beregningsgrunnlag": "16.0.10",
     "@navikt/ft-fakta-tilbakekreving-feilutbetaling": "10.0.10",
-    "@navikt/ft-form-hooks": "12.3.0",
-    "@navikt/ft-form-validators": "6.0.8",
-    "@navikt/ft-plattform-komponenter": "12.0.9",
-    "@navikt/ft-prosess-beregningsgrunnlag": "13.0.10",
-    "@navikt/ft-prosess-tilbakekreving-vedtak": "9.0.10",
-    "@navikt/ft-types": "6.1.7",
-    "@navikt/ft-ui-komponenter": "8.0.10",
-    "@navikt/ft-utils": "5.0.7",
-    "dayjs": "1.11.20",
-    "react": "19.2.6",
-    "react-dom": "19.2.6",
-    "react-hook-form": "7.75.0",
-    "react-intl": "10.1.6"
+    "@navikt/ft-prosess-tilbakekreving-vedtak": "9.0.10"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/types-avklar-aksjonspunkter/src/AksjonspunktTilBekreftelse.ts
+++ b/packages/types-avklar-aksjonspunkter/src/AksjonspunktTilBekreftelse.ts
@@ -1,7 +1,6 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { AksjonspunktKodeTilbakekreving } from '@navikt/fp-types';
+import type { BekreftetAksjonspunktDto, OverstyringAksjonspunktDto } from '@navikt/fp-types';
 
-export type AksjonspunktTilBekreftelse<T extends AksjonspunktKode | AksjonspunktKodeTilbakekreving> = {
-  kode: T;
-  begrunnelse?: string;
-};
+export type AksjonspunktTilBekreftelse<K extends string> = Extract<
+  BekreftetAksjonspunktDto | OverstyringAksjonspunktDto,
+  { kode: `${K}` }
+>;

--- a/packages/types-avklar-aksjonspunkter/src/FaktaAksjonspunkt.ts
+++ b/packages/types-avklar-aksjonspunkter/src/FaktaAksjonspunkt.ts
@@ -1,12 +1,3 @@
-import type {
-  BeregningFaktaAP,
-  BeregningOverstyringAP,
-  OverstyrBeregningsaktiviteterAP,
-} from '@navikt/ft-fakta-beregning';
-import type {
-  FordelBeregningsgrunnlagAP,
-  VurderRefusjonBeregningsgrunnlagAP,
-} from '@navikt/ft-fakta-fordel-beregningsgrunnlag';
 import type { AvklartFaktaFeilutbetalingAp } from '@navikt/ft-fakta-tilbakekreving-feilutbetaling';
 
 import type { AvklarAktivitetsPerioderAp } from './fakta/AvklarAktivitetsPerioderAp';
@@ -39,6 +30,7 @@ import type { VurderForutgaendeMedlemskapAp } from './fakta/VurderForutgaendeMed
 import type { VurderMedlemskapAp } from './fakta/VurderMedlemskapAp';
 import type { VurderOmsorgsovertakelseVilkåretAp } from './fakta/VurderOmsorgsovertakelseVilkåretAp';
 
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-duplicate-type-constituents */
 export type FaktaAksjonspunkt =
   | AvklarVergeAp
   | MerkOpptjeningUtlandAp
@@ -46,6 +38,7 @@ export type FaktaAksjonspunkt =
   | AvklarAktivitetsPerioderAp
   | BekreftAleneomsorgVurderingAp
   | ManuellKontrollBesteberegningAP
+  | KontrollerBesteberegningAP
   | VurderOmsorgsovertakelseVilkåretAp
   | VurderMedlemskapAp
   | BekreftSvangerskapspengerAp
@@ -62,12 +55,6 @@ export type FaktaAksjonspunkt =
   | AvklarAnnenforelderHarRettAp
   | BekreftUttaksperioderAp
   | OverstyringAvklarStartdatoForPeriodenAp
-  | KontrollerBesteberegningAP
-  | OverstyrBeregningsaktiviteterAP
-  | BeregningFaktaAP
-  | BeregningOverstyringAP
-  | FordelBeregningsgrunnlagAP
-  | VurderRefusjonBeregningsgrunnlagAP
   | VurderArbeidsforholdInntektsmeldingAp
   | VurderDokumentasjonAp
   | VurderArbeidsforholdPermisjonAp
@@ -76,3 +63,4 @@ export type FaktaAksjonspunkt =
   | BekreftAnnenpartsUttakEøsAp
   | AvklarDekningsgradAp
   | AvklartFaktaFeilutbetalingAp;
+/* eslint-enable @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-duplicate-type-constituents */

--- a/packages/types-avklar-aksjonspunkter/src/ProsessAksjonspunkt.ts
+++ b/packages/types-avklar-aksjonspunkter/src/ProsessAksjonspunkt.ts
@@ -29,6 +29,7 @@ import type { VurderInnsynAp } from './prosess/VurderInnsynAp';
 import type { VurderSoknadsfristAp } from './prosess/VurderSoknadsfristAp';
 import type { VurderTilbaketrekkAp } from './prosess/VurderTilbaketrekkAp';
 
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-duplicate-type-constituents */
 export type ProsessAksjonspunkt =
   | BekreftSvangerskapspengervilkarAp
   | SoknadsfristAp
@@ -51,11 +52,12 @@ export type ProsessAksjonspunkt =
   | VurderTilbaketrekkAp
   | OverstyringAp
   | KontrollerRevurderingsBehandlingAp
-  | VarselRevurderingAp
   | KontrollAvManueltOpprettetRevurderingsbehandlingAp
+  | VarselRevurderingAp
   | OverstyringMedlemskapsvilkaretLopendeAp
   | OverstyringMedlemskapvilkaretForutgaendeAp
   | VurdereAnnenYtelseForVedtakAp
   | UttakAp
   | VurdereDokumentForVedtakAp
   | VurdereInntektsmeldingKlageForVedtakAp;
+/* eslint-enable @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-duplicate-type-constituents */

--- a/packages/types-avklar-aksjonspunkter/src/fakta/AvklarAktivitetsPerioderAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/AvklarAktivitetsPerioderAp.ts
@@ -1,17 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OpptjeningAktivitetAp = {
-  arbeidsgiverReferanse?: string;
-  arbeidsforholdRef?: string;
-  erGodkjent: boolean;
-  begrunnelse: string;
-  aktivitetType: string;
-  opptjeningFom: string;
-  opptjeningTom: string;
-};
-
-export type AvklarAktivitetsPerioderAp = {
-  opptjeningsaktiviteter?: OpptjeningAktivitetAp[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_PERIODER_MED_OPPTJENING>;
+export type AvklarAktivitetsPerioderAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_PERIODER_MED_OPPTJENING>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/AvklarAnnenforelderHarRettAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/AvklarAnnenforelderHarRettAp.ts
@@ -1,9 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type AvklarAnnenforelderHarRettAp = {
-  annenforelderHarRett: boolean;
-  annenforelderMottarUføretrygd?: boolean;
-  annenForelderHarRettEØS?: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT>;
+export type AvklarAnnenforelderHarRettAp = AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/AvklarDekningsgradAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/AvklarDekningsgradAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type AvklarDekningsgradAp = {
-  dekningsgrad: number;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_DEKNINGSGRAD>;
+export type AvklarDekningsgradAp = AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_DEKNINGSGRAD>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/AvklarFortsattMedlemskapAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/AvklarFortsattMedlemskapAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
-import type { MedlemskapBekreftetPeriode } from './MedlemskapBekreftetPeriode';
 
-export type AvklarFortsattMedlemskapAp = {
-  bekreftedePerioder: MedlemskapBekreftetPeriode[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5053>;
+export type AvklarFortsattMedlemskapAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5053>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/AvklarVergeAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/AvklarVergeAp.ts
@@ -1,12 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type AvklarVergeAp = {
-  navn: string;
-  gyldigFom: string;
-  gyldigTom?: string;
-  vergeType: string;
-  organisasjonsnummer?: string;
-  fnr?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_VERGE>;
+export type AvklarVergeAp = AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_VERGE>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftAleneomsorgVurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftAleneomsorgVurderingAp.ts
@@ -1,10 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BekreftAleneomsorgVurderingAp = {
-  aleneomsorg: boolean;
-  annenforelderHarRett?: boolean;
-  annenforelderMottarUføretrygd?: boolean;
-  annenForelderHarRettEØS?: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_KONTROLL_AV_OM_BRUKER_HAR_ALENEOMSORG>;
+export type BekreftAleneomsorgVurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_KONTROLL_AV_OM_BRUKER_HAR_ALENEOMSORG>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftAnnenpartsUttakEøsAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftAnnenpartsUttakEøsAp.ts
@@ -1,10 +1,7 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { AnnenforelderUttakEøsPeriode } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BekreftAnnenpartsUttakEøsAp = {
-  perioder: AnnenforelderUttakEøsPeriode[];
-} & AksjonspunktTilBekreftelse<
+export type BekreftAnnenpartsUttakEøsAp = AksjonspunktTilBekreftelse<
   AksjonspunktKode.AVKLAR_UTTAK_I_EØS_FOR_ANNENPART | AksjonspunktKode.OVERSTYRING_AV_UTTAK_I_EØS_FOR_ANNENPART
 >;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftBosattVurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftBosattVurderingAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
-import type { MedlemskapBekreftetPeriode } from './MedlemskapBekreftetPeriode';
 
-export type BekreftBosattVurderingAp = {
-  bekreftedePerioder: MedlemskapBekreftetPeriode[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5020>;
+export type BekreftBosattVurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5020>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftErMedlemVurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftErMedlemVurderingAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
-import type { MedlemskapBekreftetPeriode } from './MedlemskapBekreftetPeriode';
 
-export type BekreftErMedlemVurderingAp = {
-  bekreftedePerioder: MedlemskapBekreftetPeriode[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5021>;
+export type BekreftErMedlemVurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5021>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftLovligOppholdVurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftLovligOppholdVurderingAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
-import type { MedlemskapBekreftetPeriode } from './MedlemskapBekreftetPeriode';
 
-export type BekreftLovligOppholdVurderingAp = {
-  bekreftedePerioder: MedlemskapBekreftetPeriode[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5019>;
+export type BekreftLovligOppholdVurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5019>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftOmsorgVurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftOmsorgVurderingAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BekreftOmsorgVurderingAp = {
-  omsorg: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_LØPENDE_OMSORG>;
+export type BekreftOmsorgVurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_LØPENDE_OMSORG>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftOppholdsrettVurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftOppholdsrettVurderingAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
-import type { MedlemskapBekreftetPeriode } from './MedlemskapBekreftetPeriode';
 
-export type BekreftOppholdsrettVurderingAp = {
-  bekreftedePerioder: MedlemskapBekreftetPeriode[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5023>;
+export type BekreftOppholdsrettVurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5023>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftSvangerskapspengerAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftSvangerskapspengerAp.ts
@@ -1,10 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { BekreftTilrettelegging } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BekreftSvangerskapspengerAp = {
-  termindato: string;
-  fødselsdato?: string;
-  bekreftetSvpArbeidsforholdList: BekreftTilrettelegging[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_SVP_TILRETTELEGGING>;
+export type BekreftSvangerskapspengerAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_SVP_TILRETTELEGGING>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BekreftUttaksperioderAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BekreftUttaksperioderAp.ts
@@ -1,11 +1,8 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { FaktaUttakPeriode } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BekreftUttaksperioderAp = {
-  perioder: FaktaUttakPeriode[];
-} & AksjonspunktTilBekreftelse<
+export type BekreftUttaksperioderAp = AksjonspunktTilBekreftelse<
   | AksjonspunktKode.FAKTA_UTTAK_MANUELT_SATT_STARTDATO_ULIK_SØKNAD_STARTDATO
   | AksjonspunktKode.FAKTA_UTTAK_INGEN_PERIODER
   | AksjonspunktKode.FAKTA_UTTAK_GRADERING_UKJENT_AKTIVITET

--- a/packages/types-avklar-aksjonspunkter/src/fakta/BeregningAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/BeregningAp.ts
@@ -1,13 +1,10 @@
-import type { BeregningFaktaAP } from '@navikt/ft-fakta-beregning';
-
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BeregningAp = BeregningFaktaAP['grunnlag'][number] &
-  AksjonspunktTilBekreftelse<
-    | AksjonspunktKode.AVKLAR_AKTIVITETER
-    | AksjonspunktKode.OVERSTYRING_AV_BEREGNINGSAKTIVITETER
-    | AksjonspunktKode.VURDER_FAKTA_FOR_ATFL_SN
-    | AksjonspunktKode.OVERSTYRING_AV_BEREGNINGSGRUNNLAG
-  >;
+export type BeregningAp = AksjonspunktTilBekreftelse<
+  | AksjonspunktKode.AVKLAR_AKTIVITETER
+  | AksjonspunktKode.OVERSTYRING_AV_BEREGNINGSAKTIVITETER
+  | AksjonspunktKode.VURDER_FAKTA_FOR_ATFL_SN
+  | AksjonspunktKode.OVERSTYRING_AV_BEREGNINGSGRUNNLAG
+>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/KontrollerBesteberegningAP.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/KontrollerBesteberegningAP.ts
@@ -1,15 +1,10 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-// Oppstod for alle besteberegninger i en periode
-export type KontrollerBesteberegningAP = {
-  besteberegningErKorrekt: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5048>;
+export type KontrollerBesteberegningAP = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5048>;
 
-// Oppstår nå kun for besteberegninger med stort avvik mellom første og tredje ledd.
-export type ManuellKontrollBesteberegningAP = {
-  besteberegningErKorrekt: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_KONTROLL_AV_BESTEBEREGNING>;
+export type ManuellKontrollBesteberegningAP = AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_KONTROLL_AV_BESTEBEREGNING>;
 
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export type BesteberegningAP = ManuellKontrollBesteberegningAP | KontrollerBesteberegningAP;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/MerkOpptjeningUtlandAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/MerkOpptjeningUtlandAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type MerkOpptjeningUtlandAp = {
-  dokStatus?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.AUTOMATISK_MARKERING_AV_UTENLANDSSAK>;
+export type MerkOpptjeningUtlandAp = AksjonspunktTilBekreftelse<AksjonspunktKode.AUTOMATISK_MARKERING_AV_UTENLANDSSAK>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/OverstyringAvklarStartdatoForPeriodenAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/OverstyringAvklarStartdatoForPeriodenAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringAvklarStartdatoForPeriodenAp = {
-  startdatoFraSøknad: string;
-  opprinneligDato?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_AVKLART_STARTDATO>;
+export type OverstyringAvklarStartdatoForPeriodenAp = AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_AVKLART_STARTDATO>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/OverstyringDekningsgradAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/OverstyringDekningsgradAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringDekningsgradAp = {
-  dekningsgrad: number;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_DEKNINGSGRAD>;
+export type OverstyringDekningsgradAp = AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_DEKNINGSGRAD>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/OverstyringRettigheterAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/OverstyringRettigheterAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import { type Rettighetstype } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringRettigheterAp = {
-  rettighetstype: Rettighetstype;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_RETT_OG_OMSORG>;
+export type OverstyringRettigheterAp = AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_RETT_OG_OMSORG>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/VurderArbeidsforholdInntektsmeldingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/VurderArbeidsforholdInntektsmeldingAp.ts
@@ -1,6 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderArbeidsforholdInntektsmeldingAp =
-  AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_ARBEIDSFORHOLD_INNTEKTSMELDING>;
+export type VurderArbeidsforholdInntektsmeldingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_ARBEIDSFORHOLD_INNTEKTSMELDING>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/VurderArbeidsforholdPermisjonAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/VurderArbeidsforholdPermisjonAp.ts
@@ -1,12 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderArbeidsforholdPermisjonAp = {
-  arbeidsforhold: {
-    internArbeidsforholdId?: string;
-    arbeidsgiverIdent: string;
-    permisjonStatus: string;
-  }[];
-  begrunnelse: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_PERMISJON_UTEN_SLUTTDATO>;
+export type VurderArbeidsforholdPermisjonAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_PERMISJON_UTEN_SLUTTDATO>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/VurderDokumentasjonAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/VurderDokumentasjonAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { DokumentasjonVurderingBehov } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderDokumentasjonAp = {
-  vurderingBehov: DokumentasjonVurderingBehov[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_UTTAK_DOKUMENTASJON>;
+export type VurderDokumentasjonAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_UTTAK_DOKUMENTASJON>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/VurderForutgaendeMedlemskapAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/VurderForutgaendeMedlemskapAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderForutgaendeMedlemskapAp = {
-  avslagskode?: string;
-  medlemFom?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR>;
+export type VurderForutgaendeMedlemskapAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/VurderMedlemskapAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/VurderMedlemskapAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderMedlemskapAp = {
-  avslagskode?: string;
-  opphørFom?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_MEDLEMSKAPSVILKÅRET>;
+export type VurderMedlemskapAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_MEDLEMSKAPSVILKÅRET>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/VurderOmsorgsovertakelseVilkåretAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/VurderOmsorgsovertakelseVilkåretAp.ts
@@ -1,12 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { Avslagsarsak, OmsorgsovertakelseVilkårType } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderOmsorgsovertakelseVilkåretAp = {
-  avslagskode?: Avslagsarsak;
-  delvilkår: OmsorgsovertakelseVilkårType;
-  omsorgsovertakelseDato: string;
-  barn: { fødselsdato: string; barnNummer: number }[];
-  ektefellesBarn: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_OMSORGSOVERTAKELSEVILKÅRET>;
+export type VurderOmsorgsovertakelseVilkåretAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_OMSORGSOVERTAKELSEVILKÅRET>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/fødsel/OverstyringFaktaFødselAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/fødsel/OverstyringFaktaFødselAp.ts
@@ -1,13 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../../AksjonspunktTilBekreftelse';
 
-export type OverstyringFaktaFødselAp = {
-  termindato: string | null;
-  barn:
-    | {
-        fødselsdato: string;
-        dødsdato?: string;
-      }[]
-    | null;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_FAKTA_OM_FØDSEL>;
+export type OverstyringFaktaFødselAp = AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_FAKTA_OM_FØDSEL>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/fødsel/SjekkManglendeFødselAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/fødsel/SjekkManglendeFødselAp.ts
@@ -1,13 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../../AksjonspunktTilBekreftelse';
 
-export type SjekkManglendeFødselAp = {
-  termindato: string | null;
-  barn:
-    | {
-        fødselsdato: string;
-        dødsdato?: string;
-      }[]
-    | null;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.SJEKK_MANGLENDE_FØDSEL>;
+export type SjekkManglendeFødselAp = AksjonspunktTilBekreftelse<AksjonspunktKode.SJEKK_MANGLENDE_FØDSEL>;

--- a/packages/types-avklar-aksjonspunkter/src/fakta/fødsel/SjekkTerminbekreftelseAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/fakta/fødsel/SjekkTerminbekreftelseAp.ts
@@ -1,9 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../../AksjonspunktTilBekreftelse';
 
-export type SjekkTerminbekreftelseAp = {
-  utstedtdato: string;
-  termindato: string | null;
-  antallBarn: number;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.SJEKK_TERMINBEKREFTELSE>;
+export type SjekkTerminbekreftelseAp = AksjonspunktTilBekreftelse<AksjonspunktKode.SJEKK_TERMINBEKREFTELSE>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/AvklarOpptjeningsvilkaretAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/AvklarOpptjeningsvilkaretAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type AvklarOpptjeningsvilkaretAp = {
-  erVilkårOk: boolean;
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_OPPTJENINGSVILKÅRET>;
+export type AvklarOpptjeningsvilkaretAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_OPPTJENINGSVILKÅRET>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/BekreftSvangerskapspengervilkarAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/BekreftSvangerskapspengervilkarAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BekreftSvangerskapspengervilkarAp = {
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_SVANGERSKAPSPENGERVILKÅRET>;
+export type BekreftSvangerskapspengervilkarAp = AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_SVANGERSKAPSPENGERVILKÅRET>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/BeregningsgrunnlagAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/BeregningsgrunnlagAp.ts
@@ -1,13 +1,10 @@
-import type { BeregningAksjonspunktSubmitType } from '@navikt/ft-prosess-beregningsgrunnlag';
-
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type BeregningsgrunnlagAp = BeregningAksjonspunktSubmitType['grunnlag'][number] &
-  AksjonspunktTilBekreftelse<
-    | AksjonspunktKode.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS
-    | AksjonspunktKode.VURDER_VARIG_ENDRET_ELLER_NYOPPSTARTET_NÆRING_SELVSTENDIG_NÆRINGSDRIVENDE
-    | AksjonspunktKode.FASTSETT_BEREGNINGSGRUNNLAG_TIDSBEGRENSET_ARBEIDSFORHOLD
-    | AksjonspunktKode.FASTSETT_BEREGNINGSGRUNNLAG_FOR_SN_NY_I_ARBEIDSLIVET
-  >;
+export type BeregningsgrunnlagAp = AksjonspunktTilBekreftelse<
+  | AksjonspunktKode.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS
+  | AksjonspunktKode.VURDER_VARIG_ENDRET_ELLER_NYOPPSTARTET_NÆRING_SELVSTENDIG_NÆRINGSDRIVENDE
+  | AksjonspunktKode.FASTSETT_BEREGNINGSGRUNNLAG_TIDSBEGRENSET_ARBEIDSFORHOLD
+  | AksjonspunktKode.FASTSETT_BEREGNINGSGRUNNLAG_FOR_SN_NY_I_ARBEIDSLIVET
+>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/Foreldreansvarsvilkar1Ap.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/Foreldreansvarsvilkar1Ap.ts
@@ -1,8 +1,6 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type Foreldreansvarsvilkar1Ap = {
-  erVilkårOk: boolean;
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5013>;
+// UTGÅTT
+export type Foreldreansvarsvilkar1Ap = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5013>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/Foreldreansvarsvilkar2Ap.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/Foreldreansvarsvilkar2Ap.ts
@@ -1,8 +1,6 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type Foreldreansvarsvilkar2Ap = {
-  erVilkårOk: boolean;
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5014>;
+// UTGÅTT
+export type Foreldreansvarsvilkar2Ap = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5014>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/ForeslaVedtakAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/ForeslaVedtakAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type ForeslaVedtakAp = {
-  skalBrukeOverstyrendeFritekstBrev?: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.FORESLÅ_VEDTAK>;
+export type ForeslaVedtakAp = AksjonspunktTilBekreftelse<AksjonspunktKode.FORESLÅ_VEDTAK>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/ForeslaVedtakManueltAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/ForeslaVedtakManueltAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type ForeslaVedtakManueltAp = {
-  skalBrukeOverstyrendeFritekstBrev?: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.FORESLÅ_VEDTAK_MANUELT>;
+export type ForeslaVedtakManueltAp = AksjonspunktTilBekreftelse<AksjonspunktKode.FORESLÅ_VEDTAK_MANUELT>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/KlageFormkravAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/KlageFormkravAp.ts
@@ -1,22 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-type KlageFormkravBasic = {
-  erKlagerPart: boolean;
-  erFristOverholdt: boolean;
-  erKonkret: boolean;
-  erSignert: boolean;
-  erTilbakekreving?: boolean;
-  tilbakekrevingInfo?: {
-    tilbakekrevingUuid?: string;
-    tilbakekrevingVedtakDato?: string;
-    tilbakekrevingBehandlingType?: string;
-  };
-  vedtakBehandlingUuid?: string;
-  fritekstTilBrev?: string;
-  mottattDato?: string;
-};
-
-export type KlageFormkravAp = KlageFormkravBasic &
-  AksjonspunktTilBekreftelse<AksjonspunktKode.VURDERING_AV_FORMKRAV_KLAGE_NFP>;
+export type KlageFormkravAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDERING_AV_FORMKRAV_KLAGE_NFP>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/KlageVurderingResultatAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/KlageVurderingResultatAp.ts
@@ -1,13 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { KlageHjemmel, KlageVurderingOmgjørType, KlageVurderingType } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type KlageVurderingResultatAp = {
-  klageVurdering: KlageVurderingType;
-  fritekstTilBrev?: string;
-  klageMedholdÅrsak?: string;
-  klageVurderingOmgjør?: KlageVurderingOmgjørType;
-  klageHjemmel?: KlageHjemmel;
-  vedtaksdatoPaklagdBehandling?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_KLAGE_NFP>;
+export type KlageVurderingResultatAp = AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_KLAGE_NFP>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/KontrollAvManueltOpprettetRevurderingsbehandlingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/KontrollAvManueltOpprettetRevurderingsbehandlingAp.ts
@@ -1,6 +1,7 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
+// UTGÅTT
 export type KontrollAvManueltOpprettetRevurderingsbehandlingAp =
   AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5056>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/KontrollerEtterbetalingTilSøkerAP.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/KontrollerEtterbetalingTilSøkerAP.ts
@@ -1,6 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type KontrollerEtterbetalingTilSøkerAP =
-  AksjonspunktTilBekreftelse<AksjonspunktKode.KONTROLLER_STOR_ETTERBETALING_SØKER>;
+export type KontrollerEtterbetalingTilSøkerAP = AksjonspunktTilBekreftelse<AksjonspunktKode.KONTROLLER_STOR_ETTERBETALING_SØKER>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/KontrollerRevurderingsBehandlingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/KontrollerRevurderingsBehandlingAp.ts
@@ -1,6 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type KontrollerRevurderingsBehandlingAp =
-  AksjonspunktTilBekreftelse<AksjonspunktKode.KONTROLLER_REVURDERINGSBEHANDLING_VARSEL_VED_UGUNST>;
+export type KontrollerRevurderingsBehandlingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.KONTROLLER_REVURDERINGSBEHANDLING_VARSEL_VED_UGUNST>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/OmsorgsvilkarAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/OmsorgsvilkarAp.ts
@@ -1,8 +1,6 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OmsorgsvilkarAp = {
-  erVilkårOk: boolean;
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5011>;
+// UTGÅTT
+export type OmsorgsvilkarAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5011>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringAp.ts
@@ -1,11 +1,8 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringAp = {
-  erVilkårOk?: boolean;
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<
+export type OverstyringAp = AksjonspunktTilBekreftelse<
   | AksjonspunktKode.OVERSTYRING_AV_SØKNADSFRISTVILKÅRET
   | AksjonspunktKode.OVERSTYRING_AV_FØDSELSVILKÅRET
   | AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET

--- a/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringMedlemskapsvilkaretAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringMedlemskapsvilkaretAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringMedlemskapsvilkaretAp = {
-  avslagskode?: string;
-  opphørFom?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET>;
+export type OverstyringMedlemskapsvilkaretAp = AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringMedlemskapsvilkaretLopendeAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringMedlemskapsvilkaretLopendeAp.ts
@@ -1,9 +1,6 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringMedlemskapsvilkaretLopendeAp = {
-  erVilkårOk?: boolean;
-  avslagskode?: string;
-  avslagDato?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_6012>;
+// UTGÅTT
+export type OverstyringMedlemskapsvilkaretLopendeAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_6012>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringMedlemskapvilkaretForutgaendeAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringMedlemskapvilkaretForutgaendeAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringMedlemskapvilkaretForutgaendeAp = {
-  avslagskode?: string;
-  medlemFom?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR>;
+export type OverstyringMedlemskapvilkaretForutgaendeAp = AksjonspunktTilBekreftelse<AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringSokersOpplysingspliktAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/OverstyringSokersOpplysingspliktAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type OverstyringSokersOpplysingspliktAp = {
-  erVilkårOk: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.SØKERS_OPPLYSNINGSPLIKT_OVST>;
+export type OverstyringSokersOpplysingspliktAp = AksjonspunktTilBekreftelse<AksjonspunktKode.SØKERS_OPPLYSNINGSPLIKT_OVST>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/SoknadsfristAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/SoknadsfristAp.ts
@@ -1,7 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type SoknadsfristAp = {
-  erVilkårOk: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_SØKNADSFRISTVILKÅRET>;
+export type SoknadsfristAp = AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_SØKNADSFRISTVILKÅRET>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/UttakAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/UttakAp.ts
@@ -1,20 +1,12 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { PeriodeSoker } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type UttakAp = {
-  perioder: PeriodeSoker[];
-} & AksjonspunktTilBekreftelse<
+export type UttakAp = AksjonspunktTilBekreftelse<
   | AksjonspunktKode.FASTSETT_UTTAKPERIODER
   | AksjonspunktKode.OVERSTYRING_AV_UTTAKPERIODER
   | AksjonspunktKode.FASTSETT_UTTAK_STORTINGSREPRESENTANT
-  | AksjonspunktKode.UTGÅTT_5069
-  | AksjonspunktKode.UTGÅTT_5067
   | AksjonspunktKode.KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE
-  | AksjonspunktKode.UTGÅTT_5075
   | AksjonspunktKode.KONTROLLER_OPPLYSNINGER_OM_DØD
   | AksjonspunktKode.KONTROLLER_OPPLYSNINGER_OM_SØKNADSFRIST
-  | AksjonspunktKode.UTGÅTT_5078
-  | AksjonspunktKode.UTGÅTT_5079
 >;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VarselRevurderingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VarselRevurderingAp.ts
@@ -1,9 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VarselRevurderingAp = {
-  sendVarsel?: boolean;
-  frist?: string;
-  ventearsak?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5025 | AksjonspunktKode.VARSEL_REVURDERING_MANUELL>;
+export type VarselRevurderingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VARSEL_REVURDERING_MANUELL>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurderFeilutbetalingAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurderFeilutbetalingAp.ts
@@ -1,9 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { TilbakekrevingVidereBehandling } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderFeilutbetalingAp = {
-  videreBehandling: TilbakekrevingVidereBehandling;
-  varseltekst?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_FEILUTBETALING>;
+export type VurderFeilutbetalingAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_FEILUTBETALING>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurderInnsynAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurderInnsynAp.ts
@@ -1,16 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { InnsynResultatType } from '@navikt/fp-types';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderInnsynAp = {
-  innsynResultatType: InnsynResultatType;
-  mottattDato: string;
-  innsynDokumenter: {
-    fikkInnsyn?: boolean;
-    journalpostId?: string;
-    dokumentId?: string;
-  }[];
-  sattPaVent?: boolean;
-  fristDato?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_INNSYN>;
+export type VurderInnsynAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDER_INNSYN>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurderSoknadsfristAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurderSoknadsfristAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderSoknadsfristAp = {
-  ansesMottattDato?: string;
-  harGyldigGrunn?: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_SØKNADSFRIST>;
+export type VurderSoknadsfristAp = AksjonspunktTilBekreftelse<AksjonspunktKode.MANUELL_VURDERING_AV_SØKNADSFRIST>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurderTilbaketrekkAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurderTilbaketrekkAp.ts
@@ -1,7 +1,6 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurderTilbaketrekkAp = {
-  hindreTilbaketrekk?: boolean;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5090>;
+// UTGÅTT
+export type VurderTilbaketrekkAp = AksjonspunktTilBekreftelse<AksjonspunktKode.UTGÅTT_5090>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurdereAnnenYtelseForVedtakAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurdereAnnenYtelseForVedtakAp.ts
@@ -1,6 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurdereAnnenYtelseForVedtakAp =
-  AksjonspunktTilBekreftelse<AksjonspunktKode.VURDERE_ANNEN_YTELSE_FØR_VEDTAK>;
+export type VurdereAnnenYtelseForVedtakAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDERE_ANNEN_YTELSE_FØR_VEDTAK>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurdereDokumentForVedtakAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurdereDokumentForVedtakAp.ts
@@ -1,4 +1,4 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurdereInntektsmeldingKlageForVedtakAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurdereInntektsmeldingKlageForVedtakAp.ts
@@ -1,6 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurdereInntektsmeldingKlageForVedtakAp =
-  AksjonspunktTilBekreftelse<AksjonspunktKode.VURDERE_INNTEKTSMELDING_FØR_VEDTAK>;
+export type VurdereInntektsmeldingKlageForVedtakAp = AksjonspunktTilBekreftelse<AksjonspunktKode.VURDERE_INNTEKTSMELDING_FØR_VEDTAK>;

--- a/packages/types-avklar-aksjonspunkter/src/prosess/VurdereYtelseSammeBarnSokerAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/prosess/VurdereYtelseSammeBarnSokerAp.ts
@@ -1,8 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type VurdereYtelseSammeBarnSokerAp = {
-  erVilkårOk: boolean;
-  avslagskode?: string;
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_OM_SØKER_HAR_MOTTATT_STØTTE>;
+export type VurdereYtelseSammeBarnSokerAp = AksjonspunktTilBekreftelse<AksjonspunktKode.AVKLAR_OM_SØKER_HAR_MOTTATT_STØTTE>;

--- a/packages/types-avklar-aksjonspunkter/src/totrinn/FatterVedtakAp.ts
+++ b/packages/types-avklar-aksjonspunkter/src/totrinn/FatterVedtakAp.ts
@@ -1,12 +1,5 @@
-import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
 import type { AksjonspunktTilBekreftelse } from '../AksjonspunktTilBekreftelse';
 
-export type FatterVedtakAp = {
-  aksjonspunktGodkjenningDtos: {
-    godkjent: boolean;
-    begrunnelse?: string;
-    aksjonspunktKode?: string;
-    arsaker: string[];
-  }[];
-} & AksjonspunktTilBekreftelse<AksjonspunktKode.FATTER_VEDTAK | '5005'>;
+export type FatterVedtakAp = AksjonspunktTilBekreftelse<AksjonspunktKode.FATTER_VEDTAK>;

--- a/packages/types/src/fpsak.gen.ts
+++ b/packages/types/src/fpsak.gen.ts
@@ -558,181 +558,182 @@ export type tjenester_behandling_dto_behandling_ProsessTaskGruppeIdDto = {
 
 export type foreldrepenger_behandling_aksjonspunkt_BekreftetAksjonspunktDto = (
   | ({
-      '@type': '5085';
+      kode: '5085';
     } & foreldrepenger_domene_arbeidInntektsmelding_BekreftArbeidInntektsmeldingAksjonspunktDto)
   | ({
-      '@type': '5041';
+      kode: '5041';
     } & foreldrepenger_domene_arbeidInntektsmelding_BekreftArbeidMedPermisjonUtenSluttdatoDto)
   | ({
-      '@type': '5051';
+      kode: '5051';
     } & foreldrepenger_domene_opptjening_dto_AvklarAktivitetsPerioderDto)
   | ({
-      '@type': '5089';
+      kode: '5089';
     } & foreldrepenger_domene_opptjening_dto_AvklarOpptjeningsvilkåretDto)
   | ({
-      '@type': '5068';
+      kode: '5068';
     } & foreldrepenger_domene_opptjening_dto_MerkOpptjeningUtlandDto)
   | ({
-      '@type': '5030';
+      kode: '5030';
     } & foreldrepenger_domene_person_verge_dto_AvklarVergeDto)
   | ({
-      '@type': '5052';
+      kode: '5052';
     } & foreldrepenger_domene_rest_dto_AvklarteAktiviteterDto)
   | ({
-      '@type': '5047';
+      kode: '5047';
     } & foreldrepenger_domene_rest_dto_FastsettBGTidsbegrensetArbeidsforholdDto)
   | ({
-      '@type': '5038';
+      kode: '5038';
     } & foreldrepenger_domene_rest_dto_FastsettBeregningsgrunnlagATFLDto)
   | ({
-      '@type': '5049';
+      kode: '5049';
     } & foreldrepenger_domene_rest_dto_FastsettBruttoBeregningsgrunnlagSNforNyIArbeidslivetDto)
   | ({
-      '@type': '5062';
+      kode: '5062';
     } & foreldrepenger_domene_rest_dto_KontrollerBesteberegningDto)
   | ({
-      '@type': '5058';
+      kode: '5058';
     } & foreldrepenger_domene_rest_dto_VurderFaktaOmBeregningDto)
   | ({
-      '@type': '5059';
+      kode: '5059';
     } & foreldrepenger_domene_rest_dto_VurderRefusjonBeregningsgrunnlagDto)
   | ({
-      '@type': '5039';
+      kode: '5039';
     } & foreldrepenger_domene_rest_dto_VurderVarigEndringEllerNyoppstartetSNDto)
   | ({
-      '@type': '5046';
+      kode: '5046';
     } & foreldrepenger_domene_rest_dto_fordeling_FordelBeregningsgrunnlagDto)
   | ({
-      '@type': '5027';
+      kode: '5027';
     } & foreldrepenger_familiehendelse_aksjonspunkt_fødsel_dto_SjekkManglendeFødselAksjonspunktDto)
   | ({
-      '@type': '5001';
+      kode: '5001';
     } & foreldrepenger_familiehendelse_aksjonspunkt_fødsel_dto_SjekkTerminbekreftelseAksjonspunktDto)
   | ({
-      '@type': '5018';
+      kode: '5018';
     } & foreldrepenger_familiehendelse_aksjonspunkt_omsorgsovertakelse_dto_VurderOmsorgsovertakelseVilkårAksjonspunktDto)
   | ({
-      '@type': '5031';
+      kode: '5031';
     } & foreldrepenger_familiehendelse_aksjonspunkt_sammebarn_dto_VurdereYtelseSammeBarnSøkerAksjonspunktDto)
   | ({
-      '@type': '5016';
+      kode: '5016';
     } & tjenester_behandling_aksjonspunkt_FatterVedtakAksjonspunktDto)
   | ({
-      '@type': '5002';
+      kode: '5002';
     } & tjenester_behandling_dekningsgrad_AvklarDekningsgradDto)
   | ({
-      '@type': '5037';
+      kode: '5037';
     } & tjenester_behandling_innsyn_aksjonspunkt_VurderInnsynDto)
   | ({
-      '@type': '5082';
+      kode: '5082';
     } & tjenester_behandling_klage_aksjonspunkt_KlageFormkravAksjonspunktDto)
   | ({
-      '@type': '5035';
+      kode: '5035';
     } & tjenester_behandling_klage_aksjonspunkt_KlageVurderingResultatAksjonspunktDto)
   | ({
-      '@type': '5102';
+      kode: '5102';
     } & tjenester_behandling_medlem_aksjonspunkt_VurderForutgåendeMedlemskapDto)
   | ({
-      '@type': '5101';
+      kode: '5101';
     } & tjenester_behandling_medlem_aksjonspunkt_VurderMedlemskapDto)
   | ({
-      '@type': '5055';
+      kode: '5055';
     } & tjenester_behandling_revurdering_aksjonspunkt_KontrollerRevurderingsBehandlingDto)
   | ({
-      '@type': '5026';
+      kode: '5026';
     } & tjenester_behandling_revurdering_aksjonspunkt_VarselRevurderingDto)
   | ({
-      '@type': '5095';
+      kode: '5095';
     } & tjenester_behandling_risikoklassifisering_VurderFaresignalerDto)
   | ({
-      '@type': '5091';
+      kode: '5091';
     } & tjenester_behandling_svp_BekreftSvangerskapspengerDto)
   | ({
-      '@type': '5092';
+      kode: '5092';
     } & tjenester_behandling_svp_BekreftSvangerskapspengervilkårDto)
   | ({
-      '@type': '5007';
+      kode: '5007';
     } & tjenester_behandling_søknad_aksjonspunkt_SoknadsfristAksjonspunktDto)
   | ({
-      '@type': '5043';
+      kode: '5043';
     } & tjenester_behandling_søknad_aksjonspunkt_VurderSøknadsfristDto)
   | ({
-      '@type': '5029';
+      kode: '5029';
     } & tjenester_behandling_tilbakekreving_aksjonspunkt_KontrollerStorEtterbetalingSøkerDto)
   | ({
-      '@type': '5084';
+      kode: '5084';
     } & tjenester_behandling_tilbakekreving_aksjonspunkt_VurderFeilutbetalingDto)
   | ({
-      '@type': '5074';
+      kode: '5074';
     } & tjenester_behandling_uttak_dokumentasjon_VurderUttakDokumentasjonDto)
   | ({
-      '@type': '5060';
+      kode: '5060';
     } & tjenester_behandling_uttak_dto_AvklarAleneomsorgVurderingDto)
   | ({
-      '@type': '5086';
+      kode: '5086';
     } & tjenester_behandling_uttak_dto_AvklarAnnenforelderHarRettDto)
   | ({
-      '@type': '5076';
+      kode: '5076';
     } & tjenester_behandling_uttak_dto_FastsetteUttakDto_FastsetteUttakKontrollerOpplysningerOmDødDto)
   | ({
-      '@type': '5077';
+      kode: '5077';
     } & tjenester_behandling_uttak_dto_FastsetteUttakDto_FastsetteUttakKontrollerOpplysningerOmSøknadsfristDto)
   | ({
-      '@type': '5073';
+      kode: '5073';
     } & tjenester_behandling_uttak_dto_FastsetteUttakDto_FastsetteUttakKontrollerRealitetsBehandlingEllerKlageDto)
   | ({
-      '@type': '5071';
+      kode: '5071';
     } & tjenester_behandling_uttak_dto_FastsetteUttakDto_FastsetteUttakPerioderDto)
   | ({
-      '@type': '5072';
+      kode: '5072';
     } & tjenester_behandling_uttak_dto_FastsetteUttakDto_FastsetteUttakStortingsrepresentantDto)
   | ({
-      '@type': '5103';
+      kode: '5103';
     } & tjenester_behandling_uttak_eøs_EøsUttakDto)
   | ({
-      '@type': '5066';
+      kode: '5066';
     } & tjenester_behandling_uttak_fakta_FaktaUttakDto_GraderingAktivitetUtenBGDto)
   | ({
-      '@type': '5063';
+      kode: '5063';
     } & tjenester_behandling_uttak_fakta_FaktaUttakDto_GraderingUkjentAktivitetDto)
   | ({
-      '@type': '5064';
+      kode: '5064';
     } & tjenester_behandling_uttak_fakta_FaktaUttakDto_IngenPerioderDto)
   | ({
-      '@type': '5065';
+      kode: '5065';
     } & tjenester_behandling_uttak_fakta_FaktaUttakDto_ManueltSattStartdatoDto)
   | ({
-      '@type': '5028';
+      kode: '5028';
     } & tjenester_behandling_vedtak_aksjonspunkt_ForeslaVedtakManueltAksjonspuntDto)
   | ({
-      '@type': '5015';
+      kode: '5015';
     } & tjenester_behandling_vedtak_aksjonspunkt_ForeslåVedtakAksjonspunktDto)
   | ({
-      '@type': '5033';
+      kode: '5033';
     } & tjenester_behandling_vedtak_aksjonspunkt_VurdereAnnenYteleseFørVedtakDto)
   | ({
-      '@type': '5034';
+      kode: '5034';
     } & tjenester_behandling_vedtak_aksjonspunkt_VurdereDokumentFørVedtakDto)
   | ({
-      '@type': '5003';
+      kode: '5003';
     } & tjenester_behandling_vedtak_aksjonspunkt_VurdereInntektsmeldingFørVedtakDto)
   | ({
-      '@type': '5061';
+      kode: '5061';
     } & tjenester_behandling_ytelsefordeling_BekreftFaktaForOmsorgVurderingDto)
   | ({
-      '@type': '5012';
+      kode: '5012';
     } & tjenester_registrering_es_ManuellRegistreringEngangsstonadDto)
   | ({
-      '@type': '5057';
+      kode: '5057';
     } & tjenester_registrering_fp_ManuellRegistreringEndringsøknadDto)
   | ({
-      '@type': '5040';
+      kode: '5040';
     } & tjenester_registrering_fp_ManuellRegistreringForeldrepengerDto)
   | ({
-      '@type': '5096';
+      kode: '5096';
     } & tjenester_registrering_svp_ManuellRegistreringSvangerskapspengerDto)
 ) & {
   begrunnelse?: string;
+  kode: string;
 };
 
 export type foreldrepenger_behandlingslager_behandling_aksjonspunkt_VurderÅrsak =
@@ -1628,7 +1629,7 @@ export type tjenester_behandling_svp_BekreftTilrettelegging = {
   stillingsprosentStartTilrettelegging?: number;
   tilretteleggingBehovFom: string;
   tilretteleggingDatoer: Array<tjenester_behandling_svp_SvpTilretteleggingDatoDto>;
-  tilretteleggingId: number;
+  tilretteleggingId?: number;
   uttakArbeidType?: foreldrepenger_behandlingslager_uttak_UttakArbeidType;
   velferdspermisjoner: Array<tjenester_behandling_svp_VelferdspermisjonDto>;
 };
@@ -2211,55 +2212,56 @@ export type tjenester_registrering_svp_SvpTilretteleggingVirksomhetDto = {
 
 export type foreldrepenger_behandling_aksjonspunkt_OverstyringAksjonspunktDto = (
   | ({
-      '@type': '6014';
+      kode: '6014';
     } & foreldrepenger_domene_rest_dto_OverstyrBeregningsaktiviteterDto)
   | ({
-      '@type': '6015';
+      kode: '6015';
     } & foreldrepenger_domene_rest_dto_OverstyrBeregningsgrunnlagDto)
   | ({
-      '@type': '6019';
+      kode: '6019';
     } & foreldrepenger_familiehendelse_aksjonspunkt_fødsel_dto_OverstyringFaktaOmFødselDto)
   | ({
-      '@type': '6016';
+      kode: '6016';
     } & tjenester_behandling_dekningsgrad_AvklarDekningsgradOverstyringDto)
   | ({
-      '@type': '6018';
+      kode: '6018';
     } & tjenester_behandling_uttak_dto_OverstyrOmsorgOgRettDto)
   | ({
-      '@type': '6008';
+      kode: '6008';
     } & tjenester_behandling_uttak_dto_OverstyringUttakDto)
   | ({
-      '@type': '6103';
+      kode: '6103';
     } & tjenester_behandling_uttak_eøs_OverstyringEøsUttakDto)
   | ({
-      '@type': '6065';
+      kode: '6065';
     } & tjenester_behandling_uttak_fakta_OverstyringFaktaUttakDto)
   | ({
-      '@type': '6017';
+      kode: '6017';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringForutgåendeMedlemskapsvilkårDto)
   | ({
-      '@type': '6003';
+      kode: '6003';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringFødselsvilkåretDto)
   | ({
-      '@type': '6009';
+      kode: '6009';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringFødselvilkåretFarMedmorDto)
   | ({
-      '@type': '6005';
+      kode: '6005';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringMedlemskapsvilkåretDto)
   | ({
-      '@type': '6011';
+      kode: '6011';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringOpptjeningsvilkåretDto)
   | ({
-      '@type': '6002';
+      kode: '6002';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringSokersOpplysingspliktDto)
   | ({
-      '@type': '6006';
+      kode: '6006';
     } & tjenester_behandling_vilkår_aksjonspunkt_dto_OverstyringSøknadsfristvilkåretDto)
   | ({
-      '@type': '6045';
+      kode: '6045';
     } & tjenester_behandling_ytelsefordeling_OverstyringAvklarStartdatoForPeriodenDto)
 ) & {
   begrunnelse?: string;
+  kode: string;
 };
 
 export type foreldrepenger_behandlingslager_behandling_ytelsefordeling_Rettighetstype =

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -110,6 +110,7 @@ export type {
   foreldrepenger_kontrakter_simulering_resultat_v1_SimuleringDto_SimuleringForMottakerDto as Mottaker,
   folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_fp_BesteberegningMånedGrunnlagDto as Månedsgrunnlag,
   foreldrepenger_domene_iay_modell_kodeverk_NaturalYtelseType as NaturalYtelseType,
+  foreldrepenger_domene_iay_modell_kodeverk_BekreftetPermisjonStatus as BekreftetPermisjonStatus,
   foreldrepenger_tilganger_InnloggetNavAnsattDto as NavAnsatt,
   foreldrepenger_behandlingslager_aktør_NavBrukerKjønn as NavBrukerKjønn,
   tjenester_behandling_ytelsefordeling_OmsorgOgRettDto as OmsorgOgRett,
@@ -191,4 +192,6 @@ export type {
   tjenester_behandling_dto_behandling_BehandlingsresultatDto as Behandlingsresultat,
   foreldrepenger_behandlingslager_behandling_KonsekvensForYtelsen as KonsekvensForYtelsen,
   foreldrepenger_behandlingslager_behandling_BehandlingResultatType as BehandlingResultatType,
+  foreldrepenger_behandling_aksjonspunkt_BekreftetAksjonspunktDto as BekreftetAksjonspunktDto,
+  foreldrepenger_behandling_aksjonspunkt_OverstyringAksjonspunktDto as OverstyringAksjonspunktDto,
 } from './fpsak.gen';


### PR DESCRIPTION
Erstatter alle manuelt definerte typer i `types-avklar-aksjonspunkter` med `Extract<BekreftetAksjonspunktDto | OverstyringAksjonspunktDto, { kode: K }>`.

## Endringer
- Skriver om `AksjonspunktTilBekreftelse` som Extract-utility
- Forenkler alle fakta/ og prosess/ typefiler til én-linjers aliaser
- Beholder UTGÅTT-typer (resolves til `never`)
- Fjerner ubrukte avhengigheter fra package.json
- Fikser consumer-kode (null→undefined, string→enum, typo sattPaVent→sattPåVent)
- Tilbakekreving-typer er uendret

## Verifisert
- `yarn tsc` — 81/81 pakker OK
- `yarn test` — 156/156 test-tasks OK
- `yarn eslint` (types-avklar-aksjonspunkter) — 0 feil