### PR TITLE
refactor: erstatt forwardRef i FaktaGruppe med ref-as-prop

### DIFF
--- a/packages/fakta/felles/src/components/FaktaBox.tsx
+++ b/packages/fakta/felles/src/components/FaktaBox.tsx
@@ -4,8 +4,8 @@ import { BodyShort, Box, Detail, HStack, Label, VStack } from '@navikt/ds-react'
 
 import { type FaktaKilde, getLabelForFaktaKilde } from './FaktaKilde';
 
-export const FaktaGruppe = (props: ComponentPropsWithRef<'div'>) => (
-  <HStack gap="space-8" style={{ display: 'flex' }} {...props} />
+export const FaktaGruppe = ({ ref, ...props }: ComponentPropsWithRef<'div'>) => (
+  <HStack gap="space-8" style={{ display: 'flex' }} {...props} ref={ref} />
 );
 
 interface FaktaBoxProps {

--- a/packages/fakta/felles/src/components/FaktaBox.tsx
+++ b/packages/fakta/felles/src/components/FaktaBox.tsx
@@ -1,14 +1,12 @@
-import React, { forwardRef, type ForwardRefExoticComponent, type PropsWithChildren, type ReactNode } from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 
 import { BodyShort, Box, Detail, HStack, Label, VStack } from '@navikt/ds-react';
 
 import { type FaktaKilde, getLabelForFaktaKilde } from './FaktaKilde';
 
-export const FaktaGruppe = forwardRef((props, ref) => (
-  <HStack gap="space-8" style={{ display: 'flex' }} {...props} ref={ref} />
-)) as ForwardRefExoticComponent<PropsWithChildren & React.RefAttributes<HTMLDivElement>>;
-
-FaktaGruppe.displayName = 'FaktaGruppe';
+export const FaktaGruppe = (props: ComponentProps<typeof HStack>) => (
+  <HStack gap="space-8" style={{ display: 'flex' }} {...props} />
+);
 
 interface FaktaBoxProps {
   label: string | ReactNode;

--- a/packages/fakta/felles/src/components/FaktaBox.tsx
+++ b/packages/fakta/felles/src/components/FaktaBox.tsx
@@ -1,10 +1,10 @@
-import { type ComponentProps, type ReactNode } from 'react';
+import { type ComponentPropsWithRef, type ReactNode } from 'react';
 
 import { BodyShort, Box, Detail, HStack, Label, VStack } from '@navikt/ds-react';
 
 import { type FaktaKilde, getLabelForFaktaKilde } from './FaktaKilde';
 
-export const FaktaGruppe = (props: ComponentProps<typeof HStack>) => (
+export const FaktaGruppe = (props: ComponentPropsWithRef<'div'>) => (
   <HStack gap="space-8" style={{ display: 'flex' }} {...props} />
 );
 


### PR DESCRIPTION
Migrerer FaktaGruppe til React 19 ref-as-prop slik at @eslint-react/no-forward-ref ikke lenger trigges, uten å endre oppførsel.