### PR TITLE
refactor: erstatt classnames med native class-join

### DIFF
--- a/apps/fp-frontend/package.json
+++ b/apps/fp-frontend/package.json
@@ -114,7 +114,6 @@
     "@navikt/ft-utils": "5.0.8",
     "@sentry/vite-plugin": "5.3.0",
     "@tanstack/react-query": "5.100.10",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "history": "5.3.0",
     "ky": "2.0.2",

--- a/apps/fp-frontend/src/behandling/felles/prosess/ProsessPanelWrapper.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/ProsessPanelWrapper.tsx
@@ -3,13 +3,10 @@ import { FormattedMessage } from 'react-intl';
 
 import { BodyShort } from '@navikt/ds-react';
 import { FadingPanel } from '@navikt/ft-ui-komponenter';
-import classnames from 'classnames/bind';
 
 import type { VilkårUtfallType } from '@navikt/fp-types';
 
 import styles from './prosessPanelWrapper.module.css';
-
-const classNames = classnames.bind(styles);
 
 interface PanelContainerProps {
   skalSkjulePanel?: boolean;
@@ -17,7 +14,7 @@ interface PanelContainerProps {
 }
 
 const PanelContainer = ({ skalSkjulePanel = false, children }: PanelContainerProps) => (
-  <div className={classNames('steg', { skalSkjulePanel })}>
+  <div className={[styles['steg'], skalSkjulePanel && styles['skalSkjulePanel']].filter(Boolean).join(' ')}>
     <FadingPanel>{children}</FadingPanel>
   </div>
 );

--- a/apps/fp-frontend/src/behandling/felles/prosess/ProsessPanelWrapper.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/ProsessPanelWrapper.tsx
@@ -5,6 +5,7 @@ import { BodyShort } from '@navikt/ds-react';
 import { FadingPanel } from '@navikt/ft-ui-komponenter';
 
 import type { VilkårUtfallType } from '@navikt/fp-types';
+import { classNames } from '@navikt/fp-utils';
 
 import styles from './prosessPanelWrapper.module.css';
 
@@ -14,7 +15,7 @@ interface PanelContainerProps {
 }
 
 const PanelContainer = ({ skalSkjulePanel = false, children }: PanelContainerProps) => (
-  <div className={[styles['steg'], skalSkjulePanel && styles['skalSkjulePanel']].filter(Boolean).join(' ')}>
+  <div className={classNames(styles['steg'], skalSkjulePanel && styles['skalSkjulePanel'])}>
     <FadingPanel>{children}</FadingPanel>
   </div>
 );

--- a/packages/fakta/arbeid-og-inntekt/package.json
+++ b/packages/fakta/arbeid-og-inntekt/package.json
@@ -30,7 +30,6 @@
     "@navikt/ft-form-validators": "6.0.9",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/fakta/arbeid-og-inntekt/src/components/ArbeidsforholdRad.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/ArbeidsforholdRad.tsx
@@ -11,6 +11,7 @@ import type {
   ManglendeInntektsmeldingVurdering,
   ManueltArbeidsforhold,
 } from '@navikt/fp-types';
+import { classNames } from '@navikt/fp-utils';
 
 import type { ArbeidsforholdOgInntektRadData, Avklaring } from '../types/arbeidsforholdOgInntekt';
 import { ArbeidsforholdInformasjonPanel } from './felles/ArbeidsforholdInformasjonPanel';
@@ -77,9 +78,7 @@ export const ArbeidsforholdRad = ({
       expandOnRowClick
       togglePlacement="right"
       contentGutter="none"
-      className={[styles['row'], erRadÅpen && styles['isOpen'], harÅpentAksjonspunkt && styles['isApOpen']]
-        .filter(Boolean)
-        .join(' ')}
+      className={classNames(styles['row'], erRadÅpen && styles['isOpen'], harÅpentAksjonspunkt && styles['isApOpen'])}
       content={
         <VStack gap="space-16" className={harÅpentAksjonspunkt ? styles['panelOpenAp'] : styles['panelOpen']}>
           {erManueltOpprettet && (

--- a/packages/fakta/arbeid-og-inntekt/src/components/ArbeidsforholdRad.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/ArbeidsforholdRad.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { CheckmarkIcon, ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { BodyShort, Table, VStack } from '@navikt/ds-react';
 import { DateLabel, PeriodLabel } from '@navikt/ft-ui-komponenter';
-import classnames from 'classnames/bind';
 import dayjs from 'dayjs';
 
 import type {
@@ -22,8 +21,6 @@ import { ManglendeInntektsmeldingForm } from './manglendeInntektsmelding/Manglen
 import { ManueltLagtTilArbeidsforholdForm } from './manuelt/ManueltLagtTilArbeidsforholdForm';
 
 import styles from './arbeidsforholdRad.module.css';
-
-const classNames = classnames.bind(styles);
 
 interface Props {
   saksnummer: string;
@@ -80,10 +77,9 @@ export const ArbeidsforholdRad = ({
       expandOnRowClick
       togglePlacement="right"
       contentGutter="none"
-      className={classNames('row', {
-        isOpen: erRadÅpen,
-        isApOpen: harÅpentAksjonspunkt,
-      })}
+      className={[styles['row'], erRadÅpen && styles['isOpen'], harÅpentAksjonspunkt && styles['isApOpen']]
+        .filter(Boolean)
+        .join(' ')}
       content={
         <VStack gap="space-16" className={harÅpentAksjonspunkt ? styles['panelOpenAp'] : styles['panelOpen']}>
           {erManueltOpprettet && (

--- a/packages/fakta/felles/package.json
+++ b/packages/fakta/felles/package.json
@@ -27,7 +27,6 @@
     "@navikt/ft-plattform-komponenter": "12.0.10",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "lodash": "^4.18.1",
     "react": "19.2.7",

--- a/packages/fakta/felles/src/components/Boks.tsx
+++ b/packages/fakta/felles/src/components/Boks.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { classNames } from '@navikt/fp-utils';
+
 import styles from './boks.module.css';
 
 interface Props {
@@ -10,9 +12,7 @@ interface Props {
 
 export const Boks = ({ harBorderTop = false, harBorderLeft = true, children }: Props) => (
   <div
-    className={[styles['boks'], harBorderLeft && styles['harBorderLeft'], harBorderTop && styles['harBorderTop']]
-      .filter(Boolean)
-      .join(' ')}
+    className={classNames(styles['boks'], harBorderLeft && styles['harBorderLeft'], harBorderTop && styles['harBorderTop'])}
   >
     {children}
   </div>

--- a/packages/fakta/felles/src/components/Boks.tsx
+++ b/packages/fakta/felles/src/components/Boks.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
-import classnames from 'classnames/bind';
-
 import styles from './boks.module.css';
-
-const classNames = classnames.bind(styles);
 
 interface Props {
   harBorderTop?: boolean;
@@ -14,10 +10,9 @@ interface Props {
 
 export const Boks = ({ harBorderTop = false, harBorderLeft = true, children }: Props) => (
   <div
-    className={classNames(styles['boks'], {
-      harBorderLeft,
-      harBorderTop,
-    })}
+    className={[styles['boks'], harBorderLeft && styles['harBorderLeft'], harBorderTop && styles['harBorderTop']]
+      .filter(Boolean)
+      .join(' ')}
   >
     {children}
   </div>

--- a/packages/fakta/permisjon/package.json
+++ b/packages/fakta/permisjon/package.json
@@ -28,7 +28,6 @@
     "@navikt/ft-form-validators": "6.0.9",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/fakta/permisjon/src/components/ArbeidsforholdBoks.tsx
+++ b/packages/fakta/permisjon/src/components/ArbeidsforholdBoks.tsx
@@ -1,10 +1,6 @@
 import { type ReactElement } from 'react';
 
-import classnames from 'classnames/bind';
-
 import styles from './arbeidsforholdBoks.module.css';
-
-const classNames = classnames.bind(styles);
 
 interface Props {
   harÅpentAksjonspunkt: boolean;
@@ -14,10 +10,13 @@ interface Props {
 
 export const ArbeidsforholdBoks = ({ harÅpentAksjonspunkt, harBorderTop, children }: Props) => (
   <div
-    className={classNames(styles['boks'], {
-      aksjonspunkt: harÅpentAksjonspunkt,
-      harBorderTop,
-    })}
+    className={[
+      styles['boks'],
+      harÅpentAksjonspunkt && styles['aksjonspunkt'],
+      harBorderTop && styles['harBorderTop'],
+    ]
+      .filter(Boolean)
+      .join(' ')}
   >
     {children}
   </div>

--- a/packages/fakta/permisjon/src/components/ArbeidsforholdBoks.tsx
+++ b/packages/fakta/permisjon/src/components/ArbeidsforholdBoks.tsx
@@ -1,5 +1,7 @@
 import { type ReactElement } from 'react';
 
+import { classNames } from '@navikt/fp-utils';
+
 import styles from './arbeidsforholdBoks.module.css';
 
 interface Props {
@@ -10,13 +12,11 @@ interface Props {
 
 export const ArbeidsforholdBoks = ({ harÅpentAksjonspunkt, harBorderTop, children }: Props) => (
   <div
-    className={[
+    className={classNames(
       styles['boks'],
       harÅpentAksjonspunkt && styles['aksjonspunkt'],
       harBorderTop && styles['harBorderTop'],
-    ]
-      .filter(Boolean)
-      .join(' ')}
+    )}
   >
     {children}
   </div>

--- a/packages/fakta/uttak/package.json
+++ b/packages/fakta/uttak/package.json
@@ -29,7 +29,6 @@
     "@navikt/ft-form-validators": "6.0.9",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/fakta/uttak/src/components/UttakFaktaTable.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaTable.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Table, VStack } from '@navikt/ds-react';
 import { calcDaysAndWeeks, dateFormat } from '@navikt/ft-utils';
-import classnames from 'classnames/bind';
 import dayjs from 'dayjs';
 
 import type { AlleKodeverk, ArbeidsgiverOpplysningerPerId, Fagsak, FaktaArbeidsforhold } from '@navikt/fp-types';
@@ -13,8 +12,6 @@ import type { KontrollerFaktaPeriodeMedApMarkering } from '../typer/kontrollerFa
 import { Årsakstype, utledÅrsakstype, UttakFaktaDetailForm } from './UttakFaktaDetailForm';
 
 import styles from './uttakFaktaTable.module.css';
-
-const classNames = classnames.bind(styles);
 
 const getTypeTekst = (
   alleKodeverk: AlleKodeverk,
@@ -132,10 +129,13 @@ export const UttakFaktaTable = ({
                 togglePlacement="right"
                 open={valgteFomDatoer.includes(periode.fom)}
                 onOpenChange={() => velgPeriodeFomDato(periode.fom)}
-                className={classNames('row', {
-                  isOpen: valgteFomDatoer.includes(periode.fom),
-                  isApOpen: !!periode.aksjonspunktType,
-                })}
+                className={[
+                  styles['row'],
+                  valgteFomDatoer.includes(periode.fom) && styles['isOpen'],
+                  !!periode.aksjonspunktType && styles['isApOpen'],
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
                 contentGutter="none"
                 content={
                   valgteFomDatoer.includes(periode.fom) && (

--- a/packages/fakta/uttak/src/components/UttakFaktaTable.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaTable.tsx
@@ -7,6 +7,7 @@ import { calcDaysAndWeeks, dateFormat } from '@navikt/ft-utils';
 import dayjs from 'dayjs';
 
 import type { AlleKodeverk, ArbeidsgiverOpplysningerPerId, Fagsak, FaktaArbeidsforhold } from '@navikt/fp-types';
+import { classNames } from '@navikt/fp-utils';
 
 import type { KontrollerFaktaPeriodeMedApMarkering } from '../typer/kontrollerFaktaPeriodeMedApMarkering';
 import { Årsakstype, utledÅrsakstype, UttakFaktaDetailForm } from './UttakFaktaDetailForm';
@@ -129,13 +130,11 @@ export const UttakFaktaTable = ({
                 togglePlacement="right"
                 open={valgteFomDatoer.includes(periode.fom)}
                 onOpenChange={() => velgPeriodeFomDato(periode.fom)}
-                className={[
+                className={classNames(
                   styles['row'],
                   valgteFomDatoer.includes(periode.fom) && styles['isOpen'],
                   !!periode.aksjonspunktType && styles['isApOpen'],
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
+                )}
                 contentGutter="none"
                 content={
                   valgteFomDatoer.includes(periode.fom) && (

--- a/packages/prosess/simulering/package.json
+++ b/packages/prosess/simulering/package.json
@@ -29,7 +29,6 @@
     "@navikt/ft-form-validators": "6.0.9",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/prosess/simulering/src/components/SimuleringTable.tsx
+++ b/packages/prosess/simulering/src/components/SimuleringTable.tsx
@@ -12,6 +12,7 @@ import type {
   SimuleringResultatPerFagområde,
   SimuleringResultatRad,
 } from '@navikt/fp-types';
+import { classNames } from '@navikt/fp-utils';
 
 import { CollapseButton } from './CollapseButton';
 
@@ -168,14 +169,12 @@ const createColumns = (
     <Table.DataCell
       key={`columnIndex${månedIndex + 1}`}
       style={{ borderBottom }}
-      className={[
+      className={classNames(
         (!måned.beløp || måned.beløp < 0) && styles['rodTekst'],
         ('måned' in måned
           ? måned.måned === nextPeriodFormatted
           : dayjs(måned.periode.tom).format('MMMMYY') === nextPeriodFormatted) && styles['lastColumn'],
-      ]
-        .filter(Boolean)
-        .join(' ')}
+      )}
     >
       <BeløpLabel beløp={måned.beløp} />
     </Table.DataCell>

--- a/packages/prosess/simulering/src/components/SimuleringTable.tsx
+++ b/packages/prosess/simulering/src/components/SimuleringTable.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl';
 
 import { Heading, Table } from '@navikt/ds-react';
 import { BeløpLabel } from '@navikt/ft-ui-komponenter';
-import classnames from 'classnames/bind';
 import dayjs from 'dayjs';
 
 import type {
@@ -17,8 +16,6 @@ import type {
 import { CollapseButton } from './CollapseButton';
 
 import styles from './simuleringTable.module.css';
-
-const classNames = classnames.bind(styles);
 
 const simuleringCodes = {
   DIFFERANSE: 'differanse',
@@ -82,10 +79,7 @@ export const SimuleringTable = ({
                 {rangeOfMonths.map(monthAndYear => (
                   <Table.HeaderCell
                     scope="col"
-                    className={classNames({
-                      nextPeriod: isNextPeriod(monthAndYear, nesteMåned),
-                      normalPeriod: !isNextPeriod(monthAndYear, nesteMåned),
-                    })}
+                    className={isNextPeriod(monthAndYear, nesteMåned) ? styles['nextPeriod'] : styles['normalPeriod']}
                     key={`${monthAndYear.month}-${monthAndYear.year}`}
                   >
                     <FormattedMessage id={`Simulering.headerText.${monthAndYear.month}`} />
@@ -174,13 +168,14 @@ const createColumns = (
     <Table.DataCell
       key={`columnIndex${månedIndex + 1}`}
       style={{ borderBottom }}
-      className={classNames({
-        rodTekst: !måned.beløp || måned.beløp < 0,
-        lastColumn:
-          'måned' in måned
-            ? måned.måned === nextPeriodFormatted
-            : dayjs(måned.periode.tom).format('MMMMYY') === nextPeriodFormatted,
-      })}
+      className={[
+        (!måned.beløp || måned.beløp < 0) && styles['rodTekst'],
+        ('måned' in måned
+          ? måned.måned === nextPeriodFormatted
+          : dayjs(måned.periode.tom).format('MMMMYY') === nextPeriodFormatted) && styles['lastColumn'],
+      ]
+        .filter(Boolean)
+        .join(' ')}
     >
       <BeløpLabel beløp={måned.beløp} />
     </Table.DataCell>

--- a/packages/prosess/uttak/package.json
+++ b/packages/prosess/uttak/package.json
@@ -31,7 +31,6 @@
     "@navikt/ft-form-validators": "6.0.9",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/prosess/uttak/src/components/stonadsdagerOversikt/StonadsdagerTab.tsx
+++ b/packages/prosess/uttak/src/components/stonadsdagerOversikt/StonadsdagerTab.tsx
@@ -2,13 +2,10 @@ import { FormattedMessage } from 'react-intl';
 
 import { BodyShort, Detail, VStack } from '@navikt/ds-react';
 import { BTag } from '@navikt/ft-utils';
-import classnames from 'classnames/bind';
 
 import type { Stonadskonto, StønadskontoType } from '@navikt/fp-types';
 
 import styles from './stonadsdagerTab.module.css';
-
-const classNames = classnames.bind(styles);
 
 const finnKorrektLabelForKvote = (stonadtype: StønadskontoType): string => {
   switch (stonadtype) {
@@ -60,10 +57,14 @@ export const StonadsdagerTab = ({ stønadskonto, visDagerForKonto, aktiv = false
 
   return (
     <div className={styles['tabs']}>
-      <li className={classNames('tab', { aktiv, error: !stønadskonto.gyldigForbruk })}>
+      <li
+        className={[styles['tab'], aktiv && styles['aktiv'], !stønadskonto.gyldigForbruk && styles['error']]
+          .filter(Boolean)
+          .join(' ')}
+      >
         <button
           role="tab"
-          className={classNames('tabInner', { error: !stønadskonto.gyldigForbruk })}
+          className={[styles['tabInner'], !stønadskonto.gyldigForbruk && styles['error']].filter(Boolean).join(' ')}
           type="button"
           onClick={velgKonto}
           aria-selected={aktiv}

--- a/packages/prosess/uttak/src/components/stonadsdagerOversikt/StonadsdagerTab.tsx
+++ b/packages/prosess/uttak/src/components/stonadsdagerOversikt/StonadsdagerTab.tsx
@@ -4,6 +4,7 @@ import { BodyShort, Detail, VStack } from '@navikt/ds-react';
 import { BTag } from '@navikt/ft-utils';
 
 import type { Stonadskonto, StønadskontoType } from '@navikt/fp-types';
+import { classNames } from '@navikt/fp-utils';
 
 import styles from './stonadsdagerTab.module.css';
 
@@ -58,13 +59,11 @@ export const StonadsdagerTab = ({ stønadskonto, visDagerForKonto, aktiv = false
   return (
     <div className={styles['tabs']}>
       <li
-        className={[styles['tab'], aktiv && styles['aktiv'], !stønadskonto.gyldigForbruk && styles['error']]
-          .filter(Boolean)
-          .join(' ')}
+        className={classNames(styles['tab'], aktiv && styles['aktiv'], !stønadskonto.gyldigForbruk && styles['error'])}
       >
         <button
           role="tab"
-          className={[styles['tabInner'], !stønadskonto.gyldigForbruk && styles['error']].filter(Boolean).join(' ')}
+          className={classNames(styles['tabInner'], !stønadskonto.gyldigForbruk && styles['error'])}
           type="button"
           onClick={velgKonto}
           aria-selected={aktiv}

--- a/packages/sak/dekorator/package.json
+++ b/packages/sak/dekorator/package.json
@@ -24,7 +24,6 @@
     "@navikt/ft-plattform-komponenter": "12.0.10",
     "@navikt/ft-ui-komponenter": "8.0.11",
     "@navikt/ft-utils": "5.0.8",
-    "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/packages/sak/dekorator/src/components/FeilmeldingPanel.tsx
+++ b/packages/sak/dekorator/src/components/FeilmeldingPanel.tsx
@@ -4,15 +4,11 @@ import { FormattedMessage } from 'react-intl';
 import { XMarkIcon } from '@navikt/aksel-icons';
 import { Button, Detail, Link } from '@navikt/ds-react';
 import { decodeHtmlEntity } from '@navikt/ft-utils';
-import classnames from 'classnames/bind';
 
 import type { Feilmelding } from '../typer/feilmeldingTsType';
 import { FeilmeldingsdetaljerModal } from './FeilmeldingsdetaljerModal';
 
 import styles from './feilmeldingPanel.module.css';
-
-// TODO Dette er gjort fordi testen viste ein warning når ein dytta 'style.link' inn i a-tag'en. Bør ikkje vera naudsynt.
-const classNames = classnames.bind(styles);
 
 interface Props {
   feilmeldinger: Feilmelding[];
@@ -55,7 +51,7 @@ export const FeilmeldingPanel = ({ feilmeldinger, fjernFeilmeldinger }: Props) =
             <Detail>
               <Link
                 href="#"
-                className={classNames('link')}
+                className={styles['link']}
                 onClick={event => toggleModalOnClick(event, index)}
                 onKeyDown={event => toggleModalOnKeyDown(event, index)}
               >

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,6 +1,7 @@
 export { MellomlagretFormDataProvider, useMellomlagretFormData } from './src/context/MellomlagretFormDataContext';
 export { PanelDataProvider, usePanelDataContext } from './src/context/PanelDataContext';
 export { PanelOverstyringProvider, usePanelOverstyring } from './src/context/PanelOverstyringContext';
+export { classNames } from './src/classNames';
 export { notEmpty } from './src/notEmpty';
 export { assertUnreachable } from './src/switchCaseUtils';
 export { åpneDokument, åpneVindu } from './src/åpneDokument';

--- a/packages/utils/src/classNames.spec.ts
+++ b/packages/utils/src/classNames.spec.ts
@@ -15,9 +15,10 @@ describe('classNames', () => {
     expect(classNames(false, undefined, null)).toBe('');
   });
 
-  it('skal støtte betinga klassar via && ', () => {
-    const aktiv = true;
-    const error = false;
-    expect(classNames('tab', aktiv && 'aktiv', error && 'error')).toBe('tab aktiv');
+  it('skal støtte betinga klassar via &&', () => {
+    const lagTabKlasse = (aktiv: boolean, error: boolean) =>
+      classNames('tab', aktiv && 'aktiv', error && 'error');
+    expect(lagTabKlasse(true, false)).toBe('tab aktiv');
+    expect(lagTabKlasse(false, true)).toBe('tab error');
   });
 });

--- a/packages/utils/src/classNames.spec.ts
+++ b/packages/utils/src/classNames.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { classNames } from './classNames';
+
+describe('classNames', () => {
+  it('skal slå saman alle sanne klassenamn med mellomrom', () => {
+    expect(classNames('a', 'b', 'c')).toBe('a b c');
+  });
+
+  it('skal hoppe over falske verdiar', () => {
+    expect(classNames('a', false, undefined, null, 'b')).toBe('a b');
+  });
+
+  it('skal returnere tom streng når ingen klassar er sanne', () => {
+    expect(classNames(false, undefined, null)).toBe('');
+  });
+
+  it('skal støtte betinga klassar via && ', () => {
+    const aktiv = true;
+    const error = false;
+    expect(classNames('tab', aktiv && 'aktiv', error && 'error')).toBe('tab aktiv');
+  });
+});

--- a/packages/utils/src/classNames.ts
+++ b/packages/utils/src/classNames.ts
@@ -1,0 +1,3 @@
+type ClassValue = string | false | null | undefined;
+
+export const classNames = (...klasser: ClassValue[]): string => klasser.filter(Boolean).join(' ');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,7 +1635,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     react: "npm:19.2.7"
@@ -1741,7 +1740,6 @@ __metadata:
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     lodash: "npm:^4.18.1"
@@ -2045,7 +2043,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     react: "npm:19.2.7"
@@ -2203,7 +2200,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     react: "npm:19.2.7"
@@ -2430,7 +2426,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     history: "npm:5.3.0"
@@ -2992,7 +2987,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     react: "npm:19.2.7"
@@ -3104,7 +3098,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     react: "npm:19.2.7"
@@ -3579,7 +3572,6 @@ __metadata:
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/react": "npm:19.2.14"
-    classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     eslint: "npm:10.3.0"
     react: "npm:19.2.7"
@@ -7208,13 +7200,6 @@ __metadata:
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10/b63cb1f73d171d140a2ed8154ee6566c8ab775d3196b0e03a2a94b5f6a0ce7777ee5685ca56849403c8d17bd457a6540672f9a60696a6137c7a409097495b82c
-  languageName: node
-  linkType: hard
-
-"classnames@npm:2.5.1":
-  version: 2.5.1
-  resolution: "classnames@npm:2.5.1"
-  checksum: 10/58eb394e8817021b153bb6e7d782cfb667e4ab390cb2e9dac2fc7c6b979d1cc2b2a733093955fc5c94aa79ef5c8c89f11ab77780894509be6afbb91dddd79d15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
@sirimykland copilot ville ha eit bytte fra classnames til clsx. Eg lurar på om det er like greit å droppa begge, sidan me brukar det så lite. Men usikker, har ikkje noko sterk meining rundt dette. Kva trur du?

Fjernar avhengigheita classnames frå alle 8 bruksstadene. Den betinga samanslåinga av CSS-module-klassar er erstatta med native [...].filter(Boolean).join(' '), og pakka er fjerna frå alle berørte package.json-ar. Runtime-verdien er uendra.