### PR TITLE
refactor: gi useRef-variabler navn som slutter på Ref

### DIFF
--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -34,11 +34,11 @@ export const useBrevEditorJs = (
   onAutoSave: (html?: string) => Promise<void>,
 ) => {
   // Hindrar tullball grunna to renders i DEV => React.StrictMode
-  const refMounted = useRef<boolean>(false);
-  const refDestroyed = useRef<boolean>(false);
-  const refEditorJs = useRef<EditorJS>(null);
-  const refUndo = useRef<Undo>(null);
-  const refCurrentHtml = useRef('');
+  const mountedRef = useRef<boolean>(false);
+  const destroyedRef = useRef<boolean>(false);
+  const editorJsRef = useRef<EditorJS>(null);
+  const undoRef = useRef<Undo>(null);
+  const currentHtmlRef = useRef('');
 
   // Refs for å unngå stale closures i EditorJS onChange-callback
   const onAutoSaveRef = useRef(onAutoSave);
@@ -55,32 +55,32 @@ export const useBrevEditorJs = (
   const autoSaveDebouncer = useAutoSaveDebouncer();
 
   const validerOgAutoLagre = async () => {
-    const editor = notEmpty(refEditorJs.current, EDITOR_IKKE_INITIALISERT);
+    const editor = notEmpty(editorJsRef.current, EDITOR_IKKE_INITIALISERT);
     const innhold = await editor.save();
     const html = edjsHTML().parse(innhold);
 
-    if (refCurrentHtml.current !== html && erRedigertHtmlGyldig(html)) {
+    if (currentHtmlRef.current !== html && erRedigertHtmlGyldig(html)) {
       void onAutoSaveRef.current(lagRedigerbartInnholdWrapper(html, footerRef.current));
     }
   };
 
   useEffect(() => {
-    if (!refEditorJs.current && !refMounted.current) {
-      refMounted.current = true;
+    if (!editorJsRef.current && !mountedRef.current) {
+      mountedRef.current = true;
       const editor = new EditorJS({
         minHeight: 20,
         data: konverterHtmlToEditorJsFormat(redigerbartInnhold),
         holder: editorHolderId,
         i18n: lagEditorJsI18n(),
         onReady: async () => {
-          if (refDestroyed.current) {
+          if (destroyedRef.current) {
             return;
           }
-          refUndo.current = new Undo({ editor });
+          undoRef.current = new Undo({ editor });
 
           // For å seinare kunne finna ut om innhaldet er endra
           const innhold = await editor.save();
-          refCurrentHtml.current = edjsHTML().parse(innhold);
+          currentHtmlRef.current = edjsHTML().parse(innhold);
         },
         tools: getTools(),
         onChange: () => {
@@ -89,37 +89,37 @@ export const useBrevEditorJs = (
       });
       // Set ref umiddelbart slik at cleanup alltid kan kalle destroy(),
       // sjølv om komponenten unmountar før onReady har fyrt
-      refEditorJs.current = editor;
+      editorJsRef.current = editor;
     }
 
     return () => {
-      refDestroyed.current = true;
-      if (refEditorJs.current?.destroy) {
-        refEditorJs.current.destroy();
+      destroyedRef.current = true;
+      if (editorJsRef.current?.destroy) {
+        editorJsRef.current.destroy();
       }
     };
   }, []);
 
   const tilbakestillEndringer = async (opprinneligRedigerbartInnhold: string) => {
-    const editor = notEmpty(refEditorJs.current, EDITOR_IKKE_INITIALISERT);
+    const editor = notEmpty(editorJsRef.current, EDITOR_IKKE_INITIALISERT);
     await editor.blocks.clear();
     await editor.blocks.render(konverterHtmlToEditorJsFormat(opprinneligRedigerbartInnhold));
     await editor.isReady;
 
     const innhold = await editor.save();
-    refCurrentHtml.current = edjsHTML().parse(innhold);
+    currentHtmlRef.current = edjsHTML().parse(innhold);
 
     void onAutoSaveRef.current(undefined);
   };
 
   /** Kombinerer validering, endringssjekk og HTML-henting i ett editor.save()-kall */
   const hentEditorStatus = async () => {
-    const editor = notEmpty(refEditorJs.current, EDITOR_IKKE_INITIALISERT);
+    const editor = notEmpty(editorJsRef.current, EDITOR_IKKE_INITIALISERT);
     const innhold = await editor.save();
     const html = edjsHTML().parse(innhold);
     return {
       erGyldig: erRedigertHtmlGyldig(html),
-      erEndret: refCurrentHtml.current !== html,
+      erEndret: currentHtmlRef.current !== html,
       redigertHtml: lagRedigerbartInnholdWrapper(html, footerRef.current),
     };
   };

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/LedigOppgaveRad.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/LedigOppgaveRad.tsx
@@ -21,10 +21,10 @@ interface Props {
 export const LedigOppgaveRad = ({ oppgave, reserverOppgave, erNyBehandling }: Props) => {
   const intl = useIntl();
 
-  const refCopyButton = useRef<HTMLDivElement | null>(null);
+  const copyButtonRef = useRef<HTMLDivElement | null>(null);
 
   const goToFagsak = (event: React.MouseEvent | React.KeyboardEvent, valgtOppgave: OppgaveDto) => {
-    const erCopyButtonKlikk = refCopyButton.current?.contains(event.target as Node);
+    const erCopyButtonKlikk = copyButtonRef.current?.contains(event.target as Node);
 
     if (erCopyButtonKlikk) {
       return;
@@ -42,7 +42,7 @@ export const LedigOppgaveRad = ({ oppgave, reserverOppgave, erNyBehandling }: Pr
     >
       <Table.DataCell>{oppgave.navn}</Table.DataCell>
       <Table.DataCell>
-        <HStack align="center" gap="space-8" ref={refCopyButton} wrap={false}>
+        <HStack align="center" gap="space-8" ref={copyButtonRef} wrap={false}>
           <BodyShort>{oppgave.saksnummer}</BodyShort>
           <CopyButton
             size="small"

--- a/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
+++ b/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
@@ -67,11 +67,11 @@ export const VarselOmRevurderingForm = ({ previewCallback, hentVarselHtml, mello
   const [skalVisePåVentModal, setSkalVisePåVentModal] = useState(false);
   const [brevData, setBrevData] = useState<{ opprinneligHtml: string; redigertHtml: string | null } | null>(null);
   const [visRedigeringModal, setVisRedigeringModal] = useState(false);
-  const hasFetchedBrevData = useRef(false);
+  const hasFetchedBrevDataRef = useRef(false);
 
   useEffect(() => {
-    if (!hasFetchedBrevData.current && erÅpentAksjonspunkt && hentVarselHtml) {
-      hasFetchedBrevData.current = true;
+    if (!hasFetchedBrevDataRef.current && erÅpentAksjonspunkt && hentVarselHtml) {
+      hasFetchedBrevDataRef.current = true;
       void hentVarselHtml()
         .then(result => {
           setBrevData({ opprinneligHtml: result.opprinneligHtml, redigertHtml: result.redigertHtml });

--- a/packages/prosess/vedtak/src/components/felles/OverstyringVedtaksbrev.tsx
+++ b/packages/prosess/vedtak/src/components/felles/OverstyringVedtaksbrev.tsx
@@ -31,11 +31,11 @@ export const OverstyringVedtaksbrev = ({ forhåndsvisBrev, setHarValgtÅRedigere
   const [visFritekstRedigeringModal, setVisFritekstRedigeringModal] = useState(false);
   const [brevOverstyring, setBrevOverstyring] = useState<BrevOverstyring | null>(null);
   const [henterVedtaksbrevPdf, setHenterVedtaksbrevPdf] = useState(false);
-  const hasFetchedBrevOverstyring = useRef(false);
+  const hasFetchedBrevOverstyringRef = useRef(false);
 
   useEffect(() => {
-    if (!isReadOnly && !hasFetchedBrevOverstyring.current && harRedigertBrev && hentBrevHtml) {
-      hasFetchedBrevOverstyring.current = true;
+    if (!isReadOnly && !hasFetchedBrevOverstyringRef.current && harRedigertBrev && hentBrevHtml) {
+      hasFetchedBrevOverstyringRef.current = true;
       void hentBrevHtml().then(setBrevOverstyring);
     }
   }, []);

--- a/packages/sak/notat/src/components/NotatPanel.tsx
+++ b/packages/sak/notat/src/components/NotatPanel.tsx
@@ -43,25 +43,25 @@ export const NotatPanel = ({ saksnummer, notater, lagreNotat, saksbehandlerNavn,
     formMethods.reset();
   };
 
-  const bottomEl = useRef<HTMLDivElement | null>(null);
+  const bottomElRef = useRef<HTMLDivElement | null>(null);
   const [top, setTop] = useState<number>();
 
   // Denne for å scrolle innerste scrollbar ved bytte til notat-fane
-  const isInitialMount = useRef(0);
+  const isInitialMountRef = useRef(0);
   useEffect(() => {
-    const lastChildElement = bottomEl.current?.lastElementChild;
-    isInitialMount.current += 1;
-    if (isInitialMount.current === 2 && lastChildElement?.scrollIntoView) {
+    const lastChildElement = bottomElRef.current?.lastElementChild;
+    isInitialMountRef.current += 1;
+    if (isInitialMountRef.current === 2 && lastChildElement?.scrollIntoView) {
       lastChildElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
   }, [top]);
 
   // Denne for å scrolle innerste scrollbar når en legger til notat
-  const isInitialMount2 = useRef(true);
+  const isInitialMount2Ref = useRef(true);
   useEffect(() => {
-    const lastChildElement = bottomEl.current?.lastElementChild;
-    if (isInitialMount2.current) {
-      isInitialMount2.current = false;
+    const lastChildElement = bottomElRef.current?.lastElementChild;
+    if (isInitialMount2Ref.current) {
+      isInitialMount2Ref.current = false;
     } else if (lastChildElement?.scrollIntoView) {
       lastChildElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
@@ -87,7 +87,7 @@ export const NotatPanel = ({ saksnummer, notater, lagreNotat, saksbehandlerNavn,
       }}
     >
       {sorterteNotater.length > 0 && (
-        <div className={styles['thechats']} ref={bottomEl}>
+        <div className={styles['thechats']} ref={bottomElRef}>
           <VStack gap="space-8">
             {sorterteNotater.map((notat, index) => (
               <div key={notat.opprettetTidspunkt} className={index === 0 ? styles['marginTop'] : undefined}>


### PR DESCRIPTION
Tilfredsstiller eslint-regelen @eslint-react/naming-convention-ref-name. Rene lokale omdøpinger uten sideeffekter.