### PR TITLE
refactor: erstatt set-state-in-effect med render-fase-utleiing

### DIFF
--- a/apps/fp-frontend/src/behandling/felles/prosess/InngangsvilkarDefaultInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/InngangsvilkarDefaultInitPanel.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, use, useEffect, useState } from 'react';
+import { type ReactElement, use, useState } from 'react';
 
 import { type OverstyringAksjonspunkter } from '@navikt/fp-kodeverk';
 import type { BehandlingFpSak, VilkårType } from '@navikt/fp-types';
@@ -30,10 +30,11 @@ export const InngangsvilkarOverstyringDefaultInitPanel = (
   const [erOverstyrt, setErOverstyrt] = useState(false);
   const toggleOverstyring = () => setErOverstyrt(!erOverstyrt);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- OK, skjer kun ved ekstern endring av behandling
+  const [forrigeVersjon, setForrigeVersjon] = useState(behandling.versjon);
+  if (behandling.versjon !== forrigeVersjon) {
+    setForrigeVersjon(behandling.versjon);
     setErOverstyrt(false);
-  }, [behandling.versjon]);
+  }
 
   return (
     <PanelOverstyringProvider

--- a/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Navigate, NavLink, useLocation, useMatch } from 'react-router-dom';
 
@@ -66,6 +66,12 @@ export const FagsakProfileIndex = ({
   const [showAll, setShowAll] = useState(!behandlingUuid);
   const toggleShowAll = () => setShowAll(!showAll);
 
+  const [forrigeBehandlingUuid, setForrigeBehandlingUuid] = useState(behandlingUuid);
+  if (behandlingUuid !== forrigeBehandlingUuid) {
+    setForrigeBehandlingUuid(behandlingUuid);
+    setShowAll(!behandlingUuid);
+  }
+
   const {
     containerRef: behandlingsvelgerRef,
     hentElementer: hentBehandlingsvelgerRader,
@@ -111,11 +117,6 @@ export const FagsakProfileIndex = ({
   const ainntektHref = sakLinks.find(l => l.rel === 'ainntekt-redirect')?.href;
 
   const { addErrorMessage } = useRestApiErrorDispatcher();
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- OK, skjer kun ved valg av ny behandling
-    setShowAll(!behandlingUuid);
-  }, [behandlingUuid]);
 
   const match = useMatch('/fagsak/:saksnummer/');
   const shouldRedirectToBehandlinger = !!match;

--- a/apps/fp-journalforing/src/components/header/JournalføringHeader.tsx
+++ b/apps/fp-journalforing/src/components/header/JournalføringHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronLeftIcon, MagnifyingGlassIcon } from '@navikt/aksel-icons';
@@ -29,12 +29,13 @@ export const JournalføringHeader = ({
 }: Props) => {
   const [åpenSøkemodal, setÅpenSøkemodal] = useState(false);
 
-  useEffect(() => {
+  const [forrigeJournalpost, setForrigeJournalpost] = useState(valgtJournalpost);
+  if (valgtJournalpost !== forrigeJournalpost) {
+    setForrigeJournalpost(valgtJournalpost);
     if (valgtJournalpost) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setÅpenSøkemodal(false);
     }
-  }, [valgtJournalpost]);
+  }
 
   return (
     <HStack className={styles['header']}>

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -53,6 +53,11 @@ const sorterEtterOpptjeningFom = (
 
 const addDay = (dato: string): string => addDaysToDate(dato, 1);
 
+const finnFørsteIkkeBehandledeIndex = (formVerdier: FormValues[]): number | undefined => {
+  const index = formVerdier.findIndex(a => a.erGodkjent === undefined);
+  return index === -1 ? undefined : index;
+};
+
 const filtrerOpptjeningAktiviteter = (
   opptjeningAktiviteter: OpptjeningAktivitet[],
   fastsattOpptjening?: Opptjening['fastsattOpptjening'],
@@ -116,7 +121,7 @@ export const OpptjeningFaktaPanel = ({
   );
 
   const [valgtAktivitetIndex, setValgtAktivitetIndex] = useState(
-    finnInitialFokusAktivitet(filtrerteOgSorterteOpptjeningsaktiviteter),
+    finnFørsteIkkeBehandledeIndex(formVerdierForAlleAktiviteter),
   );
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -128,11 +133,11 @@ export const OpptjeningFaktaPanel = ({
     [formVerdierForAlleAktiviteter],
   );
 
-  useEffect(() => {
-    const index = formVerdierForAlleAktiviteter.findIndex(a => a.erGodkjent === undefined);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setValgtAktivitetIndex(index === -1 ? undefined : index);
-  }, [formVerdierForAlleAktiviteter]);
+  const [forrigeFormVerdier, setForrigeFormVerdier] = useState(formVerdierForAlleAktiviteter);
+  if (formVerdierForAlleAktiviteter !== forrigeFormVerdier) {
+    setForrigeFormVerdier(formVerdierForAlleAktiviteter);
+    setValgtAktivitetIndex(finnFørsteIkkeBehandledeIndex(formVerdierForAlleAktiviteter));
+  }
 
   const bekreft = () => {
     setIsSubmitting(true);
@@ -226,14 +231,6 @@ export const OpptjeningFaktaPanel = ({
       )}
     </VStack>
   );
-};
-
-const finnInitialFokusAktivitet = (opptjeningsAktiviteter: OpptjeningAktivitet[]) => {
-  if (opptjeningsAktiviteter.length === 0) return undefined;
-
-  const førsteAktivitetSomIkkeErGodkjent = opptjeningsAktiviteter.findIndex(a => a.erGodkjent === undefined);
-  if (førsteAktivitetSomIkkeErGodkjent !== -1) return førsteAktivitetSomIkkeErGodkjent;
-  return 0;
 };
 
 const transformValues = (

--- a/packages/los/saksbehandler/src/reservasjonsstatusPanel/ReservasjonsstatusPanel.tsx
+++ b/packages/los/saksbehandler/src/reservasjonsstatusPanel/ReservasjonsstatusPanel.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
 
 import { PadlockLockedIcon } from '@navikt/aksel-icons';
@@ -19,20 +18,14 @@ interface Props {
 }
 
 export const ReservasjonsstatusPanel = ({ saksnummer, behandlingUuid, kanVeilede }: Props) => {
-  const [erOppgaveReservert, setErOppgaveReservert] = useState(false);
-
   const { data: reserverteOppgaver = [], refetch } = useQuery({
     ...oppgaverForFagsakerOptions([saksnummer]),
-    refetchInterval: erOppgaveReservert ? false : 30000,
+    refetchInterval: query =>
+      query.state.data?.find(ro => ro.behandlingId === behandlingUuid)?.reservasjonStatus.erReservert ? false : 30000,
   });
 
   const oppgaveForBehandling = reserverteOppgaver.find(ro => ro.behandlingId === behandlingUuid);
   const erReservert = oppgaveForBehandling?.reservasjonStatus.erReservert;
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setErOppgaveReservert(erReservert || false);
-  }, [erReservert]);
 
   const { mutate: opphevOppgavereservasjon } = useMutation({
     mutationFn: opphevReservasjon,

--- a/packages/prosess/vedtak/src/VedtakEditeringContext.tsx
+++ b/packages/prosess/vedtak/src/VedtakEditeringContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactElement, use, useEffect, useMemo, useState } from 'react';
+import { createContext, type ReactElement, use, useMemo, useState } from 'react';
 
 import type { BehandlingFpSak, BrevOverstyring } from '@navikt/fp-types';
 
@@ -25,12 +25,15 @@ export const VedtakEditeringProvider = ({
   mellomlagreBrev: (redigertInnhold?: string) => Promise<void>;
   children: ReactElement;
 }) => {
-  const [harRedigertBrev, setHarRedigertBrev] = useState(behandling.links.some(l => l.rel === 'overstyrt-vedtaksbrev'));
+  const initiellHarRedigertBrev = behandling.links.some(l => l.rel === 'overstyrt-vedtaksbrev');
+  const [harRedigertBrev, setHarRedigertBrev] = useState(initiellHarRedigertBrev);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- OK, skjer kun ved endring av behandling
-    setHarRedigertBrev(behandling.links.some(l => l.rel === 'overstyrt-vedtaksbrev'));
-  }, [behandling.uuid, behandling.versjon]);
+  const behandlingKey = `${behandling.uuid}-${behandling.versjon}`;
+  const [forrigeBehandlingKey, setForrigeBehandlingKey] = useState(behandlingKey);
+  if (behandlingKey !== forrigeBehandlingKey) {
+    setForrigeBehandlingKey(behandlingKey);
+    setHarRedigertBrev(initiellHarRedigertBrev);
+  }
 
   const value = useMemo(
     () => ({

--- a/packages/utils/src/context/MellomlagretFormDataContext.tsx
+++ b/packages/utils/src/context/MellomlagretFormDataContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactElement, use, useEffect, useMemo, useState } from 'react';
+import { createContext, type ReactElement, use, useMemo, useState } from 'react';
 
 import type { Behandling } from '@navikt/fp-types';
 
@@ -18,12 +18,14 @@ export const MellomlagretFormDataProvider = <T,>({
 }) => {
   const [mellomlagretFormData, setMellomlagretFormData] = useState<T | undefined>();
 
-  useEffect(() => {
+  const behandlingKey = `${behandling.uuid}-${behandling.versjon}`;
+  const [forrigeBehandlingKey, setForrigeBehandlingKey] = useState(behandlingKey);
+  if (behandlingKey !== forrigeBehandlingKey) {
+    setForrigeBehandlingKey(behandlingKey);
     if (mellomlagretFormData) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- OK, skjer kun ved endring av behandling
       setMellomlagretFormData(undefined);
     }
-  }, [behandling.uuid, behandling.versjon]);
+  }
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
Fjernar useEffect-baserte setState-kall i 7 komponentar til fordel for rein utleiing eller det anbefalte mønsteret med å lagre førre verdi og oppdatere vilkårsstyrt under render. useOppgavePolling beheld effekten sidan den driv ei genuin asynkron long-polling-løkke.