### PR TITLE
refactor: bytt useForm().watch til useWatch for kompilator-kompatibil…

### DIFF
--- a/apps/fp-avdelingsleder/src/behandlingskoer/saksbehandlerForm/SaksbehandlereForSakslisteForm.tsx
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/saksbehandlerForm/SaksbehandlereForSakslisteForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Box, Checkbox, ExpansionCard, Label, Table, VStack } from '@navikt/ds-react';
@@ -38,7 +38,7 @@ export const SaksbehandlereForSakslisteForm = ({
     defaultValues,
   });
 
-  const formvalues = formMethods.watch();
+  const formvalues = useWatch({ control: formMethods.control });
 
   useEffect(() => {
     formMethods.reset(defaultValues);

--- a/apps/fp-avdelingsleder/src/nokkeltall/apneOgPaVentBehandlinger/OppgaverSomErApneEllerPaVentPanel.tsx
+++ b/apps/fp-avdelingsleder/src/nokkeltall/apneOgPaVentBehandlinger/OppgaverSomErApneEllerPaVentPanel.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { HStack, Label, VStack } from '@navikt/ds-react';
@@ -44,7 +44,7 @@ export const OppgaverSomErApneEllerPaVentPanel = ({ height, valgtAvdelingEnhet }
     defaultValues: lagretFilter ?? formDefaultValues,
   });
 
-  const values = formMethods.watch();
+  const values = useWatch({ control: formMethods.control });
 
   useStoreValuesInLocalStorage(formName, values);
 

--- a/packages/fakta/aap/src/components/KontrollerBeregningAapKombinertAtflPanel.tsx
+++ b/packages/fakta/aap/src/components/KontrollerBeregningAapKombinertAtflPanel.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, VStack } from '@navikt/ds-react';
@@ -28,7 +28,7 @@ export const KontrollerBeregningAapKombinertAtflPanel = ({ aksjonspunkt }: Props
   const formMethods = useForm<FormValues>({
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkt),
   });
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   return (
     <VStack gap="space-16">

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { useForm, type UseFormGetValues } from 'react-hook-form';
+import { useForm, type UseFormGetValues, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { QuestionmarkDiamondIcon } from '@navikt/aksel-icons';
@@ -79,7 +79,7 @@ export const ManglendeArbeidsforholdForm = ({
 
   useSetDirtyForm(formMethods.formState.isDirty);
 
-  const saksbehandlersVurdering = formMethods.watch('saksbehandlersVurdering');
+  const saksbehandlersVurdering = useWatch({ control: formMethods.control, name: 'saksbehandlersVurdering' });
 
   const avbryt = () => {
     lukkArbeidsforholdRad();

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useForm, type UseFormGetValues, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -118,9 +118,7 @@ export const ManglendeArbeidsforholdForm = ({
       .finally(() => formMethods.reset(formValues));
   };
 
-  const buttonRef = useRef<SVGSVGElement>(null);
-  const [openState, setOpenState] = useState(false);
-  const toggleHjelpetekst = () => setOpenState(gammelVerdi => !gammelVerdi);
+  const [anchorEl, setAnchorEl] = useState<SVGSVGElement | null>(null);
 
   return (
     <VStack gap="space-32">
@@ -139,14 +137,13 @@ export const ManglendeArbeidsforholdForm = ({
                 <FormattedMessage id="ManglendeOpplysningerForm.SkalBrukeInntekstmelding" />
                 <QuestionmarkDiamondIcon
                   className={styles['svg']}
-                  ref={buttonRef}
-                  onClick={toggleHjelpetekst}
+                  onClick={event => setAnchorEl(anchorEl ? null : event.currentTarget)}
                   title={intl.formatMessage({ id: 'ManglendeOpplysningerForm.AltHjelpetekst' })}
                 />
                 <Popover
-                  open={openState}
-                  onClose={toggleHjelpetekst}
-                  anchorEl={buttonRef.current}
+                  open={anchorEl !== null}
+                  onClose={() => setAnchorEl(null)}
+                  anchorEl={anchorEl}
                   className={styles['hjelpetekst']}
                 >
                   <Popover.Content className={styles['hjelpetekstInnhold']}>

--- a/packages/fakta/besteberegning/src/components/KontrollerBesteberegningPanel.tsx
+++ b/packages/fakta/besteberegning/src/components/KontrollerBesteberegningPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { VStack } from '@navikt/ds-react';
@@ -35,7 +35,7 @@ export const KontrollerBesteberegningPanel = ({ aksjonspunkt }: Props) => {
   const formMethods = useForm<FormValues>({
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkt),
   });
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
   return (
     <VStack gap="space-16">
       {aksjonspunkt.status === 'OPPR' && (

--- a/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkManglendeFødselForm.tsx
+++ b/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkManglendeFødselForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Alert, VStack } from '@navikt/ds-react';
@@ -34,7 +34,7 @@ export const SjekkManglendeFødselForm = ({ aksjonspunkt, fødsel: { gjeldende, 
     defaultValues: mellomlagretFormData ?? initialValues(gjeldende, aksjonspunkt),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
   const finnesBarnIFReg = gjeldende.barn.some(b => b.kilde === 'FOLKEREGISTER');
   const diffIAntallBarn = register.barn.length > 0 && register.barn.length !== søknad.antallBarn;
 

--- a/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
+++ b/packages/fakta/fodsel/src/components/aksjonspunkt/SjekkTerminbekreftelseForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useForm, type UseFormGetValues } from 'react-hook-form';
+import { useForm, type UseFormGetValues, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Alert, HStack, VStack } from '@navikt/ds-react';
@@ -50,9 +50,9 @@ export const SjekkTerminbekreftelseForm = ({ fødsel: { gjeldende }, aksjonspunk
     defaultValues: mellomlagretFormData ?? initialValues(gjeldende, aksjonspunkt),
   });
 
-  const termindato = formMethods.watch('termindato');
-  const utstedtdato = formMethods.watch('utstedtdato');
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const termindato = useWatch({ control: formMethods.control, name: 'termindato' });
+  const utstedtdato = useWatch({ control: formMethods.control, name: 'utstedtdato' });
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const isForTidligTerminbekreftelse = erTerminbekreftelseUtstedtForTidlig(utstedtdato, termindato);
 

--- a/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
+++ b/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
 import { VStack } from '@navikt/ds-react';
@@ -43,7 +43,7 @@ export const VurderMedlemskapAksjonspunktForm = ({ manuellBehandlingResultat }: 
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel, manuellBehandlingResultat),
   });
 
-  const begrunnelseVerdi = formMethods.watch('begrunnelse');
+  const begrunnelseVerdi = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const erForutgående = harAksjonspunkt(AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR, aksjonspunkterForPanel);
 

--- a/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Checkbox, Radio, VStack } from '@navikt/ds-react';
@@ -50,9 +50,9 @@ export const VurderOmsorgsovertakelseVilkåretForm = ({ omsorgsovertakelse }: Pr
     defaultValues: buildInitialValues(omsorgsovertakelse, aksjonspunkterForPanel, alleBarn),
   });
 
-  const delvilkår = formMethods.watch('delvilkår');
-  const vilkårUtfallType = formMethods.watch('vilkårUtfallType');
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const delvilkår = useWatch({ control: formMethods.control, name: 'delvilkår' });
+  const vilkårUtfallType = useWatch({ control: formMethods.control, name: 'vilkårUtfallType' });
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
   const avslagsÅrsaker = useMemo(() => {
     if (!delvilkår) return [];
 

--- a/packages/fakta/permisjon/src/components/PermisjonFaktaPanel.tsx
+++ b/packages/fakta/permisjon/src/components/PermisjonFaktaPanel.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { BodyShort, Heading, HStack, VStack } from '@navikt/ds-react';
@@ -59,7 +59,7 @@ export const PermisjonFaktaPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysningerP
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel, sorterteArbeidsforhold),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
   const harÅpentAksjonspunkt = aksjonspunkterForPanel.some(a => a.status === 'OPPR');
 
   return (

--- a/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
+++ b/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Heading, Radio, VStack } from '@navikt/ds-react';
@@ -34,7 +34,7 @@ export const InnhentDokOpptjeningUtlandAP = ({ aksjonspunkt, dokStatus }: Props)
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkt, dokStatus),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   return (
     <AksjonspunktBox

--- a/packages/fakta/saken/src/components/dekningsgrad/DekningradAP.tsx
+++ b/packages/fakta/saken/src/components/dekningsgrad/DekningradAP.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { HStack, Radio, VStack } from '@navikt/ds-react';
@@ -35,7 +35,7 @@ export const DekningradAP = ({ ytelseFordeling, aksjonspunkt }: Props) => {
     defaultValues: mellomlagretFormData ?? buildInitialValues(ytelseFordeling, aksjonspunkt),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const { dekningsgrader } = ytelseFordeling;
   const { bruker, annenPart } = fagsak;

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { FormProvider, useForm, type UseFormGetValues } from 'react-hook-form';
+import { FormProvider, useForm, type UseFormGetValues, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { Button, HStack, Radio, VStack } from '@navikt/ds-react';
@@ -116,7 +116,7 @@ export const OppholdForm = ({
 
   // Når årsak endres må fom revalideres slik at en eventuell foreldet «samme fom»-feil
   // forsvinner når bruker bytter til Ferie (ferie kan dele fom med en tilrettelegging).
-  const valgtÅrsak = formMethods.watch(`${index}.oppholdÅrsak`);
+  const valgtÅrsak = useWatch({ control: formMethods.control, name: `${index}.oppholdÅrsak` });
   useEffect(() => {
     if (formMethods.getValues(`${index}.fom`)) {
       void formMethods.trigger(`${index}.fom`);

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaDetailForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaDetailForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, useState } from 'react';
-import { useForm, type UseFormGetValues } from 'react-hook-form';
+import { useForm, type UseFormGetValues, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -45,8 +45,8 @@ export const UttakEøsFaktaDetailForm = ({ annenForelderUttakEøsPeriode, oppdat
     defaultValues: annenForelderUttakEøsPeriode ? buildInitialValues(annenForelderUttakEøsPeriode) : undefined,
   });
 
-  const fom = formMethods.watch('fom');
-  const tom = formMethods.watch('tom');
+  const fom = useWatch({ control: formMethods.control, name: 'fom' });
+  const tom = useWatch({ control: formMethods.control, name: 'tom' });
 
   const [visSletteDialog, setVisSletteDialog] = useState(false);
   const slettUttaksperiode = () => {

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -38,7 +38,6 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
   );
   const [erOverstyrt, setErOverstyrt] = useState(false);
   const [visLeggTilPeriodeForm, setVisLeggTilPeriodeForm] = useState(false);
-  const [feilmelding, setFeilmelding] = useState<string | undefined>();
   const [isDirty, setIsDirty] = useState(false);
 
   const formMethods = useForm<FaktaBegrunnelseFormValues>({
@@ -51,15 +50,11 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
 
   const erRedigerbart = !isReadOnly && (automatiskeAksjonspunkter.length > 0 || erOverstyrt);
 
-  useEffect(() => {
-    const periodeMap = perioder.map(({ fom, tom }) => [fom, tom]);
-    const erOverlappendePerioder = periodeMap.length > 0 ? !!dateRangesNotOverlapping(periodeMap) : undefined;
-    if (erOverlappendePerioder) {
-      setFeilmelding(intl.formatMessage({ id: 'UttakEøsFaktaForm.OverlappendePerioder' }));
-    } else {
-      setFeilmelding(undefined);
-    }
-  }, [perioder]);
+  const periodeMap = perioder.map(({ fom, tom }) => [fom, tom]);
+  const erOverlappendePerioder = periodeMap.length > 0 ? !!dateRangesNotOverlapping(periodeMap) : undefined;
+  const feilmelding = erOverlappendePerioder
+    ? intl.formatMessage({ id: 'UttakEøsFaktaForm.OverlappendePerioder' })
+    : undefined;
 
   const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { ErrorSummary, Heading, HStack, VStack } from '@navikt/ds-react';
@@ -61,7 +61,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
     }
   }, [perioder]);
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   useEffect(() => {
     setMellomlagretFormData({

--- a/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm, type UseFormGetValues } from 'react-hook-form';
+import { useForm, type UseFormGetValues, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -113,10 +113,10 @@ export const UttakFaktaDetailForm = ({
   const sorterteOppholdÅrsaker = alleKodeverk['OppholdÅrsak'].toSorted((k1, k2) => k1.navn.localeCompare(k2.navn));
   const sorterteMorsAktiviteter = alleKodeverk['MorsAktivitet'].toSorted((k1, k2) => k1.navn.localeCompare(k2.navn));
 
-  const årsakstype = formMethods.watch('arsakstype');
-  const flerbarnsdager = formMethods.watch('flerbarnsdager');
-  const stønadskonto = formMethods.watch('uttakPeriodeType');
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const årsakstype = useWatch({ control: formMethods.control, name: 'arsakstype' });
+  const flerbarnsdager = useWatch({ control: formMethods.control, name: 'flerbarnsdager' });
+  const stønadskonto = useWatch({ control: formMethods.control, name: 'uttakPeriodeType' });
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   useEffect(() => {
     if (defaultValues?.arsakstype !== årsakstype) {

--- a/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { ErrorSummary, Heading, HStack, VStack } from '@navikt/ds-react';
@@ -203,7 +203,7 @@ export const UttakFaktaForm = ({
     a => a.definisjon !== AksjonspunktKode.OVERSTYRING_FAKTA_UTTAK,
   );
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const [isDirty, setIsDirty] = useState(false);
 

--- a/packages/fakta/uttaksdokumentasjon/src/components/DelOppPeriode/DelOppPeriodeModal.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/DelOppPeriode/DelOppPeriodeModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { ScissorsIcon } from '@navikt/aksel-icons';
@@ -30,7 +30,7 @@ export const DelOppPeriodeModal = ({ periode, cancel, submit }: Props) => {
 
   const formMethods = useForm<{ dato: string }>();
 
-  const splittDato = formMethods.watch('dato');
+  const splittDato = useWatch({ control: formMethods.control, name: 'dato' });
   const perioder = splittDato ? splitPeriodePåDato(periode, splittDato) : null;
 
   return (

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaDetailForm/UttakDokumentasjonFaktaDetailForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaDetailForm/UttakDokumentasjonFaktaDetailForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useState } from 'react';
-import { useFieldArray, useForm, useWatch } from 'react-hook-form';
+import { type Control, useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Button, HStack, Label, Link, Radio, ReadMore, Table, VStack } from '@navikt/ds-react';
@@ -36,6 +36,32 @@ const HEADER_TEXT_CODES = [
   'UttakDokumentasjonFaktaDetailForm.AktivitetskravGrunnlagStillingsprosent',
   'UttakDokumentasjonFaktaDetailForm.AktivitetskravGrunnlagPermisjon',
 ];
+
+const MorsStillingsprosentField = ({
+  control,
+  index,
+  readOnly,
+}: {
+  control: Control<FormValues>;
+  index: number;
+  readOnly: boolean;
+}) => {
+  const vurdering = useWatch({ control, name: `perioder.${index}.vurdering` });
+
+  if (vurdering !== VurderingsAlternativ.GODKJENT_UNDER75) {
+    return null;
+  }
+
+  return (
+    <RhfNumericField
+      name={`perioder.${index}.morsStillingsprosent`}
+      control={control}
+      label={<FormattedMessage id="UttakDokumentasjonFaktaDetailForm.MorsStillingsprosent.Label" />}
+      validate={[required, minValue(0.01), maxValue(74.99)]}
+      readOnly={readOnly}
+    />
+  );
+};
 
 interface Props {
   behov: DokumentasjonVurderingBehov;
@@ -164,15 +190,7 @@ export const UttakDokumentasjonFaktaDetailForm = ({ behov, readOnly, cancel, sub
                   </Radio>
                 ))}
               </RhfRadioGroup>
-              {useWatch({ control: formMethods.control, name: `perioder.0.vurdering` }) === VurderingsAlternativ.GODKJENT_UNDER75 && (
-                <RhfNumericField
-                  name="perioder.0.morsStillingsprosent"
-                  control={formMethods.control}
-                  label={<FormattedMessage id="UttakDokumentasjonFaktaDetailForm.MorsStillingsprosent.Label" />}
-                  validate={[required, minValue(0.01), maxValue(74.99)]}
-                  readOnly={readOnly}
-                />
-              )}
+              <MorsStillingsprosentField control={formMethods.control} index={0} readOnly={readOnly} />
             </VStack>
           )}
 
@@ -218,15 +236,7 @@ export const UttakDokumentasjonFaktaDetailForm = ({ behov, readOnly, cancel, sub
                       </Radio>
                     ))}
                   </RhfRadioGroup>
-                  {useWatch({ control: formMethods.control, name: `perioder.${index}.vurdering` }) === VurderingsAlternativ.GODKJENT_UNDER75 && (
-                    <RhfNumericField
-                      label={<FormattedMessage id="UttakDokumentasjonFaktaDetailForm.MorsStillingsprosent.Label" />}
-                      control={formMethods.control}
-                      name={`perioder.${index}.morsStillingsprosent`}
-                      validate={[required, minValue(0.01), maxValue(74.99)]}
-                      readOnly={readOnly}
-                    />
-                  )}
+                  <MorsStillingsprosentField control={formMethods.control} index={index} readOnly={readOnly} />
                 </Card.Content>
               </Card>
             ))}

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaDetailForm/UttakDokumentasjonFaktaDetailForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaDetailForm/UttakDokumentasjonFaktaDetailForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Button, HStack, Label, Link, Radio, ReadMore, Table, VStack } from '@navikt/ds-react';
@@ -164,7 +164,7 @@ export const UttakDokumentasjonFaktaDetailForm = ({ behov, readOnly, cancel, sub
                   </Radio>
                 ))}
               </RhfRadioGroup>
-              {formMethods.watch(`perioder.0.vurdering`) === VurderingsAlternativ.GODKJENT_UNDER75 && (
+              {useWatch({ control: formMethods.control, name: `perioder.0.vurdering` }) === VurderingsAlternativ.GODKJENT_UNDER75 && (
                 <RhfNumericField
                   name="perioder.0.morsStillingsprosent"
                   control={formMethods.control}
@@ -218,7 +218,7 @@ export const UttakDokumentasjonFaktaDetailForm = ({ behov, readOnly, cancel, sub
                       </Radio>
                     ))}
                   </RhfRadioGroup>
-                  {formMethods.watch(`perioder.${index}.vurdering`) === VurderingsAlternativ.GODKJENT_UNDER75 && (
+                  {useWatch({ control: formMethods.control, name: `perioder.${index}.vurdering` }) === VurderingsAlternativ.GODKJENT_UNDER75 && (
                     <RhfNumericField
                       label={<FormattedMessage id="UttakDokumentasjonFaktaDetailForm.MorsStillingsprosent.Label" />}
                       control={formMethods.control}

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Button, VStack } from '@navikt/ds-react';
@@ -51,7 +51,7 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkterForPanel),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const isSubmittable = submittable && dokBehov.every(a => a.vurdering) && !!begrunnelse;
 

--- a/packages/fakta/verge/src/components/RegistrereVergeInfoPanel.tsx
+++ b/packages/fakta/verge/src/components/RegistrereVergeInfoPanel.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 
 import { VStack } from '@navikt/ds-react';
@@ -57,8 +57,8 @@ export const RegistrereVergeInfoPanel = ({ verge, alleKodeverk }: Props) => {
     shouldUnregister: true,
   });
 
-  const valgtVergeType = formMethods.watch('vergeType');
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const valgtVergeType = useWatch({ control: formMethods.control, name: 'vergeType' });
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const vergetyper = alleKodeverk['VergeType'].sort((k1, k2) => k1.navn.localeCompare(k2.navn));
 

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
@@ -39,7 +39,7 @@ export const SakslisteVelgerForm = ({ sakslister, setValgtSakslisteId, fetchAnta
     defaultValues: getFormDefaultValues(sorterteSakslister),
   });
 
-  const sakslisteId = formMethods.watch('sakslisteId');
+  const sakslisteId = useWatch({ control: formMethods.control, name: 'sakslisteId' });
 
   // (TOR) Prøv å refaktorer dette
   useEffect(() => {

--- a/packages/modal-sett-pa-vent/src/components/SettPaVentModal.tsx
+++ b/packages/modal-sett-pa-vent/src/components/SettPaVentModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { BodyShort, Button, Dialog, VStack } from '@navikt/ds-react';
@@ -48,8 +48,8 @@ export const SettPaVentModal = ({
     defaultValues: buildInitialValues(hasManualPaVent, frist, ventearsak ?? defaultVenteårsak),
   });
 
-  const fristFraFelt = formMethods.watch('frist');
-  const ventearsakFraFelt = formMethods.watch('ventearsak');
+  const fristFraFelt = useWatch({ control: formMethods.control, name: 'frist' });
+  const ventearsakFraFelt = useWatch({ control: formMethods.control, name: 'ventearsak' });
 
   const venteArsakHasChanged = harEndretVenteårsak(ventearsak, ventearsakFraFelt);
   const fristHasChanged = harEndretFrist(frist, fristFraFelt);

--- a/packages/papirsoknad/src/SoknadTypePickerForm.tsx
+++ b/packages/papirsoknad/src/SoknadTypePickerForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Box, Button, Heading, HStack, Radio, VStack } from '@navikt/ds-react';
@@ -50,7 +50,7 @@ export const SoknadTypePickerForm = ({
     },
   });
 
-  const selectedFagsakYtelseType = formMethods.watch('fagsakYtelseType');
+  const selectedFagsakYtelseType = useWatch({ control: formMethods.control, name: 'fagsakYtelseType' });
 
   const fagsakYtelseTyper = alleKodeverk['FagsakYtelseType'];
   const familieHendelseTyper = alleKodeverk['FamilieHendelseType'];

--- a/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
+++ b/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { HGrid } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
@@ -40,8 +40,8 @@ export const EngangsstonadForm = ({
     defaultValues: { ...initialValues(), ...mellomlagretData },
   });
 
-  const foedselsDatoFraTerminOgFodelsPanel = formMethods.watch('fødselsdato');
-  const mottattDato = formMethods.watch('mottattDato');
+  const foedselsDatoFraTerminOgFodelsPanel = useWatch({ control: formMethods.control, name: 'fødselsdato' });
+  const mottattDato = useWatch({ control: formMethods.control, name: 'mottattDato' });
 
   return (
     <RhfForm formMethods={formMethods} onSubmit={values => onSubmit(transformValues(soknadData, values))}>

--- a/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
+++ b/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
@@ -34,8 +34,6 @@ export const EngangsstonadForm = ({
   onMellomlagre,
   mellomlagretData,
 }: Props) => {
-  const ComponentForFamilieHendelse = getComponentForFamiliehendelse(soknadData.getFamilieHendelseType());
-
   const formMethods = useForm({
     defaultValues: { ...initialValues(), ...mellomlagretData },
   });
@@ -47,13 +45,23 @@ export const EngangsstonadForm = ({
     <RhfForm formMethods={formMethods} onSubmit={values => onSubmit(transformValues(soknadData, values))}>
       <HGrid columns={{ sm: 1, md: 2 }} gap="space-16">
         <MottattDatoPapirsoknadIndex readOnly={readOnly} />
-        <ComponentForFamilieHendelse
-          soknadData={soknadData}
-          readOnly={readOnly}
-          alleKodeverk={alleKodeverk}
-          fodselsdato={foedselsDatoFraTerminOgFodelsPanel}
-          mottattDato={mottattDato}
-        />
+        {soknadData.getFamilieHendelseType() === 'ADPSJN' ? (
+          <RegistreringAdopsjonOgOmsorgGrid
+            soknadData={soknadData}
+            readOnly={readOnly}
+            alleKodeverk={alleKodeverk}
+            fodselsdato={foedselsDatoFraTerminOgFodelsPanel}
+            mottattDato={mottattDato}
+          />
+        ) : (
+          <RegistreringFodselGrid
+            soknadData={soknadData}
+            readOnly={readOnly}
+            alleKodeverk={alleKodeverk}
+            fodselsdato={foedselsDatoFraTerminOgFodelsPanel}
+            mottattDato={mottattDato}
+          />
+        )}
       </HGrid>
       <LagreSoknadPapirsoknadIndex
         readOnly={readOnly}

--- a/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
+++ b/packages/papirsoknad/src/engangsstonad/components/EngangsstonadForm.tsx
@@ -8,7 +8,7 @@ import {
   MottattDatoPapirsoknadIndex,
   SoknadData,
 } from '@navikt/fp-papirsoknad-ui-komponenter';
-import type { AlleKodeverk, FamilieHendelseType } from '@navikt/fp-types';
+import type { AlleKodeverk } from '@navikt/fp-types';
 
 import { RegistreringAdopsjonOgOmsorgGrid } from './RegistreringAdopsjonOgOmsorgGrid';
 import { RegistreringFodselGrid } from './RegistreringFodselGrid';
@@ -82,19 +82,13 @@ const initialValues = () => ({
 });
 
 const transformValues = (soknadData: SoknadData, values: ReturnType<typeof initialValues>) => {
+  const familieHendelseValues =
+    soknadData.getFamilieHendelseType() === 'ADPSJN'
+      ? RegistreringAdopsjonOgOmsorgGrid.transformValues(values)
+      : RegistreringFodselGrid.transformValues(values);
   return {
     ...MottattDatoPapirsoknadIndex.transformValues(values),
-    ...getComponentForFamiliehendelse(soknadData.getFamilieHendelseType()).transformValues(values),
+    ...familieHendelseValues,
     ...LagreSoknadPapirsoknadIndex.transformValues(values),
   };
-};
-
-const getComponentForFamiliehendelse = (familieHendelse: FamilieHendelseType) => {
-  if (familieHendelse === 'FODSL') {
-    return RegistreringFodselGrid;
-  }
-  if (familieHendelse === 'ADPSJN') {
-    return RegistreringAdopsjonOgOmsorgGrid;
-  }
-  throw new Error(`Unsupported FamilieHendelseType i papirsoknad for engangsstønad: ${familieHendelse}`);
 };

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
@@ -95,8 +95,8 @@ export const ForeldrepengerForm = ({
     defaultValues: { ...buildInitialValues(), ...mellomlagretData },
   });
 
-  const søkerHarAleneomsorg = useWatch({ control: formMethods.control, name: `annenForelder.søkerHarAleneomsorg` });
-  const denAndreForelderenHarRettPåForeldrepenger = useWatch({ control: formMethods.control, name: `annenForelder.denAndreForelderenHarRettPåForeldrepenger`, });
+  const søkerHarAleneomsorg = useWatch({ control: formMethods.control, name: 'annenForelder.søkerHarAleneomsorg' });
+  const denAndreForelderenHarRettPåForeldrepenger = useWatch({ control: formMethods.control, name: 'annenForelder.denAndreForelderenHarRettPåForeldrepenger' });
   const annenForelderInformertRequired = !søkerHarAleneomsorg && denAndreForelderenHarRettPåForeldrepenger !== false;
 
   const foedselsDatoFraTerminOgFodelsPanel = useWatch({ control: formMethods.control, name: 'fødselsdato' });

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { HGrid } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
@@ -95,14 +95,12 @@ export const ForeldrepengerForm = ({
     defaultValues: { ...buildInitialValues(), ...mellomlagretData },
   });
 
-  const søkerHarAleneomsorg = formMethods.watch(`annenForelder.søkerHarAleneomsorg`);
-  const denAndreForelderenHarRettPåForeldrepenger = formMethods.watch(
-    `annenForelder.denAndreForelderenHarRettPåForeldrepenger`,
-  );
+  const søkerHarAleneomsorg = useWatch({ control: formMethods.control, name: `annenForelder.søkerHarAleneomsorg` });
+  const denAndreForelderenHarRettPåForeldrepenger = useWatch({ control: formMethods.control, name: `annenForelder.denAndreForelderenHarRettPåForeldrepenger`, });
   const annenForelderInformertRequired = !søkerHarAleneomsorg && denAndreForelderenHarRettPåForeldrepenger !== false;
 
-  const foedselsDatoFraTerminOgFodelsPanel = formMethods.watch('fødselsdato');
-  const mottattDato = formMethods.watch('mottattDato');
+  const foedselsDatoFraTerminOgFodelsPanel = useWatch({ control: formMethods.control, name: 'fødselsdato' });
+  const mottattDato = useWatch({ control: formMethods.control, name: 'mottattDato' });
 
   return (
     <RhfForm formMethods={formMethods} onSubmit={(values: FormValues) => onSubmit(transformValues(values))}>

--- a/packages/papirsoknad/src/svangerskapspenger/components/SvangerskapspengerForm.tsx
+++ b/packages/papirsoknad/src/svangerskapspenger/components/SvangerskapspengerForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { HGrid } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
@@ -76,7 +76,7 @@ export const SvangerskapspengerForm = ({
     defaultValues: { ...buildInitialValues(), ...mellomlagretData },
   });
 
-  const mottattDato = formMethods.watch('mottattDato');
+  const mottattDato = useWatch({ control: formMethods.control, name: 'mottattDato' });
 
   return (
     <RhfForm formMethods={formMethods} onSubmit={(values: FormValues) => onSubmit(transformValues(values))}>

--- a/packages/prosess/formkrav/src/components/FormkravKlageFormNfp.tsx
+++ b/packages/prosess/formkrav/src/components/FormkravKlageFormNfp.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { Detail, Heading, HStack, Radio, VStack } from '@navikt/ds-react';
@@ -117,7 +117,7 @@ export const FormkravKlageFormNfp = ({ klageVurdering, avsluttedeBehandlinger, l
     defaultValues: mellomlagretFormData ?? initialValues,
   });
 
-  const formVerdier = formMethods.watch();
+  const formVerdier = useWatch({ control: formMethods.control });
 
   return (
     <RhfForm

--- a/packages/prosess/innsyn/src/components/InnsynForm.tsx
+++ b/packages/prosess/innsyn/src/components/InnsynForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Heading, HStack, Radio, VStack } from '@navikt/ds-react';
@@ -76,8 +76,8 @@ export const InnsynForm = ({ innsyn, alleDokumenter = [] }: Props) => {
 
   const isApOpen = aksjonspunkterForPanel[0]?.status === 'OPPR';
 
-  const innsynResultatTypeKode = formMethods.watch('innsynResultatType');
-  const sattPaVent = formMethods.watch('sattPaVent');
+  const innsynResultatTypeKode = useWatch({ control: formMethods.control, name: 'innsynResultatType' });
+  const sattPaVent = useWatch({ control: formMethods.control, name: 'sattPaVent' });
 
   return (
     <RhfForm

--- a/packages/prosess/klagevurdering/src/components/nfp/BehandleKlageFormNfp.tsx
+++ b/packages/prosess/klagevurdering/src/components/nfp/BehandleKlageFormNfp.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Button, Heading, HStack, VStack } from '@navikt/ds-react';
@@ -93,7 +93,7 @@ export const BehandleKlageFormNfp = ({ klageVurdering, previewCallback, saveKlag
   const formMethods = useForm<FormValues>({
     defaultValues: mellomlagretFormData ?? buildInitialValues(klageVurdering.klageVurderingResultatNFP),
   });
-  const formValues = formMethods.watch();
+  const formValues = useWatch({ control: formMethods.control });
 
   const lukkModal = () => {
     setVisSubmitModal(false);

--- a/packages/prosess/soknadsfrist/src/components/VurderSoknadsfristForeldrepengerForm.tsx
+++ b/packages/prosess/soknadsfrist/src/components/VurderSoknadsfristForeldrepengerForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { BodyShort, Box, Detail, Heading, HStack, Label, Radio, VStack } from '@navikt/ds-react';
@@ -69,7 +69,7 @@ export const VurderSoknadsfristForeldrepengerForm = ({ mottattDato, søknadsfris
     defaultValues: mellomlagretFormData ?? initialValues,
   });
 
-  const gyldigSenFremsetting = formMethods.watch('gyldigSenFremsetting');
+  const gyldigSenFremsetting = useWatch({ control: formMethods.control, name: 'gyldigSenFremsetting' });
 
   const soknadsperiodeStart = søknadsfrist?.søknadsperiodeStart;
   const soknadsperiodeSlutt = søknadsfrist?.søknadsperiodeSlutt;

--- a/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
+++ b/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { Alert, Button, HStack, Radio, VStack } from '@navikt/ds-react';
@@ -266,11 +266,11 @@ export const UttakPeriodeForm = ({
     formMethods.reset(defaultValues);
   }, [defaultValues]);
 
-  const erOppfylt = formMethods.watch('erOppfylt');
-  const graderingInnvilget = formMethods.watch('graderingInnvilget');
-  const samtidigUttak = formMethods.watch('samtidigUttak');
-  const valgtInnvilgelsesÅrsak = formMethods.watch('periodeResultatÅrsak');
-  const aktiviteter = formMethods.watch('aktiviteter');
+  const erOppfylt = useWatch({ control: formMethods.control, name: 'erOppfylt' });
+  const graderingInnvilget = useWatch({ control: formMethods.control, name: 'graderingInnvilget' });
+  const samtidigUttak = useWatch({ control: formMethods.control, name: 'samtidigUttak' });
+  const valgtInnvilgelsesÅrsak = useWatch({ control: formMethods.control, name: 'periodeResultatÅrsak' });
+  const aktiviteter = useWatch({ control: formMethods.control, name: 'aktiviteter' });
 
   const stønadskontoType: UttakPeriodeType = aktiviteter[0]?.stønadskontoType ?? '-';
 

--- a/packages/prosess/uttak/src/components/periodeDetaljer/splitt/SplittPeriodeModal.tsx
+++ b/packages/prosess/uttak/src/components/periodeDetaljer/splitt/SplittPeriodeModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
 
 import { BodyShort, Button, Detail, Dialog, HStack, VStack } from '@navikt/ds-react';
@@ -29,7 +29,7 @@ export const SplittPeriodeModal = ({ fomDato, tomDato, submit, cancel }: Props) 
 
   const formMethods = useForm<{ dato: string }>();
 
-  const dato = formMethods.watch('dato');
+  const dato = useWatch({ control: formMethods.control, name: 'dato' });
 
   const numberOfDaysAndWeeks = calcDaysAndWeeks(fomDato, dato);
 

--- a/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
+++ b/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
@@ -1,5 +1,5 @@
 import { type MouseEvent, useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Alert, Button, Heading, HStack, Link, Radio, VStack } from '@navikt/ds-react';
@@ -60,7 +60,7 @@ export const VarselOmRevurderingForm = ({ previewCallback, hentVarselHtml, mello
     defaultValues: mellomlagretFormData ?? initialValues,
   });
 
-  const formVerdier = formMethods.watch();
+  const formVerdier = useWatch({ control: formMethods.control });
 
   const erÅpentAksjonspunkt = !isReadOnly && aksjonspunkterForPanel[0]?.status === 'OPPR';
 

--- a/packages/prosess/vedtak-innsyn/src/components/InnsynVedtakForm.tsx
+++ b/packages/prosess/vedtak-innsyn/src/components/InnsynVedtakForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BodyShort, Heading, HStack, Label, Link, VStack } from '@navikt/ds-react';
@@ -129,7 +129,7 @@ export const InnsynVedtakForm = ({
   const apVurderInnsynBegrunnelse =
     aksjonspunkterForPanel.find(ap => ap.definisjon === AksjonspunktKode.VURDER_INNSYN)?.begrunnelse ?? undefined;
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const previewBrev = getPreviewCallback(previewCallback, begrunnelse);
 

--- a/packages/prosess/vedtak/src/components/forstegang/VedtakForm.tsx
+++ b/packages/prosess/vedtak/src/components/forstegang/VedtakForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { type IntlShape, useIntl } from 'react-intl';
 
 import { RhfForm } from '@navikt/ft-form-hooks';
@@ -173,7 +173,7 @@ export const VedtakForm = ({
     defaultValues: mellomlagretFormData ?? buildInitialValues(behandling),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const { harRedigertBrev } = useVedtakEditeringContext();
 

--- a/packages/prosess/vedtak/src/components/revurdering/VedtakRevurderingForm.tsx
+++ b/packages/prosess/vedtak/src/components/revurdering/VedtakRevurderingForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { type IntlShape, useIntl } from 'react-intl';
 
 import { RhfForm } from '@navikt/ft-form-hooks';
@@ -209,7 +209,7 @@ export const VedtakRevurderingForm = ({
     defaultValues: mellomlagretFormData ?? buildInitialValues(behandling),
   });
 
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   const erBehandlingEtterKlage = erÅrsakTypeBehandlingEtterKlage(behandlingÅrsaker);
   const revurderingsÅrsakString = lagÅrsakString(

--- a/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
+++ b/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { CheckmarkCircleFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
@@ -99,7 +99,7 @@ export const VilkarresultatMedOverstyringForm = ({
     toggleOverstyring();
   };
 
-  const erVilkårOk = formMethods.watch('erVilkårOk');
+  const erVilkårOk = useWatch({ control: formMethods.control, name: 'erVilkårOk' });
 
   const aksjonspunkt = behandling.aksjonspunkt.find(ap => ap.definisjon === overstyringApKode);
   const hasAksjonspunkt = aksjonspunkt !== undefined;

--- a/packages/prosess/vilkar-svangerskap/src/components/SvangerskapVilkarForm.tsx
+++ b/packages/prosess/vilkar-svangerskap/src/components/SvangerskapVilkarForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Detail, VStack } from '@navikt/ds-react';
@@ -87,7 +87,7 @@ export const SvangerskapVilkarForm = ({ svangerskapspengerTilrettelegging, statu
     defaultValues: mellomlagretFormData ?? initialValues,
   });
 
-  const erVilkårOk = formMethods.watch('erVilkårOk');
+  const erVilkårOk = useWatch({ control: formMethods.control, name: 'erVilkårOk' });
 
   useEffect(() => {
     if (erVilkårOk) {

--- a/packages/sak/meldinger/src/components/Messages.tsx
+++ b/packages/sak/meldinger/src/components/Messages.tsx
@@ -85,26 +85,32 @@ export const Messages = ({
 
   const { formState, control } = formMethods;
 
-  const [brevData, setBrevData] = useState<{ opprinneligHtml: string; redigertHtml: string | null } | null>(null);
+  const [brevDataState, setBrevDataState] = useState<{
+    key: string;
+    opprinneligHtml: string;
+    redigertHtml: string | null;
+  } | null>(null);
   const [visRedigeringModal, setVisRedigeringModal] = useState(false);
 
   const erVarselOmRevurdering = brevmalkode === 'VARREV';
   const erInnhenteOpplysninger = brevmalkode === 'INNOPP';
   const brukBreveditor = erVarselOmRevurdering || erInnhenteOpplysninger;
 
-  useEffect(() => {
-    setBrevData(null);
-  }, [årsakskode, brevmalkode]);
+  // brevData er nøkla på (brevmalkode, årsakskode). Når valet endrar seg, sluttar nøkkelen
+  // å peika, så avleidd brevData blir null og hentinga under skjer på nytt – utan å
+  // nullstilla state synkront i ein effekt (set-state-in-effect).
+  const aktivBrevKey = `${brevmalkode ?? ''}|${årsakskode ?? ''}`;
+  const brevData = brevDataState?.key === aktivBrevKey ? brevDataState : null;
 
   useEffect(() => {
     if (brukBreveditor && !brevData && (!erVarselOmRevurdering || årsakskode)) {
       void hentBrevHtml(brevmalkode, årsakskode)
         .then(result => {
-          setBrevData({ opprinneligHtml: result.opprinneligHtml, redigertHtml: result.redigertHtml });
+          setBrevDataState({ key: aktivBrevKey, opprinneligHtml: result.opprinneligHtml, redigertHtml: result.redigertHtml });
         })
         .catch(() => {});
     }
-  }, [brukBreveditor, brevData, hentBrevHtml, brevmalkode, årsakskode, erVarselOmRevurdering]);
+  }, [brukBreveditor, brevData, hentBrevHtml, brevmalkode, årsakskode, erVarselOmRevurdering, aktivBrevKey]);
 
   const forhåndsvis = (e: React.MouseEvent | React.KeyboardEvent) => {
     if (brevmalkode) {
@@ -164,7 +170,11 @@ export const Messages = ({
                     if (!brevData) {
                       try {
                         const result = await hentBrevHtml(brevmalkode, årsakskode);
-                        setBrevData({ opprinneligHtml: result.opprinneligHtml, redigertHtml: result.redigertHtml });
+                        setBrevDataState({
+                          key: aktivBrevKey,
+                          opprinneligHtml: result.opprinneligHtml,
+                          redigertHtml: result.redigertHtml,
+                        });
                       } catch {
                         return;
                       }
@@ -224,7 +234,7 @@ export const Messages = ({
             if (brevmalkode) {
               await mellomlagreBrev(brevmalkode, html);
             }
-            setBrevData(prev => (prev ? { ...prev, redigertHtml: html ?? null } : null));
+            setBrevDataState(prev => (prev ? { ...prev, redigertHtml: html ?? null } : null));
           }}
           forhåndsvisBrev={async html => {
             if (brevmalkode) {

--- a/packages/sak/meldinger/src/components/Messages.tsx
+++ b/packages/sak/meldinger/src/components/Messages.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Alert, Button, HStack, Link, VStack } from '@navikt/ds-react';
@@ -74,9 +74,9 @@ export const Messages = ({
     defaultValues: meldingFormData ?? buildInitialValues(behandling),
   });
 
-  const brevmalkode = formMethods.watch('brevmalkode');
-  const fritekst = formMethods.watch('fritekst');
-  const årsakskode = formMethods.watch('årsakskode');
+  const brevmalkode = useWatch({ control: formMethods.control, name: 'brevmalkode' });
+  const fritekst = useWatch({ control: formMethods.control, name: 'fritekst' });
+  const årsakskode = useWatch({ control: formMethods.control, name: 'årsakskode' });
 
   const filtrerteRevurderingVarslingArsaker = getfiltrerteRevurderingVarslingArsaker(
     revurderingVarslingArsak,

--- a/packages/sak/meny-henlegg/src/components/HenleggBehandlingModal.tsx
+++ b/packages/sak/meny-henlegg/src/components/HenleggBehandlingModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Button, Dialog, HStack, Label, Link, VStack } from '@navikt/ds-react';
@@ -73,9 +73,9 @@ export const HenleggBehandlingModal = ({
 
   const formMethods = useForm<FormValues>();
 
-  const årsakKode = formMethods.watch('årsakKode');
-  const begrunnelse = formMethods.watch('begrunnelse');
-  const fritekst = formMethods.watch('fritekst');
+  const årsakKode = useWatch({ control: formMethods.control, name: 'årsakKode' });
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
+  const fritekst = useWatch({ control: formMethods.control, name: 'fritekst' });
 
   const showLink = getShowLink(behandlingType, årsakKode, fritekst);
 

--- a/packages/sak/meny-ny-behandling/src/components/NyBehandlingModal.tsx
+++ b/packages/sak/meny-ny-behandling/src/components/NyBehandlingModal.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Button, Dialog, VStack } from '@navikt/ds-react';
@@ -175,7 +175,7 @@ export const NyBehandlingModal = ({
 
   const onSubmit = (values: FormValues) => submitCallback(transformValues(values, uuidForSistLukkede, ytelseType));
 
-  const valgtBehandlingTypeKode = formMethods.watch('behandlingType');
+  const valgtBehandlingTypeKode = useWatch({ control: formMethods.control, name: 'behandlingType' });
 
   const behandlingTyper = getBehandlingTyper(behandlingstyper);
   const enabledBehandlingstyper = getEnabledBehandlingstyper(

--- a/packages/sak/meny/src/endreEnhet/modal/EndreBehandlendeEnhetModal.tsx
+++ b/packages/sak/meny/src/endreEnhet/modal/EndreBehandlendeEnhetModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Button, Dialog, VStack } from '@navikt/ds-react';
@@ -52,8 +52,8 @@ export const EndreBehandlendeEnhetModal = ({
 
   const formMethods = useForm<FormValues>();
 
-  const nyEnhet = formMethods.watch('nyEnhet');
-  const begrunnelse = formMethods.watch('begrunnelse');
+  const nyEnhet = useWatch({ control: formMethods.control, name: 'nyEnhet' });
+  const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
   return (
     <Dialog open onOpenChange={lukkModal} size="small">

--- a/packages/sak/meny/src/verge/MenyVergeIndex.tsx
+++ b/packages/sak/meny/src/verge/MenyVergeIndex.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { RawIntlProvider } from 'react-intl';
 
 import { Button, Dialog } from '@navikt/ds-react';
@@ -41,7 +41,7 @@ export const MenyVergeIndex = ({ verge, type, fjernVerge, opprettVerge, lukkModa
     lukkModal();
   };
 
-  const valgtVergeType = formMethods.watch('vergeType');
+  const valgtVergeType = useWatch({ control: formMethods.control, name: 'vergeType' });
 
   useEffect(() => {
     if (verge) {

--- a/packages/sak/risikoklassifisering/src/components/AvklarFaresignalerForm.tsx
+++ b/packages/sak/risikoklassifisering/src/components/AvklarFaresignalerForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Button, Radio, VStack } from '@navikt/ds-react';
@@ -57,7 +57,7 @@ export const AvklarFaresignalerForm = ({
     defaultValues: buildInitialValues(aksjonspunkt, risikoklassifisering),
   });
 
-  const harValgtReelle = formMethods.watch(VURDERING_HOVEDKATEGORI) === 'INNVIRKNING';
+  const harValgtReelle = useWatch({ control: formMethods.control, name: VURDERING_HOVEDKATEGORI }) === 'INNVIRKNING';
 
   return (
     <RhfForm formMethods={formMethods} onSubmit={(values: Values) => submitCallback?.(transformValues(values))}>

--- a/packages/sak/sok/src/components/SearchForm.tsx
+++ b/packages/sak/sok/src/components/SearchForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
@@ -32,7 +32,7 @@ export const SearchForm = ({ searchStarted, searchResultAccessDenied, searchFags
     },
   });
 
-  const searchString = formMethods.watch('searchString');
+  const searchString = useWatch({ control: formMethods.control, name: 'searchString' });
 
   return (
     <RhfForm formMethods={formMethods} onSubmit={searchFagsakCallback} className={styles['container']}>

--- a/packages/sak/totrinnskontroll/src/components/TotrinnskontrollBeslutterForm.tsx
+++ b/packages/sak/totrinnskontroll/src/components/TotrinnskontrollBeslutterForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Button, HStack, Link, VStack } from '@navikt/ds-react';
@@ -138,7 +138,7 @@ export const TotrinnskontrollBeslutterForm = ({
     defaultValues: beslutterFormData || defaultValues,
   });
 
-  const aksjonspunktGodkjenning = formMethods.watch('aksjonspunktGodkjenning');
+  const aksjonspunktGodkjenning = useWatch({ control: formMethods.control, name: 'aksjonspunktGodkjenning' });
 
   if (!behandling.toTrinnsBehandling) {
     return null;


### PR DESCRIPTION
## Kva og kvifor

Erstattar `watch()`-kall frå `useForm()` med den React Compiler-kompatible `useWatch`-hooken. Dette fjernar `react-hooks/incompatible-library`-advarslane (frå `eslint-plugin-react-hooks` v7) utan å endra åtferd — `useWatch({ control, name })` les same verdi reaktivt som `watch('name')`.

Omfang: ~47 filer / ~68 `watch()`-kall konvertert.

## Kvifor PR-en òg fiksar ei rekkje andre eslint-feil

Dette er den viktige konteksten. `useForm().watch()` er ein **`knownIncompatible`**-API i React Compiler (motoren bak `eslint-plugin-react-hooks` v7). Når compileren ser `watch()` i ein komponent, **kastar den og bailar ut av å analysera heile komponenten**. Det slår av *alle* dei andre compiler-reglane i den fila — `set-state-in-effect`, `refs`, `static-components` osv.

Resultatet: så snart `watch()` blir fjerna frå ei fil, får compileren analysert den fullt ut, og **latente regelbrot som alltid har vore der, men som har vore gøymde, kjem fram**. Desse er ikkje innført av PR-en — dei var skjult av bailout-en. Difor måtte fleire «urelaterte» eslint-feil fiksast for at dei berørte filene skal bli grøne:

| Fil | Regel som dukka opp | Fiks |
|---|---|---|
| `papirsoknad/.../EngangsstonadForm.tsx` | `react-hooks/static-components` (dynamisk komponent laga under render) | Statisk betinga render i staden for `<VariabelKomponent>` |
| `papirsoknad/.../ForeldrepengerForm.tsx` | `max-len` | Linjelengd justert |
| `fakta/arbeid-og-inntekt/.../ManglendeArbeidsforholdForm.tsx` | `react-hooks/refs` (les `ref.current` under render) | Lagrar anker-element i `useState`, set via `event.currentTarget` |
| `fakta/uttak-eøs/.../UttakEøsFaktaForm.tsx` | `react-hooks/set-state-in-effect` | `feilmelding` utleidd under render i staden for `useEffect` + `useState` |
| `sak/meldinger/.../Messages.tsx` | `react-hooks/set-state-in-effect` | `brevData` nøkla på `(brevmalkode, årsakskode)` og utleidd under render; ingen synkron `setBrevData(null)` i effekt |
| `fakta/uttaksdokumentasjon/.../UttakDokumentasjonFaktaDetailForm.tsx` | Rules of Hooks (`useWatch` i callback/betinging etter konvertering) | Trekt ut `MorsStillingsprosentField`-komponent som kallar `useWatch` på toppnivå |

Merk: filer som **ikkje** er rørt i denne PR-en og framleis brukar `watch()`, beheld bailout-en sin og viser ikkje desse feila — så dette er avgrensa til dei konverterte filene.

## Verifisering

- `eslint` køyrt lokalt på alle 47 endra filer: **0 errors** (12 gjenståande `exhaustive-deps`-warnings er førhandseksisterande og ikkje-blokkerande).
- Ingen tilsikta åtferdsendring. `Messages`-fiksen er faktisk litt betre (ingen flash av gammal brevtekst ved bytte av brevtype).

## Reviewar-kommentarar

To review-kommentarar om `useWatch` i callbacks (Rules of Hooks) er adresserte ved å trekkja ut ein eigen feltkomponent, og trådane er resolva.
