### PR TITLE
fix: gjør svangerskapsvilkår-panelet read-only uten åpent aksjonspunkt

### DIFF
--- a/apps/fp-frontend/src/behandling/felles/prosess/useStandardProsessPanelProps.ts
+++ b/apps/fp-frontend/src/behandling/felles/prosess/useStandardProsessPanelProps.ts
@@ -128,7 +128,7 @@ const getBekreftAksjonspunktProsessCallback =
     // matcher ingen eksisterende aksjonspunkt – men det gjør heller ikke et manuelt aksjonspunkt
     // som vises uten åpent aksjonspunkt. Kun overstyringskoder kan deserialiseres av overstyr-endepunktet.
     const erOverstyring =
-      models.some(model => model.kode.startsWith('6')) ||
+      apListe.some(ap => ap.kode.startsWith('6')) ||
       aksjonspunkterTilLagring.some(ap => ap.aksjonspunktType === 'OVST' || ap.aksjonspunktType === 'SAOV');
 
     if (apListe.length === 0) {
@@ -147,7 +147,7 @@ const getBekreftAksjonspunktProsessCallback =
     // her i stedet for å sende koden til overstyr-endepunktet og få en kryptisk Jackson-feil fra backend.
     if (aksjonspunkterTilLagring.length === 0) {
       throw new Error(
-        `Forsøk på å lagre aksjonspunkt ${models.map(model => model.kode).join(', ')} uten matchende aksjonspunkt i behandlingen og uten at det er en overstyring.`,
+        `Forsøk på å lagre aksjonspunkt ${apListe.map(ap => ap.kode).join(', ')} uten matchende aksjonspunkt i behandlingen og uten at det er en overstyring.`,
       );
     }
 

--- a/apps/fp-frontend/src/behandling/felles/prosess/useStandardProsessPanelProps.ts
+++ b/apps/fp-frontend/src/behandling/felles/prosess/useStandardProsessPanelProps.ts
@@ -123,19 +123,32 @@ const getBekreftAksjonspunktProsessCallback =
     const aksjonspunkterTilLagring = aksjonspunkter.filter(ap =>
       apListe.some(apModel => apModel.kode === ap.definisjon),
     );
-    const erOverstyringsaksjonspunkter = aksjonspunkterTilLagring.some(
-      ap => ap.aksjonspunktType === 'OVST' || ap.aksjonspunktType === 'SAOV',
-    );
+    // Rut til overstyr-endepunktet basert på faktisk aksjonspunktkode, ikke på fravær av matchende
+    // aksjonspunkt. Overstyringskoder (6xxx) finnes ikke i behandlingen før de opprettes, så de
+    // matcher ingen eksisterende aksjonspunkt – men det gjør heller ikke et manuelt aksjonspunkt
+    // som vises uten åpent aksjonspunkt. Kun overstyringskoder kan deserialiseres av overstyr-endepunktet.
+    const erOverstyring =
+      models.some(model => model.kode.startsWith('6')) ||
+      aksjonspunkterTilLagring.some(ap => ap.aksjonspunktType === 'OVST' || ap.aksjonspunktType === 'SAOV');
 
     if (apListe.length === 0) {
       throw new Error('Det har oppstått en teknisk feil ved lagring av aksjonspunkter. Meld feilen i Porten.');
     }
 
-    if (aksjonspunkterTilLagring.length === 0 || erOverstyringsaksjonspunkter) {
+    if (erOverstyring) {
       return lagreOverstyrteAksjonspunkter({
         ...params,
         overstyrteAksjonspunktDtoer: models,
       }).then(etterLagringCallback);
+    }
+
+    // Fail-fast: et aksjonspunkt uten matchende aksjonspunkt i behandlingen som ikke er en overstyring
+    // er en programmeringsfeil (f.eks. et panel som er redigerbart uten åpent aksjonspunkt). Feil tydelig
+    // her i stedet for å sende koden til overstyr-endepunktet og få en kryptisk Jackson-feil fra backend.
+    if (aksjonspunkterTilLagring.length === 0) {
+      throw new Error(
+        `Forsøk på å lagre aksjonspunkt ${models.map(model => model.kode).join(', ')} uten matchende aksjonspunkt i behandlingen og uten at det er en overstyring.`,
+      );
     }
 
     return lagreAksjonspunkter({

--- a/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/inngangsvilkarPaneler/SvangerskapInngangsvilkarInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/svangerskapspenger/prosessPaneler/inngangsvilkarPaneler/SvangerskapInngangsvilkarInitPanel.tsx
@@ -19,16 +19,25 @@ export const SvangerskapInngangsvilkarInitPanel = () => {
   const intl = useIntl();
   const standardPanelProps = useStandardProsessPanelProps(AKSJONSPUNKT_KODER, VILKAR_KODER);
 
-  const api = useBehandlingApi(standardPanelProps.behandling);
+  // Svangerskapspengervilkåret har ingen overstyrings-aksjonspunkt, kun manuell vurdering (5092).
+  // Når vilkåret er automatisk avgjort finnes ikke 5092-aksjonspunktet, og panelet må være read-only
+  // slik at en innsending ikke feilaktig rutes til overstyr-endepunktet (gir ugyldig type id 5092).
+  const harAksjonspunkt = standardPanelProps.aksjonspunkterForPanel.length > 0;
+  const panelProps = {
+    ...standardPanelProps,
+    isReadOnly: standardPanelProps.isReadOnly || !harAksjonspunkt,
+  };
+
+  const api = useBehandlingApi(panelProps.behandling);
 
   const { data: svangerskapspengerTilrettelegging } = useQuery(
-    api.svp.svangerskapspengerTilretteleggingOptions(standardPanelProps.behandling),
+    api.svp.svangerskapspengerTilretteleggingOptions(panelProps.behandling),
   );
 
   return (
     <InngangsvilkarDefaultInitPanel
       vilkårKoder={VILKAR_KODER}
-      standardPanelProps={standardPanelProps}
+      standardPanelProps={panelProps}
       inngangsvilkårPanelKode="SVANGERSKAP"
       hentInngangsvilkårPanelTekst={intl.formatMessage({ id: 'SvangerskapVilkarForm.FyllerVilkår' })}
     >
@@ -36,7 +45,7 @@ export const SvangerskapInngangsvilkarInitPanel = () => {
         {svangerskapspengerTilrettelegging && (
           <SvangerskapVilkarProsessIndex
             svangerskapspengerTilrettelegging={svangerskapspengerTilrettelegging}
-            status={standardPanelProps.status}
+            status={panelProps.status}
           />
         )}
         {!svangerskapspengerTilrettelegging && <LoadingPanel />}


### PR DESCRIPTION
Svangerskapspengervilkåret (SVP_VK_1) har kun et manuelt aksjonspunkt (5092 MANUELL_VURDERING_AV_SVANGERSKAPSPENGERVILKÅRET), ikke noe overstyrings-aksjonspunkt. Når vilkåret er automatisk avgjort finnes ikke 5092-aksjonspunktet, men panelet ble likevel vist redigerbart fordi backend melder vilkåret som overstyrbart for førstegangssøknader.

Ved innsending uten et matchende aksjonspunkt rutet getBekreftAksjonspunktProsessCallback til overstyr-endepunktet, som forsøkte å deserialisere @type 5092 som en OverstyringAksjonspunktDto. Det feilet med "Could not resolve type id '5092'" fordi 5092 er et MANUELL-aksjonspunkt og ikke har noen overstyringsvariant.

Gjør panelet read-only når 5092-aksjonspunktet mangler, slik at den ugyldige overstyr-innsendingen ikke kan oppstå.

https://nav-it.slack.com/archives/CEKQHNLLU/p1778844899983279