### PR TITLE
fix: aktiver @eslint-react/purity og fjern new Date() i render

### DIFF
--- a/packages/config/eslint/eslint.config.mjs
+++ b/packages/config/eslint/eslint.config.mjs
@@ -52,6 +52,7 @@ export default [
   {
     rules: {
       ...vitest.configs.recommended.rules,
+      '@eslint-react/purity': ERROR,
       eqeqeq: ERROR,
       'max-len': [ERROR, 160],
       'no-console': ERROR,

--- a/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
+++ b/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useForm, type UseFormGetValues } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -55,6 +56,8 @@ export const SjekkTerminbekreftelseForm = ({ fødsel: { gjeldende }, aksjonspunk
 
   const isForTidligTerminbekreftelse = erTerminbekreftelseUtstedtForTidlig(utstedtdato, termindato);
 
+  const iDag = useMemo(() => new Date(), []);
+
   return (
     <FaktaKort
       label={intl.formatMessage({ id: 'SjekkTerminbekreftelseForm.Tittel' })}
@@ -78,7 +81,7 @@ export const SjekkTerminbekreftelseForm = ({ fødsel: { gjeldende }, aksjonspunk
               readOnly={isReadOnly}
               fromDate={minTerminbekreftelseDato().toDate()}
               toDate={maxTerminbekreftelseDato().toDate()}
-              defaultMonth={new Date()}
+              defaultMonth={iDag}
             />
 
             <RhfTextField

--- a/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
+++ b/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState } from 'react';
 import { useForm, type UseFormGetValues } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -56,7 +56,7 @@ export const SjekkTerminbekreftelseForm = ({ fødsel: { gjeldende }, aksjonspunk
 
   const isForTidligTerminbekreftelse = erTerminbekreftelseUtstedtForTidlig(utstedtdato, termindato);
 
-  const iDag = useMemo(() => new Date(), []);
+  const [iDag] = useState(() => new Date());
 
   return (
     <FaktaKort

--- a/packages/fakta/fodsel/src/components/form/Termindato.tsx
+++ b/packages/fakta/fodsel/src/components/form/Termindato.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps } from 'react';
+import { type ComponentProps, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
@@ -29,6 +29,8 @@ export const Termindato = ({ isReadOnly, isRequired = true }: TermindatoProps) =
   const intl = useIntl();
   const { control } = useFormContext<TermindatoFormValues>();
 
+  const iDag = useMemo(() => new Date(), []);
+
   return (
     <RhfDatepicker
       control={control}
@@ -38,7 +40,7 @@ export const Termindato = ({ isReadOnly, isRequired = true }: TermindatoProps) =
       validate={isRequired ? [required, ...notRequiredValidation] : notRequiredValidation}
       fromDate={minTermindato().toDate()}
       toDate={maxTermindato().toDate()}
-      defaultMonth={new Date()}
+      defaultMonth={iDag}
       readOnly={isReadOnly}
     />
   );

--- a/packages/fakta/fodsel/src/components/form/Termindato.tsx
+++ b/packages/fakta/fodsel/src/components/form/Termindato.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, useMemo } from 'react';
+import { type ComponentProps, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
@@ -29,7 +29,7 @@ export const Termindato = ({ isReadOnly, isRequired = true }: TermindatoProps) =
   const intl = useIntl();
   const { control } = useFormContext<TermindatoFormValues>();
 
-  const iDag = useMemo(() => new Date(), []);
+  const [iDag] = useState(() => new Date());
 
   return (
     <RhfDatepicker

--- a/packages/los/felles/src/endreReservasjondato/EndreReservasjonDato.tsx
+++ b/packages/los/felles/src/endreReservasjondato/EndreReservasjonDato.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { CalendarIcon, CheckmarkIcon } from '@navikt/aksel-icons';
 import { Button, DatePicker, HStack, Loader } from '@navikt/ds-react';
@@ -40,7 +40,7 @@ export const EndreReservasjonDato = ({ reservertTilTidspunkt, oppgaveId, invalid
 
   const { title, icon } = getState(isPending, showSuccess);
   const gjeldendeDato = new Date(reservertTilTidspunkt);
-  const iDag = useMemo(() => new Date(), []);
+  const [iDag] = useState(() => new Date());
   return (
     <HStack gap="space-8" align="center" wrap={false}>
       <span className="w-[7ch]">{capitalizeFirstLetter(dayjs(reservertTilTidspunkt).format('dddd'))}</span>

--- a/packages/los/felles/src/endreReservasjondato/EndreReservasjonDato.tsx
+++ b/packages/los/felles/src/endreReservasjondato/EndreReservasjonDato.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { CalendarIcon, CheckmarkIcon } from '@navikt/aksel-icons';
 import { Button, DatePicker, HStack, Loader } from '@navikt/ds-react';
@@ -40,6 +40,7 @@ export const EndreReservasjonDato = ({ reservertTilTidspunkt, oppgaveId, invalid
 
   const { title, icon } = getState(isPending, showSuccess);
   const gjeldendeDato = new Date(reservertTilTidspunkt);
+  const iDag = useMemo(() => new Date(), []);
   return (
     <HStack gap="space-8" align="center" wrap={false}>
       <span className="w-[7ch]">{capitalizeFirstLetter(dayjs(reservertTilTidspunkt).format('dddd'))}</span>
@@ -52,7 +53,7 @@ export const EndreReservasjonDato = ({ reservertTilTidspunkt, oppgaveId, invalid
         defaultSelected={gjeldendeDato}
         onSelect={date => (date ? mutateAsync(date) : null)}
         onClose={() => setOpenDatepicker(false)}
-        fromDate={new Date()}
+        fromDate={iDag}
         toDate={dayjs().startOf('day').add(30, 'days').toDate()}
       >
         <Button

--- a/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanel/TerminOgFodselPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanel/TerminOgFodselPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState } from 'react';
 import { useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
 
@@ -75,7 +75,7 @@ const validerTerminBekreftelse =
 export const TerminOgFodselPanel = ({ readOnly, erForeldrepenger = false }: Props) => {
   const { watch, getValues, control } = useFormContext<FormValues>();
 
-  const iDag = useMemo(() => new Date(), []);
+  const [iDag] = useState(() => new Date());
 
   const erBarnetFødt = watch('erBarnetFødt');
 

--- a/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanel/TerminOgFodselPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanel/TerminOgFodselPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
 
@@ -74,6 +75,8 @@ const validerTerminBekreftelse =
 export const TerminOgFodselPanel = ({ readOnly, erForeldrepenger = false }: Props) => {
   const { watch, getValues, control } = useFormContext<FormValues>();
 
+  const iDag = useMemo(() => new Date(), []);
+
   const erBarnetFødt = watch('erBarnetFødt');
 
   return (
@@ -109,7 +112,7 @@ export const TerminOgFodselPanel = ({ readOnly, erForeldrepenger = false }: Prop
                       readOnly={readOnly}
                       fromDate={minTermindato().toDate()}
                       toDate={maxTermindato().toDate()}
-                      defaultMonth={new Date()}
+                      defaultMonth={iDag}
                       validate={[
                         required,
                         hasValidDate,
@@ -136,7 +139,7 @@ export const TerminOgFodselPanel = ({ readOnly, erForeldrepenger = false }: Prop
                     readOnly={readOnly}
                     fromDate={minTerminbekreftelseDato().toDate()}
                     toDate={maxTerminbekreftelseDato().toDate()}
-                    defaultMonth={new Date()}
+                    defaultMonth={iDag}
                     validate={[hasValidDate, validerTerminBekreftelse(getValues)]}
                   />
                 </>
@@ -185,7 +188,7 @@ export const TerminOgFodselPanel = ({ readOnly, erForeldrepenger = false }: Prop
                     ]}
                     fromDate={minTermindato().toDate()}
                     toDate={maxTermindato().toDate()}
-                    defaultMonth={new Date()}
+                    defaultMonth={iDag}
                   />
                 </>
               )}

--- a/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminOgFodselPanelSvp.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminOgFodselPanelSvp.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState } from 'react';
 import { useFormContext, type UseFormGetValues } from 'react-hook-form';
 
 import { Heading, Radio, VStack } from '@navikt/ds-react';
@@ -49,7 +49,7 @@ const validateTermin = (getValues: UseFormGetValues<FormValues>) => (termindato:
 export const TerminOgFodselPanelSvp = ({ readOnly }: Props) => {
   const { getValues, watch, control } = useFormContext<FormValues>();
 
-  const iDag = useMemo(() => new Date(), []);
+  const [iDag] = useState(() => new Date());
 
   const erBarnetFødt = watch('erBarnetFødt');
 

--- a/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminOgFodselPanelSvp.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminOgFodselPanelSvp.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useFormContext, type UseFormGetValues } from 'react-hook-form';
 
 import { Heading, Radio, VStack } from '@navikt/ds-react';
@@ -48,6 +49,8 @@ const validateTermin = (getValues: UseFormGetValues<FormValues>) => (termindato:
 export const TerminOgFodselPanelSvp = ({ readOnly }: Props) => {
   const { getValues, watch, control } = useFormContext<FormValues>();
 
+  const iDag = useMemo(() => new Date(), []);
+
   const erBarnetFødt = watch('erBarnetFødt');
 
   return (
@@ -88,7 +91,7 @@ export const TerminOgFodselPanelSvp = ({ readOnly }: Props) => {
           readOnly={readOnly}
           fromDate={minTermindato().toDate()}
           toDate={maxTermindato().toDate()}
-          defaultMonth={new Date()}
+          defaultMonth={iDag}
           validate={[
             required,
             hasValidDate,


### PR DESCRIPTION
@sirimykland Kva syns du om denne? Overkill?

Flytter inline new Date()-kall ut av render og memoiserer dei, slik at datepicker-komponentane ikkje bryt purity-regelen. Aktiverer regelen som error i den delte eslint-konfigurasjonen.