### PR TITLE
fix: åpne sidepanel for snarvegar

### DIFF
--- a/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.stories.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.stories.tsx
@@ -81,6 +81,8 @@ const meta = {
   args: {
     setBehandling: action('button-click'),
     hentOgSettBehandling: action('button-click'),
+    visSideMeny: true,
+    åpneSideMeny: action('button-click'),
   },
   render: function Render(props) {
     //Må hente data til cache før testa komponent blir kalla

--- a/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -89,7 +89,7 @@ export const BehandlingMenuIndex = ({
       fokuserFørsteVedÅpning();
       setMenyÅpen(true);
     }
-  }, [fokuserFørsteVedÅpning, fokuserMenyKnapp, menyÅpen]);
+  }, [fokuserFørsteVedÅpning, fokuserMenyKnapp, menyÅpen, setMenyÅpen]);
   const åpneMenyNårSideMenyVises = useFokusNårKlar(visSideMeny, åpneOgFokuserMeny);
 
   useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.ÅPNE_BEHANDLINGSMENY, () => {

--- a/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
@@ -48,6 +48,8 @@ interface Props {
   behandling?: Behandling;
   setBehandling: (behandling: Behandling | undefined) => void;
   hentOgSettBehandling: () => void;
+  visSideMeny: boolean;
+  åpneSideMeny: () => void;
 }
 
 export const BehandlingMenuIndex = ({
@@ -56,6 +58,8 @@ export const BehandlingMenuIndex = ({
   behandling,
   setBehandling,
   hentOgSettBehandling,
+  visSideMeny,
+  åpneSideMeny,
 }: Props) => {
   const initFetchQuery = useQuery(initFetchOptions());
   const { innloggetBruker: navAnsatt } = notEmpty(initFetchQuery.data);
@@ -78,9 +82,23 @@ export const BehandlingMenuIndex = ({
   });
   const fokuserFørsteVedÅpning = useFokusNårKlar(menyÅpen, () => fokuserMenyKnapp(0));
 
+  const åpneOgFokuserMeny = useCallback(() => {
+    if (menyÅpen) {
+      fokuserMenyKnapp(0);
+    } else {
+      fokuserFørsteVedÅpning();
+      setMenyÅpen(true);
+    }
+  }, [fokuserFørsteVedÅpning, fokuserMenyKnapp, menyÅpen]);
+  const åpneMenyNårSideMenyVises = useFokusNårKlar(visSideMeny, åpneOgFokuserMeny);
+
   useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.ÅPNE_BEHANDLINGSMENY, () => {
-    fokuserFørsteVedÅpning();
-    setMenyÅpen(true);
+    if (visSideMeny) {
+      åpneOgFokuserMeny();
+    } else {
+      åpneMenyNårSideMenyVises();
+      åpneSideMeny();
+    }
   });
 
   const fagsak = fagsakData.getFagsak();

--- a/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
+++ b/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
@@ -83,6 +83,10 @@ export const FagsakIndex = () => {
     setVisSideMeny(!visSideMeny);
   };
 
+  const åpneSideMeny = () => {
+    setVisSideMeny(true);
+  };
+
   useEffect(() => {
     if (behandlingUuidFraUrl && fagsakBehandling) {
       hentOgSettBehandling();
@@ -135,6 +139,7 @@ export const FagsakIndex = () => {
             behandling={behandling}
             visSideMeny={visSideMeny}
             toggleSideMeny={toggleSideMeny}
+            åpneSideMeny={åpneSideMeny}
             visUtvidetBehandlingDetaljer={visUtvidetBehandlingDetaljer}
           />
         }

--- a/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.stories.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.stories.tsx
@@ -118,6 +118,7 @@ const meta = {
     setBehandling: action('button-click'),
     hentOgSettBehandling: action('button-click'),
     toggleSideMeny: action('button-click'),
+    åpneSideMeny: action('button-click'),
     visSideMeny: true,
     visUtvidetBehandlingDetaljer: false,
   },

--- a/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -49,6 +49,7 @@ interface Props {
   hentOgSettBehandling: () => void;
   visSideMeny: boolean;
   toggleSideMeny: () => void;
+  åpneSideMeny: () => void;
   visUtvidetBehandlingDetaljer: boolean;
 }
 
@@ -60,6 +61,7 @@ export const FagsakProfileIndex = ({
   hentOgSettBehandling,
   visSideMeny,
   toggleSideMeny,
+  åpneSideMeny,
   visUtvidetBehandlingDetaljer,
 }: Props) => {
   const intl = useIntl();
@@ -83,12 +85,22 @@ export const FagsakProfileIndex = ({
   }, [fokuserRad, hentBehandlingsvelgerRader]);
   const fokuserNårBehandlingsvelgerVises = useFokusNårKlar(showAll, fokuserBehandlingsvelger);
 
-  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.FOKUSER_BEHANDLINGSVELGER, () => {
+  const visOgFokuserBehandlingsvelger = useCallback(() => {
     if (showAll) {
       fokuserBehandlingsvelger();
     } else {
       fokuserNårBehandlingsvelgerVises();
       setShowAll(true);
+    }
+  }, [fokuserBehandlingsvelger, fokuserNårBehandlingsvelgerVises, showAll]);
+  const fokuserNårSideMenyVises = useFokusNårKlar(visSideMeny, visOgFokuserBehandlingsvelger);
+
+  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.FOKUSER_BEHANDLINGSVELGER, () => {
+    if (visSideMeny) {
+      visOgFokuserBehandlingsvelger();
+    } else {
+      fokuserNårSideMenyVises();
+      åpneSideMeny();
     }
   });
 
@@ -157,6 +169,8 @@ export const FagsakProfileIndex = ({
                   setBehandling={setBehandling}
                   hentOgSettBehandling={hentOgSettBehandling}
                   behandling={behandling}
+                  visSideMeny={visSideMeny}
+                  åpneSideMeny={åpneSideMeny}
                 />
                 <ReservasjonsstatusPanel
                   saksnummer={fagsak.saksnummer}


### PR DESCRIPTION
Problemet: panelet med behandlingsmeny (M) og behandlingsvelger (B) ligger i en kolonne som skjules via CSS (width: 0) når visSideMeny er false, men forblir i DOM-en. Snarvegene fyrte derfor, men handlingen var usynlig.