### PR TITLE
refactor: trekk ut buildInitialValues-funksjoner i skjema med transformValues

### DIFF
--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/UtvalgskriterierForSakslisteForm.tsx
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/UtvalgskriterierForSakslisteForm.tsx
@@ -59,7 +59,7 @@ export const UtvalgskriterierForSakslisteForm = ({ valgtSaksliste, valgtAvdeling
   const queryClient = useQueryClient();
 
   const formMethods = useForm<FormValues>({
-    defaultValues: buildDefaultValues(valgtSaksliste),
+    defaultValues: buildInitialValues(valgtSaksliste),
   });
 
   const { mutate: lagreSaksliste, isPending } = useMutation({
@@ -142,7 +142,17 @@ export const UtvalgskriterierForSakslisteForm = ({ valgtSaksliste, valgtAvdeling
   );
 };
 
-const buildDefaultValues = (valgtSaksliste: SakslisteDto): FormValues => {
+const fraAndreKriterierTilBeslutter = (andreKriterier?: AndreKriterieDto): TilBeslutter => {
+  if (andreKriterier?.inkluder.includes('TIL_BESLUTTER')) {
+    return 'TA_MED';
+  } else if (andreKriterier?.ekskluder.includes('TIL_BESLUTTER')) {
+    return 'FJERN';
+  } else {
+    return 'TA_MED_ALLE';
+  }
+};
+
+const buildInitialValues = (valgtSaksliste: SakslisteDto): FormValues => {
   return {
     navn: valgtSaksliste.navn,
     beskrivelse: valgtSaksliste.beskrivelse ?? '',
@@ -159,16 +169,6 @@ const buildDefaultValues = (valgtSaksliste: SakslisteDto): FormValues => {
     behandlingTyper: valgtSaksliste.behandlingTyper,
     fagsakYtelseTyper: valgtSaksliste.fagsakYtelseTyper,
   };
-};
-
-const fraAndreKriterierTilBeslutter = (andreKriterier?: AndreKriterieDto): TilBeslutter => {
-  if (andreKriterier?.inkluder.includes('TIL_BESLUTTER')) {
-    return 'TA_MED';
-  } else if (andreKriterier?.ekskluder.includes('TIL_BESLUTTER')) {
-    return 'FJERN';
-  } else {
-    return 'TA_MED_ALLE';
-  }
 };
 
 const transformValues = (values: FormValues, valgtAvdelingEnhet: string, sakslisteId: number): SakslisteLagreDto => {

--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/UtvalgskriterierForSakslisteForm.tsx
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/UtvalgskriterierForSakslisteForm.tsx
@@ -142,16 +142,6 @@ export const UtvalgskriterierForSakslisteForm = ({ valgtSaksliste, valgtAvdeling
   );
 };
 
-const fraAndreKriterierTilBeslutter = (andreKriterier?: AndreKriterieDto): TilBeslutter => {
-  if (andreKriterier?.inkluder.includes('TIL_BESLUTTER')) {
-    return 'TA_MED';
-  } else if (andreKriterier?.ekskluder.includes('TIL_BESLUTTER')) {
-    return 'FJERN';
-  } else {
-    return 'TA_MED_ALLE';
-  }
-};
-
 const buildInitialValues = (valgtSaksliste: SakslisteDto): FormValues => {
   return {
     navn: valgtSaksliste.navn,
@@ -169,6 +159,16 @@ const buildInitialValues = (valgtSaksliste: SakslisteDto): FormValues => {
     behandlingTyper: valgtSaksliste.behandlingTyper,
     fagsakYtelseTyper: valgtSaksliste.fagsakYtelseTyper,
   };
+};
+
+const fraAndreKriterierTilBeslutter = (andreKriterier?: AndreKriterieDto): TilBeslutter => {
+  if (andreKriterier?.inkluder.includes('TIL_BESLUTTER')) {
+    return 'TA_MED';
+  } else if (andreKriterier?.ekskluder.includes('TIL_BESLUTTER')) {
+    return 'FJERN';
+  } else {
+    return 'TA_MED_ALLE';
+  }
 };
 
 const transformValues = (values: FormValues, valgtAvdelingEnhet: string, sakslisteId: number): SakslisteLagreDto => {

--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/UtvalgskriterierForSakslisteForm.tsx
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/UtvalgskriterierForSakslisteForm.tsx
@@ -172,7 +172,7 @@ const buildInitialValues = (valgtSaksliste: SakslisteDto): FormValues => {
 };
 
 const transformValues = (values: FormValues, valgtAvdelingEnhet: string, sakslisteId: number): SakslisteLagreDto => {
-  const { tilBeslutter, andreKriterie, sortering, beskrivelse, ...rest } = values;
+  const { tilBeslutter, andreKriterie, sortering } = values;
   const inkluder = andreKriterie.inkluder.filter((t): t is AndreKriterierType => t !== 'TIL_BESLUTTER');
   const ekskluder = andreKriterie.ekskluder.filter((t): t is AndreKriterierType => t !== 'TIL_BESLUTTER');
   if (tilBeslutter === 'TA_MED') {
@@ -182,8 +182,10 @@ const transformValues = (values: FormValues, valgtAvdelingEnhet: string, sakslis
   }
 
   return {
-    ...rest,
-    beskrivelse: beskrivelse === '' ? undefined : beskrivelse,
+    beskrivelse: values.beskrivelse === '' ? undefined : values.beskrivelse,
+    navn: values.navn,
+    behandlingTyper: values.behandlingTyper,
+    fagsakYtelseTyper: values.fagsakYtelseTyper,
     andreKriterie: {
       inkluder,
       ekskluder,

--- a/packages/fakta/besteberegning/src/components/KontrollerBesteberegningPanel.tsx
+++ b/packages/fakta/besteberegning/src/components/KontrollerBesteberegningPanel.tsx
@@ -6,16 +6,15 @@ import { VStack } from '@navikt/ds-react';
 import { RhfCheckbox, RhfForm } from '@navikt/ft-form-hooks';
 import { AksjonspunktHelpTextHTML } from '@navikt/ft-ui-komponenter';
 
-import { FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
+import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import type { Aksjonspunkt } from '@navikt/fp-types';
 import type { BesteberegningAP, ManuellKontrollBesteberegningAP } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
 type FormValues = {
-  begrunnelse: string | undefined;
   besteberegningErKorrektValg?: boolean;
-};
+} & FaktaBegrunnelseFormValues;
 
 interface Props {
   aksjonspunkt: Aksjonspunkt;

--- a/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
+++ b/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
@@ -40,7 +40,7 @@ export const VurderMedlemskapAksjonspunktForm = ({ manuellBehandlingResultat }: 
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
 
   const formMethods = useForm<FormValues>({
-    defaultValues: mellomlagretFormData ?? createInitialValues(aksjonspunkterForPanel, manuellBehandlingResultat),
+    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel, manuellBehandlingResultat),
   });
 
   const begrunnelseVerdi = formMethods.watch('begrunnelse');
@@ -96,7 +96,7 @@ export const VurderMedlemskapAksjonspunktForm = ({ manuellBehandlingResultat }: 
   );
 };
 
-const createInitialValues = (
+const buildInitialValues = (
   aksjonspunkterForPanel: Aksjonspunkt[],
   resultat: ManuellBehandlingResultat | undefined,
 ): FormValues => {

--- a/packages/fakta/omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
@@ -6,7 +6,12 @@ import { RhfForm } from '@navikt/ft-form-hooks';
 import { FaktaGruppe } from '@navikt/ft-ui-komponenter';
 import { BTag } from '@navikt/ft-utils';
 
-import { FaktaBegrunnelseTextField, FaktaSubmitButton, TrueFalseInput } from '@navikt/fp-fakta-felles';
+import {
+  type FaktaBegrunnelseFormValues,
+  FaktaBegrunnelseTextField,
+  FaktaSubmitButton,
+  TrueFalseInput,
+} from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { type Aksjonspunkt, type OmsorgOgRett } from '@navikt/fp-types';
 import type { BekreftAleneomsorgVurderingAp } from '@navikt/fp-types-avklar-aksjonspunkter';
@@ -19,8 +24,7 @@ type FormValues = {
   harAnnenForelderRett?: boolean;
   mottarAnnenForelderUforetrygd?: boolean;
   harAnnenForelderRettEØS?: boolean;
-  begrunnelse: string;
-};
+} & FaktaBegrunnelseFormValues;
 
 interface Props {
   omsorgOgRett: OmsorgOgRett;

--- a/packages/fakta/omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { type DefaultValues, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { VStack } from '@navikt/ds-react';
@@ -31,22 +31,13 @@ interface Props {
 export const AleneomsorgForm = ({ omsorgOgRett, aksjonspunkt, isSubmittable }: Props) => {
   const { submitCallback, isReadOnly, alleMerknaderFraBeslutter } =
     usePanelDataContext<BekreftAleneomsorgVurderingAp>();
-  const harAleneomsorg = omsorgOgRett.manuellBehandlingResultat?.søkerHarAleneomsorg ?? undefined;
-  const harRettNorge = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettNorge ?? undefined;
-  const harRettEØS = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettEØS ?? undefined;
   const harUføretrygd = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harUføretrygd ?? undefined;
 
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
   const isReadOnlyOrApIsNull = isReadOnly || aksjonspunkt === undefined;
 
   const formMethods = useForm<FormValues>({
-    defaultValues: mellomlagretFormData ?? {
-      harAleneomsorg: harAleneomsorg === undefined ? undefined : harAleneomsorg === 'JA',
-      harAnnenForelderRett: harRettNorge === undefined ? undefined : harRettNorge === 'JA',
-      harAnnenForelderRettEØS: harRettEØS === undefined ? undefined : harRettEØS === 'JA',
-      mottarAnnenForelderUforetrygd: harUføretrygd === undefined ? undefined : harUføretrygd === 'JA',
-      ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
-    },
+    defaultValues: mellomlagretFormData ?? buildInitialValues(omsorgOgRett, aksjonspunkt),
   });
 
   const skalAvklareUforetrygd = omsorgOgRett.relasjonsRolleType !== 'MORA' || harUføretrygd === 'JA';
@@ -93,6 +84,20 @@ export const AleneomsorgForm = ({ omsorgOgRett, aksjonspunkt, isSubmittable }: P
       </FaktaGruppe>
     </RhfForm>
   );
+};
+
+const buildInitialValues = (omsorgOgRett: OmsorgOgRett, aksjonspunkt?: Aksjonspunkt): DefaultValues<FormValues> => {
+  const harAleneomsorg = omsorgOgRett.manuellBehandlingResultat?.søkerHarAleneomsorg ?? undefined;
+  const harRettNorge = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettNorge ?? undefined;
+  const harRettEØS = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettEØS ?? undefined;
+  const harUføretrygd = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harUføretrygd ?? undefined;
+  return {
+    harAleneomsorg: harAleneomsorg === undefined ? undefined : harAleneomsorg === 'JA',
+    harAnnenForelderRett: harRettNorge === undefined ? undefined : harRettNorge === 'JA',
+    harAnnenForelderRettEØS: harRettEØS === undefined ? undefined : harRettEØS === 'JA',
+    mottarAnnenForelderUforetrygd: harUføretrygd === undefined ? undefined : harUføretrygd === 'JA',
+    ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
+  };
 };
 
 const transformValues = (values: FormValues): BekreftAleneomsorgVurderingAp => ({

--- a/packages/fakta/omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { type DefaultValues, useForm } from 'react-hook-form';
 
 import { VStack } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
@@ -28,20 +28,13 @@ interface Props {
 export const HarAnnenForelderRettForm = ({ omsorgOgRett, aksjonspunkt, isSubmittable }: Props) => {
   const { submitCallback, isReadOnly, alleMerknaderFraBeslutter } = usePanelDataContext<AvklarAnnenforelderHarRettAp>();
 
-  const harRettNorge = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettNorge ?? undefined;
-  const harRettEØS = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettEØS ?? undefined;
   const harUføretrygd = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harUføretrygd ?? undefined;
 
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
   const readOnly = isReadOnly || aksjonspunkt === undefined;
 
   const formMethods = useForm<FormValues>({
-    defaultValues: mellomlagretFormData ?? {
-      harAnnenForelderRett: harRettNorge === undefined ? undefined : harRettNorge === 'JA',
-      mottarAnnenForelderUforetrygd: harUføretrygd === undefined ? undefined : harUføretrygd === 'JA',
-      harAnnenForelderRettEØS: harRettEØS === undefined ? undefined : harRettEØS === 'JA',
-      ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
-    },
+    defaultValues: mellomlagretFormData ?? buildInitialValues(omsorgOgRett, aksjonspunkt),
   });
 
   const skalAvklareUforetrygd = omsorgOgRett.relasjonsRolleType !== 'MORA' || harUføretrygd === 'JA';
@@ -76,6 +69,18 @@ export const HarAnnenForelderRettForm = ({ omsorgOgRett, aksjonspunkt, isSubmitt
       </FaktaGruppe>
     </RhfForm>
   );
+};
+
+const buildInitialValues = (omsorgOgRett: OmsorgOgRett, aksjonspunkt?: Aksjonspunkt): DefaultValues<FormValues> => {
+  const harRettNorge = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettNorge ?? undefined;
+  const harRettEØS = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harRettEØS ?? undefined;
+  const harUføretrygd = omsorgOgRett.manuellBehandlingResultat?.annenpartRettighet?.harUføretrygd ?? undefined;
+  return {
+    harAnnenForelderRett: harRettNorge === undefined ? undefined : harRettNorge === 'JA',
+    mottarAnnenForelderUforetrygd: harUføretrygd === undefined ? undefined : harUføretrygd === 'JA',
+    harAnnenForelderRettEØS: harRettEØS === undefined ? undefined : harRettEØS === 'JA',
+    ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
+  };
 };
 
 const transformValues = (values: FormValues): AvklarAnnenforelderHarRettAp => ({

--- a/packages/fakta/omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
@@ -4,9 +4,9 @@ import { VStack } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
 import { FaktaGruppe } from '@navikt/ft-ui-komponenter';
 
-import { FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
+import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import { type Aksjonspunkt, type OmsorgOgRett } from '@navikt/fp-types';
+import type { Aksjonspunkt, OmsorgOgRett } from '@navikt/fp-types';
 import type { AvklarAnnenforelderHarRettAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
@@ -16,8 +16,7 @@ type FormValues = {
   harAnnenForelderRett: boolean;
   mottarAnnenForelderUforetrygd?: boolean;
   harAnnenForelderRettEØS?: boolean;
-  begrunnelse: string;
-};
+} & FaktaBegrunnelseFormValues;
 
 interface Props {
   omsorgOgRett: OmsorgOgRett;

--- a/packages/fakta/omsorg-og-rett/src/components/forms/RettighetstypeForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/RettighetstypeForm.tsx
@@ -7,7 +7,7 @@ import { RhfForm, RhfSelect } from '@navikt/ft-form-hooks';
 import { required } from '@navikt/ft-form-validators';
 import { FaktaGruppe, OverstyringKnapp } from '@navikt/ft-ui-komponenter';
 
-import { FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
+import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { type Aksjonspunkt, type OmsorgOgRett, type Rettighetstype } from '@navikt/fp-types';
 import type { OverstyringRettigheterAp } from '@navikt/fp-types-avklar-aksjonspunkter';
@@ -17,8 +17,7 @@ import styles from './overstyrRettigheterForm.module.css';
 
 type FormValues = {
   rettighetstype: Rettighetstype;
-  begrunnelse: string;
-};
+} & FaktaBegrunnelseFormValues;
 
 interface Props {
   omsorgOgRett: OmsorgOgRett;

--- a/packages/fakta/omsorg-og-rett/src/components/forms/RettighetstypeForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/RettighetstypeForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { type DefaultValues, useForm } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { HStack, VStack } from '@navikt/ds-react';
@@ -39,13 +39,8 @@ export const RettighetstypeForm = ({ omsorgOgRett, aksjonspunkt, kanOverstyre }:
   const { submitCallback, alleMerknaderFraBeslutter, isReadOnly, isSubmittable } =
     usePanelDataContext<OverstyringRettigheterAp>();
 
-  const rettighetstype = omsorgOgRett.rettighetstype ?? undefined;
-
   const formMethods = useForm<FormValues>({
-    defaultValues: {
-      rettighetstype: rettighetstype,
-      ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
-    },
+    defaultValues: buildInitialValues(omsorgOgRett, aksjonspunkt),
   });
 
   const rettighetstyper =
@@ -99,6 +94,11 @@ export const RettighetstypeForm = ({ omsorgOgRett, aksjonspunkt, kanOverstyre }:
     </RhfForm>
   );
 };
+
+const buildInitialValues = (omsorgOgRett: OmsorgOgRett, aksjonspunkt?: Aksjonspunkt): DefaultValues<FormValues> => ({
+  rettighetstype: omsorgOgRett.rettighetstype ?? undefined,
+  ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
+});
 
 const transformValues = (values: FormValues): OverstyringRettigheterAp => ({
   kode: AksjonspunktKode.OVERSTYRING_AV_RETT_OG_OMSORG,

--- a/packages/fakta/omsorg/src/components/OmsorgInfoPanel.tsx
+++ b/packages/fakta/omsorg/src/components/OmsorgInfoPanel.tsx
@@ -19,18 +19,6 @@ import { type FormValues as OmsorgFormValues, OmsorgFaktaFields } from './Omsorg
 
 type FormValues = OmsorgFormValues & FaktaBegrunnelseFormValues;
 
-const createInitialValues = (ytelsefordeling: Ytelsefordeling, aksjonspunkter: Aksjonspunkt[]): FormValues => {
-  return {
-    ...OmsorgFaktaFields.initialValues(ytelsefordeling, aksjonspunkter),
-    ...FaktaBegrunnelseTextField.initialValues(aksjonspunkter),
-  };
-};
-
-const transformValues = (values: FormValues): BekreftOmsorgVurderingAp => ({
-  ...OmsorgFaktaFields.transformValues(values),
-  ...FaktaBegrunnelseTextField.transformValues(values),
-});
-
 interface Props {
   personoversikt: Personoversikt | undefined;
   ytelsefordeling: Ytelsefordeling;
@@ -50,7 +38,7 @@ export const OmsorgInfoPanel = ({ personoversikt, ytelsefordeling }: Props) => {
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
 
   const formMethods = useForm<FormValues>({
-    defaultValues: mellomlagretFormData ?? createInitialValues(ytelsefordeling, aksjonspunkterForPanel),
+    defaultValues: mellomlagretFormData ?? buildInitialValues(ytelsefordeling, aksjonspunkterForPanel),
   });
 
   const harAksjonspunkt = aksjonspunkterForPanel.length > 0;
@@ -91,3 +79,15 @@ export const OmsorgInfoPanel = ({ personoversikt, ytelsefordeling }: Props) => {
     </VStack>
   );
 };
+
+const buildInitialValues = (ytelsefordeling: Ytelsefordeling, aksjonspunkter: Aksjonspunkt[]): FormValues => {
+  return {
+    ...OmsorgFaktaFields.initialValues(ytelsefordeling, aksjonspunkter),
+    ...FaktaBegrunnelseTextField.initialValues(aksjonspunkter),
+  };
+};
+
+const transformValues = (values: FormValues): BekreftOmsorgVurderingAp => ({
+  ...OmsorgFaktaFields.transformValues(values),
+  ...FaktaBegrunnelseTextField.transformValues(values),
+});

--- a/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
+++ b/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
@@ -37,10 +37,7 @@ export const InnhentDokOpptjeningUtlandAP = ({ aksjonspunkt, dokStatus }: Props)
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
 
   const formMethods = useForm<FormValues>({
-    defaultValues: mellomlagretFormData ?? {
-      dokStatus,
-      ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
-    },
+    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkt, dokStatus),
   });
 
   const begrunnelse = formMethods.watch('begrunnelse');
@@ -95,6 +92,11 @@ export const InnhentDokOpptjeningUtlandAP = ({ aksjonspunkt, dokStatus }: Props)
     </AksjonspunktBox>
   );
 };
+
+const buildInitialValues = (aksjonspunkt: Aksjonspunkt, dokStatus?: string): FormValues => ({
+  dokStatus,
+  ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
+});
 
 const transformValues = (values: FormValues): MerkOpptjeningUtlandAp => ({
   kode: AksjonspunktKode.AUTOMATISK_MARKERING_AV_UTENLANDSSAK,

--- a/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
+++ b/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
@@ -7,7 +7,7 @@ import { required } from '@navikt/ft-form-validators';
 import { AksjonspunktBox } from '@navikt/ft-ui-komponenter';
 import { BTag } from '@navikt/ft-utils';
 
-import { FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
+import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import type { Aksjonspunkt } from '@navikt/fp-types';
 import type { MerkOpptjeningUtlandAp } from '@navikt/fp-types-avklar-aksjonspunkter';
@@ -19,9 +19,8 @@ const OpptjeningIUtlandDokStatus = {
 };
 
 type FormValues = {
-  begrunnelse: string | undefined;
   dokStatus?: string;
-};
+} & FaktaBegrunnelseFormValues;
 
 interface Props {
   aksjonspunkt: Aksjonspunkt;

--- a/packages/fakta/saken/src/components/dekningsgrad/DekningradAP.tsx
+++ b/packages/fakta/saken/src/components/dekningsgrad/DekningradAP.tsx
@@ -6,18 +6,17 @@ import { RhfForm, RhfRadioGroup } from '@navikt/ft-form-hooks';
 import { required } from '@navikt/ft-form-validators';
 import { AksjonspunktBox } from '@navikt/ft-ui-komponenter';
 
-import { FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
+import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import type { Aksjonspunkt, Ytelsefordeling } from '@navikt/fp-types';
 import type { AvklarDekningsgradAp } from '@navikt/fp-types-avklar-aksjonspunkter';
-import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
+import { notEmpty, useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
 import { DekningsgradVisning } from './DekningsgradVisning';
 
 type FormValues = {
-  dekningsgrad: number;
-  begrunnelse: string | undefined;
-};
+  dekningsgrad: number | undefined;
+} & FaktaBegrunnelseFormValues;
 
 interface Props {
   ytelseFordeling: Ytelsefordeling;
@@ -112,11 +111,12 @@ export const DekningradAP = ({ ytelseFordeling, aksjonspunkt }: Props) => {
 };
 
 const buildInitialValues = (ytelseFordeling: Ytelsefordeling, aksjonspunkt: Aksjonspunkt): FormValues => ({
-  dekningsgrad: ytelseFordeling.dekningsgrader.avklartDekningsgrad as number,
+  dekningsgrad: ytelseFordeling.dekningsgrader.avklartDekningsgrad,
   ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
 });
 
 const transformValues = (values: FormValues): AvklarDekningsgradAp => ({
   kode: AksjonspunktKode.AVKLAR_DEKNINGSGRAD,
-  ...values,
+  dekningsgrad: notEmpty(values.dekningsgrad),
+  ...FaktaBegrunnelseTextField.transformValues(values),
 });

--- a/packages/fakta/saken/src/components/dekningsgrad/DekningradAP.tsx
+++ b/packages/fakta/saken/src/components/dekningsgrad/DekningradAP.tsx
@@ -16,7 +16,7 @@ import { DekningsgradVisning } from './DekningsgradVisning';
 
 type FormValues = {
   dekningsgrad: number;
-  begrunnelse: string;
+  begrunnelse: string | undefined;
 };
 
 interface Props {
@@ -33,10 +33,7 @@ export const DekningradAP = ({ ytelseFordeling, aksjonspunkt }: Props) => {
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
 
   const formMethods = useForm<FormValues>({
-    defaultValues: mellomlagretFormData ?? {
-      dekningsgrad: ytelseFordeling.dekningsgrader.avklartDekningsgrad ?? undefined,
-      ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
-    },
+    defaultValues: mellomlagretFormData ?? buildInitialValues(ytelseFordeling, aksjonspunkt),
   });
 
   const begrunnelse = formMethods.watch('begrunnelse');
@@ -113,6 +110,11 @@ export const DekningradAP = ({ ytelseFordeling, aksjonspunkt }: Props) => {
     </AksjonspunktBox>
   );
 };
+
+const buildInitialValues = (ytelseFordeling: Ytelsefordeling, aksjonspunkt: Aksjonspunkt): FormValues => ({
+  dekningsgrad: ytelseFordeling.dekningsgrader.avklartDekningsgrad as number,
+  ...FaktaBegrunnelseTextField.initialValues(aksjonspunkt),
+});
 
 const transformValues = (values: FormValues): AvklarDekningsgradAp => ({
   kode: AksjonspunktKode.AVKLAR_DEKNINGSGRAD,

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaDetailForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaDetailForm.tsx
@@ -205,17 +205,19 @@ const validerTomEtterFom = (intl: IntlShape, getValues: UseFormGetValues<FormVal
   dayjs(tom).isBefore(getValues('fom')) ? intl.formatMessage({ id: 'UttakEøsFaktaDetailForm.TomForFom' }) : null;
 
 const buildInitialValues = (annenForelderUttakEøsPeriode: AnnenforelderUttakEøsPeriode): FormValues => ({
-  ...annenForelderUttakEøsPeriode,
+  fom: annenForelderUttakEøsPeriode.fom,
+  tom: annenForelderUttakEøsPeriode.tom,
+  trekkonto: annenForelderUttakEøsPeriode.trekkonto,
   trekkdager: finnDager(annenForelderUttakEøsPeriode.trekkdager),
   trekkuker: finnUker(annenForelderUttakEøsPeriode.trekkdager),
 });
 
-const transformValues = ({ trekkdager, trekkuker, ...rest }: FormValues): AnnenforelderUttakEøsPeriode => {
-  return {
-    ...rest,
-    trekkdager: Number((Number.parseFloat(trekkuker) * 5 + Number.parseFloat(trekkdager)).toFixed(1)),
-  };
-};
+const transformValues = (values: FormValues): AnnenforelderUttakEøsPeriode => ({
+  fom: values.fom,
+  tom: values.tom,
+  trekkonto: values.trekkonto,
+  trekkdager: Number((Number.parseFloat(values.trekkuker) * 5 + Number.parseFloat(values.trekkdager)).toFixed(1)),
+});
 
 export const finnTrekkkonto = (trekkontoKode: UttakPeriodeType, alleKodeverk: AlleKodeverk): string => {
   return alleKodeverk['UttakPeriodeType'].find(k => k.kode === trekkontoKode)?.navn ?? trekkontoKode;

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaDetailForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaDetailForm.tsx
@@ -42,13 +42,7 @@ export const UttakEøsFaktaDetailForm = ({ annenForelderUttakEøsPeriode, oppdat
   const { isReadOnly, fagsak, alleKodeverk } = usePanelDataContext<BekreftUttaksperioderAp[]>();
 
   const formMethods = useForm<FormValues>({
-    defaultValues: annenForelderUttakEøsPeriode
-      ? {
-          ...annenForelderUttakEøsPeriode,
-          trekkdager: finnDager(annenForelderUttakEøsPeriode.trekkdager),
-          trekkuker: finnUker(annenForelderUttakEøsPeriode.trekkdager),
-        }
-      : undefined,
+    defaultValues: annenForelderUttakEøsPeriode ? buildInitialValues(annenForelderUttakEøsPeriode) : undefined,
   });
 
   const fom = formMethods.watch('fom');
@@ -209,6 +203,12 @@ const lagGyldigeKontotyperOption = (fagsak: Fagsak, alleKodeverk: AlleKodeverk):
 
 const validerTomEtterFom = (intl: IntlShape, getValues: UseFormGetValues<FormValues>) => (tom?: string) =>
   dayjs(tom).isBefore(getValues('fom')) ? intl.formatMessage({ id: 'UttakEøsFaktaDetailForm.TomForFom' }) : null;
+
+const buildInitialValues = (annenForelderUttakEøsPeriode: AnnenforelderUttakEøsPeriode): FormValues => ({
+  ...annenForelderUttakEøsPeriode,
+  trekkdager: finnDager(annenForelderUttakEøsPeriode.trekkdager),
+  trekkuker: finnUker(annenForelderUttakEøsPeriode.trekkdager),
+});
 
 const transformValues = ({ trekkdager, trekkuker, ...rest }: FormValues): AnnenforelderUttakEøsPeriode => {
   return {

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -10,7 +10,7 @@ import dayjs from 'dayjs';
 
 import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { AnnenforelderUttakEøsPeriode } from '@navikt/fp-types';
+import type { Aksjonspunkt, AnnenforelderUttakEøsPeriode } from '@navikt/fp-types';
 import type { BekreftAnnenpartsUttakEøsAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
@@ -42,9 +42,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
   const [isDirty, setIsDirty] = useState(false);
 
   const formMethods = useForm<FaktaBegrunnelseFormValues>({
-    defaultValues: mellomlagretFormData
-      ? { begrunnelse: mellomlagretFormData.begrunnelse }
-      : FaktaBegrunnelseTextField.initialValues(aksjonspunkterForPanel[0]),
+    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel[0]),
   });
 
   const automatiskeAksjonspunkter = aksjonspunkterForPanel.filter(
@@ -127,6 +125,9 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
     </VStack>
   );
 };
+
+const buildInitialValues = (aksjonspunkt?: Aksjonspunkt): FaktaBegrunnelseFormValues =>
+  FaktaBegrunnelseTextField.initialValues(aksjonspunkt);
 
 const transformValues = (
   values: FaktaBegrunnelseFormValues,

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -42,7 +42,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
   const [isDirty, setIsDirty] = useState(false);
 
   const formMethods = useForm<FaktaBegrunnelseFormValues>({
-    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel[0]),
+    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel),
   });
 
   const automatiskeAksjonspunkter = aksjonspunkterForPanel.filter(
@@ -126,8 +126,8 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
   );
 };
 
-const buildInitialValues = (aksjonspunkt?: Aksjonspunkt): FaktaBegrunnelseFormValues =>
-  FaktaBegrunnelseTextField.initialValues(aksjonspunkt);
+const buildInitialValues = (aksjonspunkter: Aksjonspunkt[]): FaktaBegrunnelseFormValues =>
+  FaktaBegrunnelseTextField.initialValues(aksjonspunkter);
 
 const transformValues = (
   values: FaktaBegrunnelseFormValues,

--- a/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
@@ -57,48 +57,6 @@ export const utledÅrsakstype = (valgtPeriode: KontrollerFaktaPeriodeMedApMarker
   return Årsakstype.UTTAK;
 };
 
-const lagDefaultVerdier = (
-  valgtPeriode: KontrollerFaktaPeriodeMedApMarkering,
-  arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId,
-): FormValues => {
-  const arsakstype = utledÅrsakstype(valgtPeriode);
-
-  const aRef =
-    valgtPeriode.arbeidsforhold?.arbeidsgiverReferanse === 'undefined'
-      ? undefined
-      : valgtPeriode.arbeidsforhold?.arbeidsgiverReferanse;
-  const aOpplysninger = aRef ? arbeidsgiverOpplysningerPerId[aRef] : undefined;
-
-  let arbeidsgiverId;
-
-  if ((!!aRef && aOpplysninger) || (valgtPeriode.arbeidsforhold && !aRef)) {
-    arbeidsgiverId = `${valgtPeriode.arbeidsforhold?.arbeidsgiverReferanse}-${valgtPeriode.arbeidsforhold?.arbeidType}`;
-  }
-
-  return {
-    ...valgtPeriode,
-    arsakstype,
-    arbeidsgiverId,
-    harGradering: !!valgtPeriode.arbeidstidsprosent,
-    harSamtidigUttaksprosent: !!valgtPeriode.samtidigUttaksprosent,
-  };
-};
-
-const transformValues = (values: FormValues): KontrollerFaktaPeriodeMedApMarkering => ({
-  ...omitMany(values, ['arsakstype', 'arbeidsgiverId', 'harGradering', 'harSamtidigUttaksprosent']),
-  arbeidsforhold: values.arbeidsgiverId
-    ? {
-        arbeidsgiverReferanse:
-          values.arbeidsgiverId.split('-')[0] === 'undefined' ? undefined : values.arbeidsgiverId.split('-')[0],
-        arbeidType: values.arbeidsgiverId.split('-')[1] as UttakArbeidType,
-      }
-    : undefined,
-  periodeKilde: 'SAKSBEHANDLER',
-  aksjonspunktType: undefined,
-  arbeidstidsprosent: values.arbeidstidsprosent,
-  samtidigUttaksprosent: values.samtidigUttaksprosent,
-});
-
 const validerTomEtterFom = (intl: IntlShape, getValues: UseFormGetValues<FormValues>) => (tom?: string) =>
   dayjs(tom).isBefore(getValues('fom')) ? intl.formatMessage({ id: 'UttakFaktaDetailForm.TomForFom' }) : null;
 
@@ -129,7 +87,7 @@ export const UttakFaktaDetailForm = ({
 }: Props) => {
   const intl = useIntl();
 
-  const defaultValues = valgtPeriode ? lagDefaultVerdier(valgtPeriode, arbeidsgiverOpplysningerPerId) : undefined;
+  const defaultValues = valgtPeriode ? buildInitialValues(valgtPeriode, arbeidsgiverOpplysningerPerId) : undefined;
 
   const formMethods = useForm<FormValues>({
     defaultValues,
@@ -391,3 +349,45 @@ export const UttakFaktaDetailForm = ({
     </>
   );
 };
+
+const buildInitialValues = (
+  valgtPeriode: KontrollerFaktaPeriodeMedApMarkering,
+  arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId,
+): FormValues => {
+  const arsakstype = utledÅrsakstype(valgtPeriode);
+
+  const aRef =
+    valgtPeriode.arbeidsforhold?.arbeidsgiverReferanse === 'undefined'
+      ? undefined
+      : valgtPeriode.arbeidsforhold?.arbeidsgiverReferanse;
+  const aOpplysninger = aRef ? arbeidsgiverOpplysningerPerId[aRef] : undefined;
+
+  let arbeidsgiverId;
+
+  if ((!!aRef && aOpplysninger) || (valgtPeriode.arbeidsforhold && !aRef)) {
+    arbeidsgiverId = `${valgtPeriode.arbeidsforhold?.arbeidsgiverReferanse}-${valgtPeriode.arbeidsforhold?.arbeidType}`;
+  }
+
+  return {
+    ...valgtPeriode,
+    arsakstype,
+    arbeidsgiverId,
+    harGradering: !!valgtPeriode.arbeidstidsprosent,
+    harSamtidigUttaksprosent: !!valgtPeriode.samtidigUttaksprosent,
+  };
+};
+
+const transformValues = (values: FormValues): KontrollerFaktaPeriodeMedApMarkering => ({
+  ...omitMany(values, ['arsakstype', 'arbeidsgiverId', 'harGradering', 'harSamtidigUttaksprosent']),
+  arbeidsforhold: values.arbeidsgiverId
+    ? {
+        arbeidsgiverReferanse:
+          values.arbeidsgiverId.split('-')[0] === 'undefined' ? undefined : values.arbeidsgiverId.split('-')[0],
+        arbeidType: values.arbeidsgiverId.split('-')[1] as UttakArbeidType,
+      }
+    : undefined,
+  periodeKilde: 'SAKSBEHANDLER',
+  aksjonspunktType: undefined,
+  arbeidstidsprosent: values.arbeidstidsprosent,
+  samtidigUttaksprosent: values.samtidigUttaksprosent,
+});

--- a/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
@@ -189,11 +189,7 @@ export const UttakFaktaForm = ({
   const [valgteFomDatoer, setValgteFomDatoer] = useState<string[]>([]);
 
   const formMethods = useForm<FaktaBegrunnelseFormValues>({
-    defaultValues: {
-      begrunnelse:
-        mellomlagretFormData?.begrunnelse ??
-        FaktaBegrunnelseTextField.initialValues(aksjonspunkterForPanel).begrunnelse,
-    },
+    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel),
   });
 
   useEffect(
@@ -290,6 +286,9 @@ export const UttakFaktaForm = ({
     </VStack>
   );
 };
+
+const buildInitialValues = (aksjonspunkter: Aksjonspunkt[]): FaktaBegrunnelseFormValues =>
+  FaktaBegrunnelseTextField.initialValues(aksjonspunkter);
 
 const transformValues = (
   values: FaktaBegrunnelseFormValues,

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -51,13 +51,6 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel),
   });
 
-  useEffect(
-    () => () => {
-      setMellomlagretFormData({ dokBehov, begrunnelse: formMethods.getValues('begrunnelse') });
-    },
-    [],
-  );
-
   const begrunnelse = formMethods.watch('begrunnelse');
 
   const isSubmittable = submittable && dokBehov.every(a => a.vurdering) && !!begrunnelse;
@@ -77,7 +70,11 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
         setDirty={setIsDirty}
         readOnly={readOnly}
       />
-      <RhfForm formMethods={formMethods} onSubmit={values => bekreft(values)}>
+      <RhfForm
+        formMethods={formMethods}
+        setDataOnUnmount={(values: FaktaBegrunnelseFormValues) => setMellomlagretFormData({ ...values, dokBehov })}
+        onSubmit={values => bekreft(values)}
+      >
         <VStack gap="space-16">
           <FaktaBegrunnelseTextField
             control={formMethods.control}

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
@@ -8,7 +8,7 @@ import { AksjonspunktHelpTextHTML } from '@navikt/ft-ui-komponenter';
 
 import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
-import type { DokumentasjonVurderingBehov } from '@navikt/fp-types';
+import type { Aksjonspunkt, DokumentasjonVurderingBehov } from '@navikt/fp-types';
 import type { VurderDokumentasjonAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
@@ -48,11 +48,7 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
   };
 
   const formMethods = useForm<FaktaBegrunnelseFormValues>({
-    defaultValues: {
-      begrunnelse:
-        mellomlagretFormData?.begrunnelse ??
-        FaktaBegrunnelseTextField.initialValues(aksjonspunkterForPanel).begrunnelse,
-    },
+    defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel),
   });
 
   useEffect(
@@ -107,6 +103,9 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
     </VStack>
   );
 };
+
+const buildInitialValues = (aksjonspunkter: Aksjonspunkt[]): FaktaBegrunnelseFormValues =>
+  FaktaBegrunnelseTextField.initialValues(aksjonspunkter);
 
 const transformValues = (
   values: FaktaBegrunnelseFormValues,

--- a/packages/prosess/innsyn/src/components/InnsynForm.tsx
+++ b/packages/prosess/innsyn/src/components/InnsynForm.tsx
@@ -27,35 +27,12 @@ const hentDokumenterMedNavnOgFikkInnsyn = (dokumenter: InnsynDokument[]): Record
     };
   }, {});
 
-const getDefaultValues = (
-  aksjonspunkter: Aksjonspunkt[],
-  fristBehandlingPåVent?: string,
-  innsyn?: Innsyn,
-): InnsynFormValues => ({
-  mottattDato: innsyn?.innsynMottattDato,
-  innsynResultatType: innsyn?.innsynResultatType,
-  fristDato: fristBehandlingPåVent ?? dayjs().add(3, 'days').format(ISO_DATE_FORMAT),
-  sattPaVent: aksjonspunkter[0]?.status === 'OPPR' ? undefined : !!fristBehandlingPåVent,
-  ...ProsessStegBegrunnelseTextField.buildInitialValues(aksjonspunkter),
-  ...hentDokumenterMedNavnOgFikkInnsyn(innsyn?.dokumenter ?? []),
-});
-
 const getDocumentsStatus = (values: InnsynFormValues, documents: Dokument[]) =>
   documents.map(document => ({
     dokumentId: document.dokumentId,
     journalpostId: document.journalpostId,
     fikkInnsyn: !!values[`dokument_${document.dokumentId}`],
   }));
-
-const transformValues = (values: InnsynFormValues, documents: Dokument[]): VurderInnsynAp => ({
-  kode: AksjonspunktKode.VURDER_INNSYN,
-  innsynDokumenter: getDocumentsStatus(values, documents),
-  mottattDato: notEmpty(values.mottattDato),
-  innsynResultatType: notEmpty(values.innsynResultatType),
-  fristDato: values.fristDato,
-  sattPaVent: values.sattPaVent,
-  begrunnelse: values.begrunnelse,
-});
 
 // Samme dokument kan ligge på flere behandlinger under samme fagsak.
 const getFilteredReceivedDocuments = (allDocuments: Dokument[]): Dokument[] => {
@@ -84,12 +61,11 @@ export const InnsynForm = ({ innsyn, alleDokumenter = [] }: Props) => {
   const { fagsak, alleKodeverk, isSubmittable, aksjonspunkterForPanel, submitCallback, isReadOnly, behandling } =
     usePanelDataContext<VurderInnsynAp>();
 
-  const defaultValues = getDefaultValues(aksjonspunkterForPanel, behandling.fristBehandlingPåVent, innsyn);
-
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<InnsynFormValues>();
 
   const formMethods = useForm<InnsynFormValues>({
-    defaultValues: mellomlagretFormData ?? defaultValues,
+    defaultValues:
+      mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel, behandling.fristBehandlingPåVent, innsyn),
   });
 
   const documents = getFilteredReceivedDocuments(alleDokumenter);
@@ -194,3 +170,26 @@ export const InnsynForm = ({ innsyn, alleDokumenter = [] }: Props) => {
     </RhfForm>
   );
 };
+
+const buildInitialValues = (
+  aksjonspunkter: Aksjonspunkt[],
+  fristBehandlingPåVent?: string,
+  innsyn?: Innsyn,
+): InnsynFormValues => ({
+  mottattDato: innsyn?.innsynMottattDato,
+  innsynResultatType: innsyn?.innsynResultatType,
+  fristDato: fristBehandlingPåVent ?? dayjs().add(3, 'days').format(ISO_DATE_FORMAT),
+  sattPaVent: aksjonspunkter[0]?.status === 'OPPR' ? undefined : !!fristBehandlingPåVent,
+  ...ProsessStegBegrunnelseTextField.buildInitialValues(aksjonspunkter),
+  ...hentDokumenterMedNavnOgFikkInnsyn(innsyn?.dokumenter ?? []),
+});
+
+const transformValues = (values: InnsynFormValues, documents: Dokument[]): VurderInnsynAp => ({
+  kode: AksjonspunktKode.VURDER_INNSYN,
+  innsynDokumenter: getDocumentsStatus(values, documents),
+  mottattDato: notEmpty(values.mottattDato),
+  innsynResultatType: notEmpty(values.innsynResultatType),
+  fristDato: values.fristDato,
+  sattPaVent: values.sattPaVent,
+  begrunnelse: values.begrunnelse,
+});

--- a/packages/prosess/klagevurdering/src/KlagevurderingProsessIndex.tsx
+++ b/packages/prosess/klagevurdering/src/KlagevurderingProsessIndex.tsx
@@ -1,6 +1,6 @@
 import { RawIntlProvider } from 'react-intl';
 
-import { createIntl } from '@navikt/ft-utils';
+import { createIntl, hasAksjonspunkt } from '@navikt/ft-utils';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import type { KlageVurdering } from '@navikt/fp-types';
@@ -25,12 +25,12 @@ export const KlagevurderingProsessIndex = ({ klageVurdering, saveKlage, previewC
   return (
     <RawIntlProvider value={intl}>
       {klageVurdering.klageVurderingResultatNK && <BehandleKlageFormKa klageVurdering={klageVurdering} />}
-      {aksjonspunkterForPanel.some(a => a.definisjon === AksjonspunktKode.MANUELL_VURDERING_AV_KLAGE_NFP) && (
+      {hasAksjonspunkt(AksjonspunktKode.MANUELL_VURDERING_AV_KLAGE_NFP, aksjonspunkterForPanel) && (
         <BehandleKlageFormNfp
           klageVurdering={klageVurdering}
           saveKlage={saveKlage}
           previewCallback={previewCallback}
-          alleAktuelleHjemler={klageVurdering.aktuelleHjemler ? klageVurdering.aktuelleHjemler : []}
+          alleAktuelleHjemler={klageVurdering.aktuelleHjemler ?? []}
         />
       )}
     </RawIntlProvider>

--- a/packages/prosess/klagevurdering/src/components/ka/BehandleKlageFormKa.tsx
+++ b/packages/prosess/klagevurdering/src/components/ka/BehandleKlageFormKa.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { BodyShort, Heading, Label, VStack } from '@navikt/ds-react';
 
@@ -15,8 +15,6 @@ interface Props {
  * Setter opp readonly-panel for behandling av klage (KA).
  */
 export const BehandleKlageFormKa = ({ klageVurdering }: Props) => {
-  const intl = useIntl();
-
   const { alleKodeverk } = usePanelDataContext();
 
   const {
@@ -32,7 +30,7 @@ export const BehandleKlageFormKa = ({ klageVurdering }: Props) => {
   return (
     <VStack gap="space-16">
       <Heading size="small" level="2">
-        {intl.formatMessage({ id: 'Klage.ResolveKlage.Title' })}
+        <FormattedMessage id="Klage.ResolveKlage.Title" />
       </Heading>
       <VStack gap="space-4">
         <Label size="small">

--- a/packages/prosess/klagevurdering/src/components/nfp/BehandleKlageFormNfp.tsx
+++ b/packages/prosess/klagevurdering/src/components/nfp/BehandleKlageFormNfp.tsx
@@ -19,7 +19,7 @@ import type {
 import type { KlageVurderingResultatAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 import { notEmpty, useMellomlagretFormData, usePanelDataContext } from '@navikt/fp-utils';
 
-import type { KlageFormType } from '../../types/klageFormType';
+import type { FormValues } from '../../types/FormValues';
 import { BekreftOgSubmitKlageModal } from './BekreftOgSubmitKlageModal';
 import { FritekstBrevTextField } from './FritekstKlageBrevTextField';
 import { KlageVurderingRadioOptionsNfp } from './KlageVurderingRadioOptionsNfp';
@@ -35,7 +35,7 @@ export type TransformedValues = {
   klageVurdering: KlageVurderingType;
 };
 
-const transformValues = (values: KlageFormType): KlageVurderingResultatAp => ({
+const transformValues = (values: FormValues): KlageVurderingResultatAp => ({
   klageMedholdÅrsak: values.klageVurdering === 'MEDHOLD_I_KLAGE' ? values.klageMedholdÅrsak : undefined,
   klageVurderingOmgjør: values.klageVurdering === 'MEDHOLD_I_KLAGE' ? values.klageVurderingOmgjør : undefined,
   klageHjemmel: values.klageHjemmel,
@@ -59,7 +59,7 @@ const lagHjemlerMedNavn = (
   kodeverkNavn.filter(({ kode }) => kodeverkVerdier.includes(kode)).sort((a, b) => a.kode.localeCompare(b.kode));
 const lagHjemmelsKoder = (kodeverkVerdier: string[]): string[] => kodeverkVerdier.map(kode => kode);
 
-const buildInitialValues = (klageVurderingResultat?: KlageVurderingResultat): KlageFormType => ({
+const buildInitialValues = (klageVurderingResultat?: KlageVurderingResultat): FormValues => ({
   klageMedholdÅrsak: definertKodeverdiEllerUndefined(klageVurderingResultat?.klageMedholdÅrsak ?? undefined),
   klageVurderingOmgjør: definertKodeverdiEllerUndefined(klageVurderingResultat?.klageVurderingOmgjør ?? undefined),
   klageHjemmel: definertKodeverdiEllerUndefined(klageVurderingResultat?.klageHjemmel ?? undefined),
@@ -88,12 +88,10 @@ export const BehandleKlageFormNfp = ({ klageVurdering, previewCallback, saveKlag
   const intl = useIntl();
   const [visSubmitModal, setVisSubmitModal] = useState<boolean>(false);
 
-  const defaultValues = buildInitialValues(klageVurdering.klageVurderingResultatNFP ?? undefined);
+  const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
 
-  const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<KlageFormType>();
-
-  const formMethods = useForm<KlageFormType>({
-    defaultValues: mellomlagretFormData ?? defaultValues,
+  const formMethods = useForm<FormValues>({
+    defaultValues: mellomlagretFormData ?? buildInitialValues(klageVurdering.klageVurderingResultatNFP),
   });
   const formValues = formMethods.watch();
 
@@ -109,7 +107,7 @@ export const BehandleKlageFormNfp = ({ klageVurdering, previewCallback, saveKlag
     <RhfForm formMethods={formMethods} setDataOnUnmount={setMellomlagretFormData}>
       <VStack gap="space-16">
         <Heading size="small" level="2">
-          {intl.formatMessage({ id: 'Klage.ResolveKlage.Title' })}
+          <FormattedMessage id="Klage.ResolveKlage.Title" />
         </Heading>
         {isSubmittable && (
           <AksjonspunktHelpTextHTML>
@@ -170,7 +168,7 @@ export const BehandleKlageFormNfp = ({ klageVurdering, previewCallback, saveKlag
             <Button
               size="small"
               variant="primary"
-              onClick={formMethods.handleSubmit((values: KlageFormType) =>
+              onClick={formMethods.handleSubmit((values: FormValues) =>
                 saveKlage(transformValuesTempSave(values, AksjonspunktKode.MANUELL_VURDERING_AV_KLAGE_NFP)),
               )}
               type="button"
@@ -184,7 +182,7 @@ export const BehandleKlageFormNfp = ({ klageVurdering, previewCallback, saveKlag
   );
 };
 
-const transformValuesTempSave = (values: KlageFormType, aksjonspunktCode: string): TransformedValues => ({
+const transformValuesTempSave = (values: FormValues, aksjonspunktCode: string): TransformedValues => ({
   kode: aksjonspunktCode,
   klageMedholdÅrsak:
     values.klageVurdering === 'MEDHOLD_I_KLAGE' || values.klageVurdering === 'OPPHEVE_YTELSESVEDTAK'

--- a/packages/prosess/klagevurdering/src/components/nfp/FritekstKlageBrevTextField.tsx
+++ b/packages/prosess/klagevurdering/src/components/nfp/FritekstKlageBrevTextField.tsx
@@ -5,7 +5,7 @@ import { RhfTextarea } from '@navikt/ft-form-hooks';
 import { hasValidText, required } from '@navikt/ft-form-validators';
 import { formaterFritekst, getLanguageFromSprakkode } from '@navikt/ft-utils';
 
-import type { KlageFormType } from '../../types/klageFormType';
+import type { FormValues } from '../../types/FormValues';
 
 import styles from './fritekstKlageBrevTextField.module.css';
 
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export const FritekstBrevTextField = ({ språkkode, readOnly = true }: Props) => {
-  const { control } = useFormContext<KlageFormType>();
+  const { control } = useFormContext<FormValues>();
 
   return (
     <div className={styles['fritekstTilBrevTextArea']}>

--- a/packages/prosess/klagevurdering/src/components/nfp/KlageVurderingRadioOptionsNfp.tsx
+++ b/packages/prosess/klagevurdering/src/components/nfp/KlageVurderingRadioOptionsNfp.tsx
@@ -8,7 +8,7 @@ import { ArrowBox } from '@navikt/ft-ui-komponenter';
 
 import type { KlageVurderingOmgjørType, KlageVurderingType, KodeverkMedNavn } from '@navikt/fp-types';
 
-import type { KlageFormType } from '../../types/klageFormType';
+import type { FormValues } from '../../types/FormValues';
 
 import styles from './klageVurderingRadioOptionsNfp.module.css';
 
@@ -27,7 +27,7 @@ export const KlageVurderingRadioOptionsNfp = ({
 }: Props) => {
   const intl = useIntl();
 
-  const { control } = useFormContext<KlageFormType>();
+  const { control } = useFormContext<FormValues>();
 
   const medholdOptions = medholdReasons.map(mo => (
     <option key={mo.kode} value={mo.kode}>

--- a/packages/prosess/klagevurdering/src/types/FormValues.ts
+++ b/packages/prosess/klagevurdering/src/types/FormValues.ts
@@ -1,7 +1,7 @@
 import type { ProsessStegBegrunnelseTextFieldFormValues } from '@navikt/fp-prosess-felles';
 import type { KlageHjemmel, KlageVurderingOmgjørType, KlageVurderingType } from '@navikt/fp-types';
 
-export type KlageFormType = {
+export type FormValues = {
   fritekstTilBrev?: string;
   klageVurdering?: KlageVurderingType;
   klageVurderingOmgjør?: KlageVurderingOmgjørType;

--- a/packages/prosess/klagevurdering/src/types/klageFormType.ts
+++ b/packages/prosess/klagevurdering/src/types/klageFormType.ts
@@ -1,10 +1,10 @@
+import type { ProsessStegBegrunnelseTextFieldFormValues } from '@navikt/fp-prosess-felles';
 import type { KlageHjemmel, KlageVurderingOmgjørType, KlageVurderingType } from '@navikt/fp-types';
 
 export type KlageFormType = {
-  begrunnelse?: string;
   fritekstTilBrev?: string;
   klageVurdering?: KlageVurderingType;
   klageVurderingOmgjør?: KlageVurderingOmgjørType;
   klageMedholdÅrsak?: string;
   klageHjemmel?: KlageHjemmel;
-};
+} & ProsessStegBegrunnelseTextFieldFormValues;

--- a/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
+++ b/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
@@ -217,64 +217,6 @@ const hentSorterAktiviteterFn =
     return data1.arbeidsforhold.localeCompare(data2.arbeidsforhold);
   };
 
-const byggDefaultValues = (
-  valgtPeriode: PeriodeSoker,
-  sorterteAktiviteter: PeriodeSokerAktivitet[],
-  periodeResultatårsakKoder: PeriodeResultatÅrsakMuligeÅrsaker[],
-): UttakAktivitetType => {
-  const kontoIkkeSatt = !valgtPeriode.periodeType && valgtPeriode.aktiviteter[0]?.stønadskontoType === '-';
-
-  return {
-    begrunnelse: valgtPeriode.begrunnelse,
-    erOppfylt: erPeriodeOppfylt(valgtPeriode, periodeResultatårsakKoder),
-    periodeResultatÅrsak: valgtPeriode.periodeResultatÅrsak,
-    graderingInnvilget: valgtPeriode.graderingInnvilget,
-    samtidigUttak: valgtPeriode.samtidigUttak,
-    graderingAvslagÅrsak: valgtPeriode.graderingAvslagÅrsak,
-    samtidigUttaksprosent: valgtPeriode.samtidigUttaksprosent
-      ? valgtPeriode.samtidigUttaksprosent.toString()
-      : undefined,
-    flerbarnsdager: valgtPeriode.flerbarnsdager,
-    oppholdÅrsak: valgtPeriode.oppholdÅrsak,
-    aktiviteter: sorterteAktiviteter.map(a => ({
-      stønadskontoType: a.stønadskontoType ?? '-',
-      weeks: finnUker(a, valgtPeriode),
-      days: finnDager(a, valgtPeriode),
-      utbetalingsgrad: !kontoIkkeSatt && a.utbetalingsgrad ? a.utbetalingsgrad.toString() : '0',
-    })),
-  };
-};
-
-const transformValues = (
-  values: UttakAktivitetType,
-  valgtPeriode: PeriodeSoker,
-  filtrerteAktiviteter: PeriodeSokerAktivitet[],
-): PeriodeSoker => ({
-  ...valgtPeriode,
-  begrunnelse: values.begrunnelse,
-  graderingInnvilget: values.erOppfylt ? values.graderingInnvilget : false,
-  oppholdÅrsak: values.oppholdÅrsak,
-  periodeResultatType: values.erOppfylt || values.oppholdÅrsak !== '-' ? 'INNVILGET' : 'AVSLÅTT',
-  graderingAvslagÅrsak: values.graderingAvslagÅrsak,
-  periodeResultatÅrsak: values.periodeResultatÅrsak,
-  samtidigUttaksprosent: values.samtidigUttaksprosent ? Number.parseFloat(values.samtidigUttaksprosent) : undefined,
-  samtidigUttak: values.samtidigUttak,
-  flerbarnsdager: values.flerbarnsdager,
-  aktiviteter: filtrerteAktiviteter.flatMap((a, index) => {
-    const aktivitet = values.aktiviteter[index];
-    if (!aktivitet) {
-      return [];
-    }
-    return {
-      ...a,
-      stønadskontoType: aktivitet.stønadskontoType,
-      utbetalingsgrad: Number.parseFloat(aktivitet.utbetalingsgrad),
-      trekkdagerDesimaler: Number.parseFloat(aktivitet.weeks) * 5 + Number.parseFloat(aktivitet.days),
-      trekkdager: Number.parseFloat(aktivitet.weeks) * 5 + Number.parseFloat(aktivitet.days),
-    };
-  }),
-});
-
 interface Props {
   valgtPeriode: PeriodeSoker;
   isReadOnly: boolean;
@@ -312,7 +254,7 @@ export const UttakPeriodeForm = ({
 
   // Her er det noko rart. Denne må ha useMemo, ellers blir testen aldri ferdig
   const defaultValues = useMemo(
-    () => byggDefaultValues(valgtPeriode, sorterteAktiviteter, muligeÅrsaker),
+    () => buildInitialValues(valgtPeriode, sorterteAktiviteter, muligeÅrsaker),
     [valgtPeriode, sorterteAktiviteter, arbeidsgiverOpplysningerPerId],
   );
 
@@ -481,3 +423,61 @@ export const UttakPeriodeForm = ({
     </RhfForm>
   );
 };
+
+const buildInitialValues = (
+  valgtPeriode: PeriodeSoker,
+  sorterteAktiviteter: PeriodeSokerAktivitet[],
+  periodeResultatårsakKoder: PeriodeResultatÅrsakMuligeÅrsaker[],
+): UttakAktivitetType => {
+  const kontoIkkeSatt = !valgtPeriode.periodeType && valgtPeriode.aktiviteter[0]?.stønadskontoType === '-';
+
+  return {
+    begrunnelse: valgtPeriode.begrunnelse,
+    erOppfylt: erPeriodeOppfylt(valgtPeriode, periodeResultatårsakKoder),
+    periodeResultatÅrsak: valgtPeriode.periodeResultatÅrsak,
+    graderingInnvilget: valgtPeriode.graderingInnvilget,
+    samtidigUttak: valgtPeriode.samtidigUttak,
+    graderingAvslagÅrsak: valgtPeriode.graderingAvslagÅrsak,
+    samtidigUttaksprosent: valgtPeriode.samtidigUttaksprosent
+      ? valgtPeriode.samtidigUttaksprosent.toString()
+      : undefined,
+    flerbarnsdager: valgtPeriode.flerbarnsdager,
+    oppholdÅrsak: valgtPeriode.oppholdÅrsak,
+    aktiviteter: sorterteAktiviteter.map(a => ({
+      stønadskontoType: a.stønadskontoType ?? '-',
+      weeks: finnUker(a, valgtPeriode),
+      days: finnDager(a, valgtPeriode),
+      utbetalingsgrad: !kontoIkkeSatt && a.utbetalingsgrad ? a.utbetalingsgrad.toString() : '0',
+    })),
+  };
+};
+
+const transformValues = (
+  values: UttakAktivitetType,
+  valgtPeriode: PeriodeSoker,
+  filtrerteAktiviteter: PeriodeSokerAktivitet[],
+): PeriodeSoker => ({
+  ...valgtPeriode,
+  begrunnelse: values.begrunnelse,
+  graderingInnvilget: values.erOppfylt ? values.graderingInnvilget : false,
+  oppholdÅrsak: values.oppholdÅrsak,
+  periodeResultatType: values.erOppfylt || values.oppholdÅrsak !== '-' ? 'INNVILGET' : 'AVSLÅTT',
+  graderingAvslagÅrsak: values.graderingAvslagÅrsak,
+  periodeResultatÅrsak: values.periodeResultatÅrsak,
+  samtidigUttaksprosent: values.samtidigUttaksprosent ? Number.parseFloat(values.samtidigUttaksprosent) : undefined,
+  samtidigUttak: values.samtidigUttak,
+  flerbarnsdager: values.flerbarnsdager,
+  aktiviteter: filtrerteAktiviteter.flatMap((a, index) => {
+    const aktivitet = values.aktiviteter[index];
+    if (!aktivitet) {
+      return [];
+    }
+    return {
+      ...a,
+      stønadskontoType: aktivitet.stønadskontoType,
+      utbetalingsgrad: Number.parseFloat(aktivitet.utbetalingsgrad),
+      trekkdagerDesimaler: Number.parseFloat(aktivitet.weeks) * 5 + Number.parseFloat(aktivitet.days),
+      trekkdager: Number.parseFloat(aktivitet.weeks) * 5 + Number.parseFloat(aktivitet.days),
+    };
+  }),
+});

--- a/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
+++ b/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
@@ -49,59 +49,11 @@ function erOverstyringAvMedlemskap(overstyringApKode: AksjonspunktKode) {
   ].includes(overstyringApKode);
 }
 
-const createInitialValues = (
-  aksjonspunkter: Aksjonspunkt[],
-  status: string,
-  overstyringApKode: VilkårOverstyringAksjonspunkter,
-  behandlingsresultat: BehandlingFpSak['behandlingsresultat'],
-  medlemskapManuellBehandlingResultat: ManuellBehandlingResultat | undefined,
-): FormValues => {
-  const aksjonspunkt = aksjonspunkter.find(ap => ap.definisjon === overstyringApKode);
-  const felles = {
-    isOverstyrt: aksjonspunkt !== undefined,
-    begrunnelse: decodeHtmlEntity(aksjonspunkt?.begrunnelse ?? ''),
-  };
-
-  if (erOverstyringAvMedlemskap(overstyringApKode)) {
-    return aksjonspunkt
-      ? {
-          ...felles,
-          ...MedlemskapVurderinger.initialValues(medlemskapManuellBehandlingResultat),
-        }
-      : felles;
-  }
-  return {
-    ...felles,
-    ...VilkarResultPicker.buildInitialValues(aksjonspunkt ? [aksjonspunkt] : [], status, behandlingsresultat),
-  };
-};
-
 type OverstyringVilkår =
   | OverstyringAp
   | OverstyringMedlemskapsvilkaretLopendeAp
   | OverstyringMedlemskapsvilkaretAp
   | OverstyringMedlemskapvilkaretForutgaendeAp;
-
-const transformValues = (values: FormValues, overstyringApKode: VilkårOverstyringAksjonspunkter): OverstyringVilkår => {
-  const felles = {
-    kode: overstyringApKode,
-    begrunnelse: values.begrunnelse,
-  };
-
-  switch (overstyringApKode) {
-    case AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET:
-    case AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR:
-      return {
-        ...felles,
-        ...MedlemskapVurderinger.transformValues(values),
-      };
-    default:
-      return {
-        ...felles,
-        ...VilkarResultPicker.transformValues(values),
-      };
-  }
-};
 
 interface Props {
   medlemskapManuellBehandlingResultat: ManuellBehandlingResultat | undefined;
@@ -127,7 +79,7 @@ export const VilkarresultatMedOverstyringForm = ({
   const { erOverstyrt, toggleOverstyring, overstyringApKode, overrideReadOnly, kanOverstyreAccess } =
     usePanelOverstyring<VilkårOverstyringAksjonspunkter>();
 
-  const initialValues = createInitialValues(
+  const initialValues = buildInitialValues(
     behandling.aksjonspunkt,
     status,
     overstyringApKode,
@@ -238,4 +190,52 @@ export const VilkarresultatMedOverstyringForm = ({
       </HStack>
     </RhfForm>
   );
+};
+
+const buildInitialValues = (
+  aksjonspunkter: Aksjonspunkt[],
+  status: string,
+  overstyringApKode: VilkårOverstyringAksjonspunkter,
+  behandlingsresultat: BehandlingFpSak['behandlingsresultat'],
+  medlemskapManuellBehandlingResultat: ManuellBehandlingResultat | undefined,
+): FormValues => {
+  const aksjonspunkt = aksjonspunkter.find(ap => ap.definisjon === overstyringApKode);
+  const felles = {
+    isOverstyrt: aksjonspunkt !== undefined,
+    begrunnelse: decodeHtmlEntity(aksjonspunkt?.begrunnelse ?? ''),
+  };
+
+  if (erOverstyringAvMedlemskap(overstyringApKode)) {
+    return aksjonspunkt
+      ? {
+          ...felles,
+          ...MedlemskapVurderinger.initialValues(medlemskapManuellBehandlingResultat),
+        }
+      : felles;
+  }
+  return {
+    ...felles,
+    ...VilkarResultPicker.buildInitialValues(aksjonspunkt ? [aksjonspunkt] : [], status, behandlingsresultat),
+  };
+};
+
+const transformValues = (values: FormValues, overstyringApKode: VilkårOverstyringAksjonspunkter): OverstyringVilkår => {
+  const felles = {
+    kode: overstyringApKode,
+    begrunnelse: values.begrunnelse,
+  };
+
+  switch (overstyringApKode) {
+    case AksjonspunktKode.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET:
+    case AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR:
+      return {
+        ...felles,
+        ...MedlemskapVurderinger.transformValues(values),
+      };
+    default:
+      return {
+        ...felles,
+        ...VilkarResultPicker.transformValues(values),
+      };
+  }
 };

--- a/packages/sak/meny-ny-behandling/src/components/NyBehandlingModal.tsx
+++ b/packages/sak/meny-ny-behandling/src/components/NyBehandlingModal.tsx
@@ -252,7 +252,9 @@ const transformValues = (
   eksternUuid: string | undefined,
   fagsakYtelseType: string,
 ): { eksternUuid?: string; fagsakYtelseType: string } & FormValues => ({
-  ...values,
+  behandlingType: values.behandlingType,
+  nyBehandlingEtterKlage: values.nyBehandlingEtterKlage,
+  behandlingArsakType: values.behandlingArsakType,
   eksternUuid,
   fagsakYtelseType,
 });


### PR DESCRIPTION
## Hva

Oppfølging av #7382. Speiler `transformValues`-mønsteret ved å gi skjema som har `transformValues` en dedikert `buildInitialValues`-funksjon.

### Konvensjon
- `buildInitialValues` ligger nederst i fila, **foran** `transformValues` (rekkefølge: `buildInitialValues` så `transformValues`).
- Signatur speiler `transformValues`: domeneargumenter inn, skjemaets `FormValues` ut.
- Kallstedet blir `defaultValues: mellomlagretFormData ?? buildInitialValues(...)` (eksisterende mellomlagrings-fallback beholdt).
- Delte hjelpere (`FaktaBegrunnelseTextField`/`ProsessStegBegrunnelseTextField` sine `initialValues`/`buildInitialValues`) brukes som før.

### Endrede forms
- `AleneomsorgForm`, `HarAnnenForelderRettForm`, `RettighetstypeForm` (omsorg-og-rett)
- `InnhentDokOpptjeningUtlandAP`, `DekningradAP` (saken)
- `UttakEøsFaktaDetailForm`, `UttakEøsFaktaForm`
- `UttakFaktaDetailForm`, `UttakFaktaForm`
- `UttakDokumentasjonFaktaForm`
- `InnsynForm`
- `UttakPeriodeForm`
- `UtvalgskriterierForSakslisteForm` (`buildDefaultValues`)
- `VurderMedlemskapAksjonspunktForm`, `OmsorgInfoPanel`, `VilkarresultatMedOverstyringForm` ( het `createInitialValues`)


## Verifisering
- ESLint: 0 errors (kun eksisterende warnings)
- tsc: grønt for alle berørte pakker
- Tester: grønt for alle berørte pakker

## Gjenbruk av delte begrunnelse-FormValues-typer

Skjema som bruker `FaktaBegrunnelseTextField`/`ProsessStegBegrunnelseTextField` og deklarerte `begrunnelse` i egen `FormValues`, gjenbruker nå de delte typene `FaktaBegrunnelseFormValues` / `ProsessStegBegrunnelseTextFieldFormValues` via intersection i stedet for å duplisere feltet.

- `InnhentDokOpptjeningUtlandAP`, `DekningradAP` (saken)
- `RettighetstypeForm`, `HarAnnenForelderRettForm`, `AleneomsorgForm` (omsorg-og-rett)
- `KontrollerBesteberegningPanel` (besteberegning)
- `KlageFormType` (klagevurdering)

## Map ut properties i transformValues (i stedet for spread)

`UtvalgskriterierForSakslisteForm`, `UttakEøsFaktaDetailForm` og `NyBehandlingModal` mapper nå ut hvert felt eksplisitt i `transformValues`/`buildInitialValues` i stedet for å spre selve `values`-argumentet.

> ℹ️ Permisjon-endringene som tidligere lå her er flyttet til egen PR #7386.

