### PR TITLE
feat: flytt fokus til panelinnhald ved snarveg-panelbyte

### DIFF
--- a/apps/fp-frontend/src/behandling/felles/fakta/FaktaMeny.tsx
+++ b/apps/fp-frontend/src/behandling/felles/fakta/FaktaMeny.tsx
@@ -43,7 +43,7 @@ export const FaktaMeny = <T extends Behandling>({
   const byttFaktaPanel = (retning: 1 | -1) => {
     const nyId = finnNabopanelId(faktaPanelMenyData, retning);
     if (nyId) {
-      planleggInnholdsfokus();
+      planleggInnholdsfokus(nyId);
       oppdaterProsessStegOgFaktaPanelIUrl(valgtProsessSteg, nyId);
     }
   };

--- a/apps/fp-frontend/src/behandling/felles/fakta/FaktaMeny.tsx
+++ b/apps/fp-frontend/src/behandling/felles/fakta/FaktaMeny.tsx
@@ -1,4 +1,4 @@
-import { createContext, type JSX, type ReactNode, useMemo } from 'react';
+import { createContext, type JSX, type ReactNode, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
@@ -9,6 +9,7 @@ import type { Behandling } from '@navikt/fp-types';
 
 import { BEHANDLING_SNARVEG_IDER } from '../../../snarveger/snarvegDefinisjoner';
 import { useRegistrerSnarveg } from '../../../snarveger/SnarvegerContext';
+import { useFokuserVedPanelbyte } from '../../../snarveger/useTastaturfokus';
 import { useBehandlingDataContext } from '../context/BehandlingDataContext';
 import { finnNabopanelId } from '../menyNavigasjon';
 import { type FaktaPanelMedÅpentApInfo, type FaktaPanelMenyData, useFaktaPanelMenyData } from './useFaktaPanelMenyData';
@@ -34,9 +35,15 @@ export const FaktaMeny = <T extends Behandling>({
 
   const { faktaPanelMenyData, settFaktaPanelMenyData } = useFaktaPanelMenyData(setFaktaPanelMedÅpentApInfo);
 
+  const innholdRef = useRef<HTMLDivElement>(null);
+  const planleggInnholdsfokus = useFokuserVedPanelbyte(valgtFaktaSteg, () =>
+    innholdRef.current?.focus({ preventScroll: true }),
+  );
+
   const byttFaktaPanel = (retning: 1 | -1) => {
     const nyId = finnNabopanelId(faktaPanelMenyData, retning);
     if (nyId) {
+      planleggInnholdsfokus();
       oppdaterProsessStegOgFaktaPanelIUrl(valgtProsessSteg, nyId);
     }
   };
@@ -66,7 +73,7 @@ export const FaktaMeny = <T extends Behandling>({
           />
         </div>
       )}
-      <div className={styles['content']}>
+      <div className={styles['content']} ref={innholdRef} tabIndex={-1}>
         <FaktaMenyProvider
           valgtFaktaSteg={valgtFaktaSteg}
           settFaktaPanelMenyData={settFaktaPanelMenyData}

--- a/apps/fp-frontend/src/behandling/felles/prosess/ProsessMeny.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/ProsessMeny.tsx
@@ -1,4 +1,4 @@
-import { createContext, type JSX, type ReactNode, useMemo } from 'react';
+import { createContext, type JSX, type ReactNode, useMemo, useRef } from 'react';
 
 import { ProcessMenu, ProcessMenuStepType } from '@navikt/ft-plattform-komponenter';
 
@@ -6,6 +6,7 @@ import type { Behandling, VilkårUtfallType } from '@navikt/fp-types';
 
 import { BEHANDLING_SNARVEG_IDER } from '../../../snarveger/snarvegDefinisjoner';
 import { useRegistrerSnarveg } from '../../../snarveger/SnarvegerContext';
+import { useFokuserVedPanelbyte } from '../../../snarveger/useTastaturfokus';
 import { useBehandlingDataContext } from '../context/BehandlingDataContext';
 import { finnNabopanelId } from '../menyNavigasjon';
 import { BehandlingHenlagtPanel } from './BehandlingHenlagtPanel';
@@ -24,6 +25,11 @@ export const ProsessMeny = <T extends Behandling>({ valgtProsessSteg, valgtFakta
 
   const { prosessPanelMenyData, settProsessPanelMenyData } = useProsessPanelMenyData();
 
+  const innholdRef = useRef<HTMLDivElement>(null);
+  const planleggInnholdsfokus = useFokuserVedPanelbyte(valgtProsessSteg, () =>
+    innholdRef.current?.focus({ preventScroll: true }),
+  );
+
   const oppdaterProsessPanelIUrl = (index: number) => {
     const panel = prosessPanelMenyData[index];
     const nyvalgtProsessSteg = panel?.erAktiv ? undefined : panel?.id;
@@ -33,6 +39,7 @@ export const ProsessMeny = <T extends Behandling>({ valgtProsessSteg, valgtFakta
   const byttProsessPanel = (retning: 1 | -1) => {
     const nyId = finnNabopanelId(prosessPanelMenyData, retning);
     if (nyId) {
+      planleggInnholdsfokus();
       oppdaterProsessStegOgFaktaPanelIUrl(nyId, valgtFaktaSteg);
     }
   };
@@ -58,13 +65,15 @@ export const ProsessMeny = <T extends Behandling>({ valgtProsessSteg, valgtFakta
           stepArrowContainerStyle={styles['stepArrowContainer']}
         />
       </div>
-      <ProsessMenyProvider
-        valgtProsessSteg={valgtProsessSteg}
-        settProsessPanelMenyData={settProsessPanelMenyData}
-        prosessPanelMenyData={prosessPanelMenyData}
-      >
-        {children}
-      </ProsessMenyProvider>
+      <div ref={innholdRef} tabIndex={-1}>
+        <ProsessMenyProvider
+          valgtProsessSteg={valgtProsessSteg}
+          settProsessPanelMenyData={settProsessPanelMenyData}
+          prosessPanelMenyData={prosessPanelMenyData}
+        >
+          {children}
+        </ProsessMenyProvider>
+      </div>
       {behandling.behandlingHenlagt && (
         <BehandlingHenlagtPanel
           valgtProsessSteg={valgtProsessSteg}

--- a/apps/fp-frontend/src/behandling/felles/prosess/ProsessMeny.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/ProsessMeny.tsx
@@ -39,7 +39,7 @@ export const ProsessMeny = <T extends Behandling>({ valgtProsessSteg, valgtFakta
   const byttProsessPanel = (retning: 1 | -1) => {
     const nyId = finnNabopanelId(prosessPanelMenyData, retning);
     if (nyId) {
-      planleggInnholdsfokus();
+      planleggInnholdsfokus(nyId);
       oppdaterProsessStegOgFaktaPanelIUrl(nyId, valgtFaktaSteg);
     }
   };

--- a/apps/fp-frontend/src/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/BehandlingSupportIndex.tsx
@@ -94,7 +94,7 @@ export const BehandlingSupportIndex = ({
   );
 
   const byttSupportPanel = (supportPanel: string) => {
-    planleggPanelfokus();
+    planleggPanelfokus(supportPanel);
     changeRouteCallback(supportPanel);
   };
 

--- a/apps/fp-frontend/src/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/BehandlingSupportIndex.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
@@ -20,6 +20,7 @@ import { getSupportPanelLocationCreator } from '../app/paths';
 import { FagsakData } from '../fagsak/FagsakData';
 import { BEHANDLING_SNARVEG_IDER } from '../snarveger/snarvegDefinisjoner';
 import { useRegistrerSnarveg } from '../snarveger/SnarvegerContext';
+import { useFokuserVedPanelbyte } from '../snarveger/useTastaturfokus';
 import { DokumentIndex } from './dokument/DokumentIndex';
 import { HistorikkIndex } from './historikk/HistorikkIndex';
 import { MeldingIndex } from './melding/MeldingIndex';
@@ -87,24 +88,34 @@ export const BehandlingSupportIndex = ({
     void navigate(getSupportPanelLocation(supportPanel));
   };
 
-  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_HISTORIKK, () => changeRouteCallback(SupportTabs.HISTORIKK));
-  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_MELDINGER, () => changeRouteCallback(SupportTabs.MELDINGER));
-  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_DOKUMENTER, () => changeRouteCallback(SupportTabs.DOKUMENTER));
-  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_NOTATER, () => changeRouteCallback(SupportTabs.NOTATER));
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const planleggPanelfokus = useFokuserVedPanelbyte(aktivtSupportPanel, () =>
+    tabsRef.current?.querySelector<HTMLElement>('[role="tabpanel"]:not([hidden])')?.focus({ preventScroll: true }),
+  );
+
+  const byttSupportPanel = (supportPanel: string) => {
+    planleggPanelfokus();
+    changeRouteCallback(supportPanel);
+  };
+
+  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_HISTORIKK, () => byttSupportPanel(SupportTabs.HISTORIKK));
+  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_MELDINGER, () => byttSupportPanel(SupportTabs.MELDINGER));
+  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_DOKUMENTER, () => byttSupportPanel(SupportTabs.DOKUMENTER));
+  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.STØTTE_NOTATER, () => byttSupportPanel(SupportTabs.NOTATER));
   useRegistrerSnarveg(
     BEHANDLING_SNARVEG_IDER.STØTTE_TIL_BESLUTTER,
-    () => changeRouteCallback(SupportTabs.TIL_BESLUTTER),
+    () => byttSupportPanel(SupportTabs.TIL_BESLUTTER),
     skalViseTilGodkjenning,
   );
   useRegistrerSnarveg(
     BEHANDLING_SNARVEG_IDER.STØTTE_FRA_BESLUTTER,
-    () => changeRouteCallback(SupportTabs.FRA_BESLUTTER),
+    () => byttSupportPanel(SupportTabs.FRA_BESLUTTER),
     skalViseFraBeslutter,
   );
   useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.UTVID_DETALJER, toggleVisUtvidetBehandlingDetaljer);
 
   return (
-    <Tabs value={aktivtSupportPanel} onChange={changeRouteCallback}>
+    <Tabs ref={tabsRef} value={aktivtSupportPanel} onChange={changeRouteCallback}>
       <Tabs.List className={styles['tabContainer']}>
         {skalViseFraBeslutter && (
           <Tabs.Tab

--- a/apps/fp-frontend/src/snarveger/useTastaturfokus.spec.tsx
+++ b/apps/fp-frontend/src/snarveger/useTastaturfokus.spec.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+
+import { useFokuserVedPanelbyte } from './useTastaturfokus';
+
+describe('useTastaturfokus', () => {
+  const renderPanelfokus = (fokuser: () => void) =>
+    renderHook(({ panel }: { panel: string | undefined }) => useFokuserVedPanelbyte(panel, fokuser), {
+      initialProps: { panel: 'a' as string | undefined },
+    });
+
+  it('skal flytte fokus når det er planlagt og panelet endrar seg', () => {
+    const fokuser = vi.fn();
+    const { result, rerender } = renderPanelfokus(fokuser);
+
+    result.current();
+    rerender({ panel: 'b' });
+
+    expect(fokuser).toHaveBeenCalledTimes(1);
+  });
+
+  it('skal ikkje flytte fokus ved panelbyte utan planlegging', () => {
+    const fokuser = vi.fn();
+    const { rerender } = renderPanelfokus(fokuser);
+
+    rerender({ panel: 'b' });
+
+    expect(fokuser).not.toHaveBeenCalled();
+  });
+
+  it('skal ikkje flytte fokus før panelet faktisk endrar seg', () => {
+    const fokuser = vi.fn();
+    const { result, rerender } = renderPanelfokus(fokuser);
+
+    result.current();
+    rerender({ panel: 'a' });
+
+    expect(fokuser).not.toHaveBeenCalled();
+  });
+
+  it('skal berre flytte fokus éin gong per planlegging', () => {
+    const fokuser = vi.fn();
+    const { result, rerender } = renderPanelfokus(fokuser);
+
+    result.current();
+    rerender({ panel: 'b' });
+    rerender({ panel: 'c' });
+
+    expect(fokuser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/fp-frontend/src/snarveger/useTastaturfokus.spec.tsx
+++ b/apps/fp-frontend/src/snarveger/useTastaturfokus.spec.tsx
@@ -12,7 +12,7 @@ describe('useTastaturfokus', () => {
     const fokuser = vi.fn();
     const { result, rerender } = renderPanelfokus(fokuser);
 
-    result.current();
+    result.current('b');
     rerender({ panel: 'b' });
 
     expect(fokuser).toHaveBeenCalledTimes(1);
@@ -31,7 +31,7 @@ describe('useTastaturfokus', () => {
     const fokuser = vi.fn();
     const { result, rerender } = renderPanelfokus(fokuser);
 
-    result.current();
+    result.current('b');
     rerender({ panel: 'a' });
 
     expect(fokuser).not.toHaveBeenCalled();
@@ -41,10 +41,20 @@ describe('useTastaturfokus', () => {
     const fokuser = vi.fn();
     const { result, rerender } = renderPanelfokus(fokuser);
 
-    result.current();
+    result.current('b');
     rerender({ panel: 'b' });
     rerender({ panel: 'c' });
 
     expect(fokuser).toHaveBeenCalledTimes(1);
+  });
+
+  it('skal ikkje planleggje fokus når målpanelet alt er aktivt', () => {
+    const fokuser = vi.fn();
+    const { result, rerender } = renderPanelfokus(fokuser);
+
+    result.current('a');
+    rerender({ panel: 'b' });
+
+    expect(fokuser).not.toHaveBeenCalled();
   });
 });

--- a/apps/fp-frontend/src/snarveger/useTastaturfokus.spec.tsx
+++ b/apps/fp-frontend/src/snarveger/useTastaturfokus.spec.tsx
@@ -5,7 +5,7 @@ import { useFokuserVedPanelbyte } from './useTastaturfokus';
 describe('useTastaturfokus', () => {
   const renderPanelfokus = (fokuser: () => void) =>
     renderHook(({ panel }: { panel: string | undefined }) => useFokuserVedPanelbyte(panel, fokuser), {
-      initialProps: { panel: 'a' as string | undefined },
+      initialProps: { panel: 'a' },
     });
 
   it('skal flytte fokus når det er planlagt og panelet endrar seg', () => {

--- a/apps/fp-frontend/src/snarveger/useTastaturfokus.ts
+++ b/apps/fp-frontend/src/snarveger/useTastaturfokus.ts
@@ -80,6 +80,37 @@ export const useFokusNårKlar = (kanFokusere: boolean, fokuser: () => void): (()
   return fokuserNårKlar;
 };
 
+/**
+ * Flyttar fokus til panelinnhaldet når det valde panelet endrar seg etter ein snarveg.
+ *
+ * Brukast av tastatursnarvegar som byter panel (fakta, prosess, støttepanel): rett etter
+ * byttet hamnar fokus på sjølve panel-containeren, slik at neste Tab går rett inn i første
+ * skjemafelt i det nye panelet. Kall den returnerte funksjonen rett før du byter panel –
+ * fokuseringa skjer fyrst når {@link aktivtPanel} har endra seg og DOM-en er oppdatert,
+ * slik at vi ikkje treng å vente på asynkron lasting av innhaldet.
+ */
+export const useFokuserVedPanelbyte = (aktivtPanel: string | undefined, fokuser: () => void): (() => void) => {
+  const skalFokusereRef = useRef(false);
+  const fokuserRef = useRef(fokuser);
+
+  useEffect(() => {
+    fokuserRef.current = fokuser;
+  });
+
+  const planleggFokus = useCallback(() => {
+    skalFokusereRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (skalFokusereRef.current) {
+      skalFokusereRef.current = false;
+      fokuserRef.current();
+    }
+  }, [aktivtPanel]);
+
+  return planleggFokus;
+};
+
 interface Tastaturhendelse {
   key: string;
   preventDefault: () => void;

--- a/apps/fp-frontend/src/snarveger/useTastaturfokus.ts
+++ b/apps/fp-frontend/src/snarveger/useTastaturfokus.ts
@@ -85,20 +85,32 @@ export const useFokusNårKlar = (kanFokusere: boolean, fokuser: () => void): (()
  *
  * Brukast av tastatursnarvegar som byter panel (fakta, prosess, støttepanel): rett etter
  * byttet hamnar fokus på sjølve panel-containeren, slik at neste Tab går rett inn i første
- * skjemafelt i det nye panelet. Kall den returnerte funksjonen rett før du byter panel –
- * fokuseringa skjer fyrst når {@link aktivtPanel} har endra seg og DOM-en er oppdatert,
- * slik at vi ikkje treng å vente på asynkron lasting av innhaldet.
+ * skjemafelt i det nye panelet. Kall den returnerte funksjonen med målpanelet rett før du
+ * byter – fokuseringa skjer fyrst når {@link aktivtPanel} har endra seg og DOM-en er
+ * oppdatert, slik at vi ikkje treng å vente på asynkron lasting av innhaldet.
+ *
+ * Fokus blir berre planlagt når målpanelet skil seg frå det aktive panelet. Då unngår vi at
+ * eit «armert» fokus blir liggjande når byttet er ein no-op (t.d. snarveg til det panelet
+ * som alt er ope, eller ein meny med berre eitt panel) og seinare stel fokus ved ei
+ * urelatert panelendring.
  */
-export const useFokuserVedPanelbyte = (aktivtPanel: string | undefined, fokuser: () => void): (() => void) => {
+export const useFokuserVedPanelbyte = (
+  aktivtPanel: string | undefined,
+  fokuser: () => void,
+): ((målPanel: string | undefined) => void) => {
   const skalFokusereRef = useRef(false);
   const fokuserRef = useRef(fokuser);
+  const aktivtPanelRef = useRef(aktivtPanel);
 
   useEffect(() => {
     fokuserRef.current = fokuser;
+    aktivtPanelRef.current = aktivtPanel;
   });
 
-  const planleggFokus = useCallback(() => {
-    skalFokusereRef.current = true;
+  const planleggFokus = useCallback((målPanel: string | undefined) => {
+    if (målPanel !== aktivtPanelRef.current) {
+      skalFokusereRef.current = true;
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Når ein byter fakta-, prosess- eller støttepanel med tastatursnarveg, flyttast fokus no til sjølve panelet slik at neste Tab går rett inn i første skjemafelt. Brukar preventScroll for å unngå at viewporten scrollar og skjuler prosessmenyen.