### PR TITLE
FAGSYSTEM-432772: la beslutter åpne automatisk vedtaksbrev når brevet er redigert

### DIFF
--- a/packages/prosess/vedtak/src/components/felles/VedtakFellesPanel.tsx
+++ b/packages/prosess/vedtak/src/components/felles/VedtakFellesPanel.tsx
@@ -133,7 +133,7 @@ export const VedtakFellesPanel = ({
           </Label>
         </div>
         <div className={styles['space']}>
-          {skalViseLink && harIkkeKonsekvensForYtelse && kanBehandles && !(isReadOnly && harRedigertBrev) && (
+          {skalViseLink && harIkkeKonsekvensForYtelse && kanBehandles && (
             <Link href="#" onClick={previewAutomatiskBrev}>
               <span>
                 <FormattedMessage
@@ -147,7 +147,7 @@ export const VedtakFellesPanel = ({
               <ArrowForwardIcon className={styles['pil']} />
             </Link>
           )}
-          {skalViseLink && harIkkeKonsekvensForYtelse && (!kanBehandles || (isReadOnly && harRedigertBrev)) && (
+          {skalViseLink && harIkkeKonsekvensForYtelse && !kanBehandles && (
             <BodyShort size="small" className={styles['disabletLink']}>
               <FormattedMessage
                 id={


### PR DESCRIPTION
https://jira.adeo.no/browse/FAGSYSTEM-432772

Regresjon fra #7331 deaktiverte lenken til automatisk vedtaksbrev for beslutter (read-only) når saksbehandler hadde redigert brevet. Beslutter fikk dermed ikke sammenlignet automatisk og korrigert vedtak. Tilbakestiller betingelsen slik at lenken igjen er klikkbar.