### PR TITLE
fix: opne sidemeny for snarvegar og legg til snarveg for å vise/skjul…

### DIFF
--- a/apps/fp-frontend/i18n/nb_NO.json
+++ b/apps/fp-frontend/i18n/nb_NO.json
@@ -23,6 +23,7 @@
   "Snarveger.StøtteTilBeslutter": "Vis til godkjenning",
   "Snarveger.StøtteFraBeslutter": "Vis fra beslutter",
   "Snarveger.UtvidDetaljer": "Utvid eller minsk behandlingsdetaljer",
+  "Snarveger.ToggleSidemeny": "Vis eller skjul sidemenyen",
   "Snarveger.ÅpneBehandlingsmeny": "Åpne behandlingsmenyen",
   "Snarveger.FokuserBehandlingsvelger": "Vis behandlingsvelgeren og naviger med piltastene (Enter for å velge)",
   "Snarveger.ForrigeProsess": "Forrige prosesspanel",

--- a/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.stories.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.stories.tsx
@@ -81,8 +81,6 @@ const meta = {
   args: {
     setBehandling: action('button-click'),
     hentOgSettBehandling: action('button-click'),
-    visSideMeny: true,
-    åpneSideMeny: action('button-click'),
   },
   render: function Render(props) {
     //Må hente data til cache før testa komponent blir kalla

--- a/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
@@ -48,8 +48,6 @@ interface Props {
   behandling?: Behandling;
   setBehandling: (behandling: Behandling | undefined) => void;
   hentOgSettBehandling: () => void;
-  visSideMeny: boolean;
-  åpneSideMeny: () => void;
 }
 
 export const BehandlingMenuIndex = ({
@@ -58,8 +56,6 @@ export const BehandlingMenuIndex = ({
   behandling,
   setBehandling,
   hentOgSettBehandling,
-  visSideMeny,
-  åpneSideMeny,
 }: Props) => {
   const initFetchQuery = useQuery(initFetchOptions());
   const { innloggetBruker: navAnsatt } = notEmpty(initFetchQuery.data);
@@ -82,23 +78,9 @@ export const BehandlingMenuIndex = ({
   });
   const fokuserFørsteVedÅpning = useFokusNårKlar(menyÅpen, () => fokuserMenyKnapp(0));
 
-  const åpneOgFokuserMeny = useCallback(() => {
-    if (menyÅpen) {
-      fokuserMenyKnapp(0);
-    } else {
-      fokuserFørsteVedÅpning();
-      setMenyÅpen(true);
-    }
-  }, [fokuserFørsteVedÅpning, fokuserMenyKnapp, menyÅpen, setMenyÅpen]);
-  const åpneMenyNårSideMenyVises = useFokusNårKlar(visSideMeny, åpneOgFokuserMeny);
-
   useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.ÅPNE_BEHANDLINGSMENY, () => {
-    if (visSideMeny) {
-      åpneOgFokuserMeny();
-    } else {
-      åpneMenyNårSideMenyVises();
-      åpneSideMeny();
-    }
+    fokuserFørsteVedÅpning();
+    setMenyÅpen(true);
   });
 
   const fagsak = fagsakData.getFagsak();

--- a/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -79,8 +79,12 @@ export const BehandlingMenuIndex = ({
   const fokuserFørsteVedÅpning = useFokusNårKlar(menyÅpen, () => fokuserMenyKnapp(0));
 
   useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.ÅPNE_BEHANDLINGSMENY, () => {
-    fokuserFørsteVedÅpning();
-    setMenyÅpen(true);
+    if (menyÅpen) {
+      fokuserMenyKnapp(0);
+    } else {
+      fokuserFørsteVedÅpning();
+      setMenyÅpen(true);
+    }
   });
 
   const fagsak = fagsakData.getFagsak();

--- a/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
+++ b/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
@@ -21,6 +21,8 @@ import { BehandlingSupportIndex } from '../behandlingsupport/BehandlingSupportIn
 import { useRequestPendingContext } from '../data/polling/RequestPendingContext';
 import { useHentBehandling } from '../data/polling/useHentBehandling';
 import { FagsakProfileIndex } from '../fagsakprofile/FagsakProfileIndex';
+import { BEHANDLING_SNARVEG_IDER, krevSideMeny } from '../snarveger/snarvegDefinisjoner';
+import { useRegistrerFørDispatch, useRegistrerSnarveg } from '../snarveger/SnarvegerContext';
 import { FagsakGrid } from './components/FagsakGrid';
 import { useHentFagsak } from './useHentFagsak';
 
@@ -83,9 +85,15 @@ export const FagsakIndex = () => {
     setVisSideMeny(!visSideMeny);
   };
 
-  const åpneSideMeny = () => {
-    setVisSideMeny(true);
-  };
+  useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.TOGGLE_SIDEMENY, toggleSideMeny);
+
+  // Snarvegane E, M, B og 1–6 peikar på innhald i sidemenyen. Er han lukka, opnar vi han att
+  // før handlinga køyrer, slik at endringa ikkje skjer i ein skjult kolonne.
+  useRegistrerFørDispatch(id => {
+    if (!visSideMeny && krevSideMeny(id)) {
+      setVisSideMeny(true);
+    }
+  });
 
   useEffect(() => {
     if (behandlingUuidFraUrl && fagsakBehandling) {
@@ -139,7 +147,6 @@ export const FagsakIndex = () => {
             behandling={behandling}
             visSideMeny={visSideMeny}
             toggleSideMeny={toggleSideMeny}
-            åpneSideMeny={åpneSideMeny}
             visUtvidetBehandlingDetaljer={visUtvidetBehandlingDetaljer}
           />
         }

--- a/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.stories.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.stories.tsx
@@ -118,7 +118,6 @@ const meta = {
     setBehandling: action('button-click'),
     hentOgSettBehandling: action('button-click'),
     toggleSideMeny: action('button-click'),
-    åpneSideMeny: action('button-click'),
     visSideMeny: true,
     visUtvidetBehandlingDetaljer: false,
   },

--- a/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Navigate, NavLink, useLocation, useMatch } from 'react-router-dom';
 
@@ -20,8 +20,8 @@ import { initFetchOptions, useFagsakApi } from '../data/fagsakApi';
 import { useFpSakKodeverk } from '../data/useKodeverk';
 import { FagsakData } from '../fagsak/FagsakData';
 import { BEHANDLING_SNARVEG_IDER } from '../snarveger/snarvegDefinisjoner';
-import { useRegistrerSnarveg } from '../snarveger/SnarvegerContext';
-import { useFokusNårKlar, useTastaturfokus } from '../snarveger/useTastaturfokus';
+import { useRegistrerSnarveg, useSnarvegerContextValgfri } from '../snarveger/SnarvegerContext';
+import { useTastaturfokus } from '../snarveger/useTastaturfokus';
 import { EksterneRessurser } from './EksterneRessurser';
 import { RisikoklassifiseringIndex } from './risikoklassifisering/RisikoklassifiseringIndex';
 
@@ -49,7 +49,6 @@ interface Props {
   hentOgSettBehandling: () => void;
   visSideMeny: boolean;
   toggleSideMeny: () => void;
-  åpneSideMeny: () => void;
   visUtvidetBehandlingDetaljer: boolean;
 }
 
@@ -61,7 +60,6 @@ export const FagsakProfileIndex = ({
   hentOgSettBehandling,
   visSideMeny,
   toggleSideMeny,
-  åpneSideMeny,
   visUtvidetBehandlingDetaljer,
 }: Props) => {
   const intl = useIntl();
@@ -86,27 +84,51 @@ export const FagsakProfileIndex = ({
 
   const fokuserBehandlingsvelger = useCallback(() => {
     const rader = hentBehandlingsvelgerRader();
+    if (rader.length === 0) {
+      return false;
+    }
     const aktivIndex = rader.findIndex(rad => rad.getAttribute('aria-current') === 'page');
     fokuserRad(aktivIndex === -1 ? 0 : aktivIndex);
+    return true;
   }, [fokuserRad, hentBehandlingsvelgerRader]);
-  const fokuserNårBehandlingsvelgerVises = useFokusNårKlar(showAll, fokuserBehandlingsvelger);
 
-  const visOgFokuserBehandlingsvelger = useCallback(() => {
-    if (showAll) {
-      fokuserBehandlingsvelger();
-    } else {
-      fokuserNårBehandlingsvelgerVises();
-      setShowAll(true);
+  // Behandlingsvelgaren er gøymd (height: 0) når dei utvida behandlingsdetaljane er på. Snarvegen
+  // syter difor for å vise detaljane att – på same måte som «E» – og utvide lista før fokus blir
+  // flytta. Sidan DOM-en oppdaterast asynkront etter desse statusbyta, armerer me eit ynske om
+  // fokus og prøver på nytt over nokre animasjonsrammer til radene faktisk finst.
+  const snarveger = useSnarvegerContextValgfri();
+  const velgerErSynleg = !visUtvidetBehandlingDetaljer && showAll;
+  const skalFokuserVelgerRef = useRef(false);
+
+  useEffect(() => {
+    if (!skalFokuserVelgerRef.current || !velgerErSynleg) {
+      return undefined;
     }
-  }, [fokuserBehandlingsvelger, fokuserNårBehandlingsvelgerVises, showAll]);
-  const fokuserNårSideMenyVises = useFokusNårKlar(visSideMeny, visOgFokuserBehandlingsvelger);
+    let gjenståandeForsøk = 20;
+    let rammeId = 0;
+    const prøvFokuser = () => {
+      if (fokuserBehandlingsvelger() || gjenståandeForsøk <= 0) {
+        skalFokuserVelgerRef.current = false;
+        return;
+      }
+      gjenståandeForsøk -= 1;
+      rammeId = requestAnimationFrame(prøvFokuser);
+    };
+    rammeId = requestAnimationFrame(prøvFokuser);
+    return () => cancelAnimationFrame(rammeId);
+  }, [velgerErSynleg, fokuserBehandlingsvelger]);
 
   useRegistrerSnarveg(BEHANDLING_SNARVEG_IDER.FOKUSER_BEHANDLINGSVELGER, () => {
-    if (visSideMeny) {
-      visOgFokuserBehandlingsvelger();
-    } else {
-      fokuserNårSideMenyVises();
-      åpneSideMeny();
+    if (velgerErSynleg) {
+      fokuserBehandlingsvelger();
+      return;
+    }
+    skalFokuserVelgerRef.current = true;
+    if (visUtvidetBehandlingDetaljer) {
+      snarveger?.dispatch(BEHANDLING_SNARVEG_IDER.UTVID_DETALJER);
+    }
+    if (!showAll) {
+      setShowAll(true);
     }
   });
 
@@ -170,8 +192,6 @@ export const FagsakProfileIndex = ({
                   setBehandling={setBehandling}
                   hentOgSettBehandling={hentOgSettBehandling}
                   behandling={behandling}
-                  visSideMeny={visSideMeny}
-                  åpneSideMeny={åpneSideMeny}
                 />
                 <ReservasjonsstatusPanel
                   saksnummer={fagsak.saksnummer}

--- a/apps/fp-frontend/src/snarveger/SnarvegerContext.tsx
+++ b/apps/fp-frontend/src/snarveger/SnarvegerContext.tsx
@@ -5,6 +5,7 @@ import { useSnarvegInnstilling } from './useSnarvegInnstilling';
 
 export const SnarvegerProvider = ({ children }: { children: ReactNode }) => {
   const handlereRef = useRef(new Map<string, () => void>());
+  const førDispatchRef = useRef(new Set<(id: string) => void>());
   const [snarveiModalÅpen, setSnarveiModalÅpen] = useState(false);
   const { aktiv, settAktiv } = useSnarvegInnstilling();
   const toggleSnarveiModal = useCallback(() => {
@@ -20,9 +21,17 @@ export const SnarvegerProvider = ({ children }: { children: ReactNode }) => {
     };
   }, []);
 
+  const registrerFørDispatch = useCallback((fn: (id: string) => void) => {
+    førDispatchRef.current.add(fn);
+    return () => {
+      førDispatchRef.current.delete(fn);
+    };
+  }, []);
+
   const dispatch = useCallback((id: string) => {
     const handler = handlereRef.current.get(id);
     if (handler) {
+      førDispatchRef.current.forEach(fn => fn(id));
       handler();
       return true;
     }
@@ -32,8 +41,16 @@ export const SnarvegerProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => registrer(GLOBALE_SNARVEG_IDER.HJELP, toggleSnarveiModal), [registrer, toggleSnarveiModal]);
 
   const value = useMemo<SnarvegerContextValue>(
-    () => ({ registrer, dispatch, snarveiModalÅpen, settSnarveiModalÅpen: setSnarveiModalÅpen, aktiv, settAktiv }),
-    [registrer, dispatch, snarveiModalÅpen, aktiv, settAktiv],
+    () => ({
+      registrer,
+      registrerFørDispatch,
+      dispatch,
+      snarveiModalÅpen,
+      settSnarveiModalÅpen: setSnarveiModalÅpen,
+      aktiv,
+      settAktiv,
+    }),
+    [registrer, registrerFørDispatch, dispatch, snarveiModalÅpen, aktiv, settAktiv],
   );
 
   return <SnarvegerContext value={value}>{children}</SnarvegerContext>;
@@ -76,9 +93,37 @@ export const useRegistrerSnarveg = (id: string, handler: () => void, aktivert = 
   }, [id, aktivert, registrer]);
 };
 
+/**
+ * Registrerer ein funksjon som køyrer rett før kvar snarveg-dispatch, så lenge komponenten
+ * er montert. Brukast til sideeffektar som må skje uavhengig av kva snarveg som blir køyrd
+ * (t.d. å opne sidemenyen før ein snarveg som peikar inn i han).
+ */
+export const useRegistrerFørDispatch = (fn: (id: string) => void): void => {
+  const registrer = use(SnarvegerContext)?.registrerFørDispatch;
+  const fnRef = useRef(fn);
+
+  useEffect(() => {
+    fnRef.current = fn;
+  });
+
+  useEffect(() => {
+    // Utan provider (t.d. i isolerte stories/tester) er dette ein no-op.
+    if (!registrer) {
+      return undefined;
+    }
+    return registrer(id => fnRef.current(id));
+  }, [registrer]);
+};
+
 interface SnarvegerContextValue {
   /** Registrer ein handler for ein snarveg-id. Returnerer ein opprydjingsfunksjon. */
   registrer: (id: string, handler: () => void) => () => void;
+  /**
+   * Registrer ein funksjon som køyrer rett før kvar dispatch (med id-en som argument).
+   * Brukast t.d. til å opne sidemenyen før ein snarveg som peikar inn i han køyrer.
+   * Returnerer ein opprydjingsfunksjon.
+   */
+  registrerFørDispatch: (fn: (id: string) => void) => () => void;
   /** Køyr handleren som er registrert for id-en, om nokon. Returnerer true om noko vart køyrt. */
   dispatch: (id: string) => boolean;
   snarveiModalÅpen: boolean;

--- a/apps/fp-frontend/src/snarveger/snarvegDefinisjoner.tsx
+++ b/apps/fp-frontend/src/snarveger/snarvegDefinisjoner.tsx
@@ -31,6 +31,7 @@ export const BEHANDLING_SNARVEG_IDER = {
   STØTTE_TIL_BESLUTTER: 'støtte-til-beslutter',
   STØTTE_FRA_BESLUTTER: 'støtte-fra-beslutter',
   UTVID_DETALJER: 'utvid-detaljer',
+  TOGGLE_SIDEMENY: 'toggle-sidemeny',
   ÅPNE_BEHANDLINGSMENY: 'åpne-behandlingsmeny',
   FOKUSER_BEHANDLINGSVELGER: 'fokuser-behandlingsvelger',
   FORRIGE_PROSESS: 'forrige-prosess',
@@ -117,6 +118,12 @@ export const snarvegDefinisjoner: SnarvegDefinisjon[] = [
     beskrivelse: <FormattedMessage id="Snarveger.UtvidDetaljer" />,
   },
   {
+    id: BEHANDLING_SNARVEG_IDER.TOGGLE_SIDEMENY,
+    gruppe: 'behandling',
+    taster: ['S'],
+    beskrivelse: <FormattedMessage id="Snarveger.ToggleSidemeny" />,
+  },
+  {
     id: BEHANDLING_SNARVEG_IDER.ÅPNE_BEHANDLINGSMENY,
     gruppe: 'behandling',
     taster: ['M'],
@@ -153,6 +160,25 @@ export const snarvegDefinisjoner: SnarvegDefinisjon[] = [
     beskrivelse: <FormattedMessage id="Snarveger.NesteFakta" />,
   },
 ];
+
+/**
+ * Snarvegar som peikar på innhald i sidemenyen (høgre kolonne). Når sidemenyen er lukka må han
+ * opnast att før handlinga køyrer, elles skjer endringa i ein skjult kolonne (width: 0).
+ */
+const SIDEMENY_SNARVEG_IDER: ReadonlySet<string> = new Set([
+  BEHANDLING_SNARVEG_IDER.STØTTE_HISTORIKK,
+  BEHANDLING_SNARVEG_IDER.STØTTE_MELDINGER,
+  BEHANDLING_SNARVEG_IDER.STØTTE_DOKUMENTER,
+  BEHANDLING_SNARVEG_IDER.STØTTE_NOTATER,
+  BEHANDLING_SNARVEG_IDER.STØTTE_TIL_BESLUTTER,
+  BEHANDLING_SNARVEG_IDER.STØTTE_FRA_BESLUTTER,
+  BEHANDLING_SNARVEG_IDER.UTVID_DETALJER,
+  BEHANDLING_SNARVEG_IDER.ÅPNE_BEHANDLINGSMENY,
+  BEHANDLING_SNARVEG_IDER.FOKUSER_BEHANDLINGSVELGER,
+]);
+
+/** Sann når snarvegen treng at sidemenyen er open for å vere synleg. */
+export const krevSideMeny = (id: string): boolean => SIDEMENY_SNARVEG_IDER.has(id);
 
 export const finnSekvensDefinisjon = (førsteTast: string, andreTast: string): SnarvegDefinisjon | undefined =>
   snarvegDefinisjoner.find(


### PR DESCRIPTION
…e han

Den forrige endringa for å åpne sidemenyen(når lukka) ved trykk på hurtigtast for å markera behandlingsvelgar funka dårleg. I tillegg vart sidemenyen åpna ved bruk av hurtigtast for behandlingsmeny, som ikkje er naudsynt. Har lagt til ny hurtigtast for å toggle heile sidemenyen. (så no er det to, ein for toggling av heile sidemenyen, og ein for toggling av support/behandlingsvelgar

Fokuser-behandlingsvelgar-snarvegen (B) viser no detaljane (som E) før den flyttar fokus når dei er minimerte. Snarvegane E, M, B og 1-6 opnar sidemenyen att om han er lukka, slik at handlinga ikkje skjer i ein skjult kolonne. I tillegg er det lagt til ein snarveg (S) for å vise eller skjule sidemenyen.