### PR TITLE
refactor: rett opp trygge react-hooks/exhaustive-deps-brudd

### DIFF
--- a/apps/fp-avdelingsleder/src/app/AvdelingslederIndex.tsx
+++ b/apps/fp-avdelingsleder/src/app/AvdelingslederIndex.tsx
@@ -44,6 +44,7 @@ export const AvdelingslederIndex = ({ initData }: Props) => {
 
   useEffect(() => {
     setAvdeling(setValgtAvdelingEnhet, initData.avdelinger, valgtAvdelingEnhet);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun setje default avdeling ein gong ved montering
   }, []);
 
   const activeAvdelingslederPanel = activeAvdelingslederPanelTemp || getPanelFromUrlOrDefault(location);

--- a/apps/fp-avdelingsleder/src/behandlingskoer/saksbehandlerForm/SaksbehandlereForSakslisteForm.tsx
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/saksbehandlerForm/SaksbehandlereForSakslisteForm.tsx
@@ -42,7 +42,7 @@ export const SaksbehandlereForSakslisteForm = ({
 
   useEffect(() => {
     formMethods.reset(defaultValues);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun nullstille skjema når valt saksliste endrar seg; defaultValues vert rekna på nytt kvar render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- nullstill skjema berre når valt saksliste endrar seg; defaultValues er ny kvar render
   }, [valgtSaksliste.sakslisteId]);
 
   const harGrupper =

--- a/apps/fp-avdelingsleder/src/behandlingskoer/saksbehandlerForm/SaksbehandlereForSakslisteForm.tsx
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/saksbehandlerForm/SaksbehandlereForSakslisteForm.tsx
@@ -42,6 +42,7 @@ export const SaksbehandlereForSakslisteForm = ({
 
   useEffect(() => {
     formMethods.reset(defaultValues);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun nullstille skjema når valt saksliste endrar seg; defaultValues vert rekna på nytt kvar render
   }, [valgtSaksliste.sakslisteId]);
 
   const harGrupper =

--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/filtrering/useAktuelleAndreKriterier.ts
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/filtrering/useAktuelleAndreKriterier.ts
@@ -54,7 +54,7 @@ export const useAktuelleAndreKriterier = (): LosKodeverkMedNavn<'AndreKriterierT
     if (nyInkluder.length !== andreKriterie.inkluder.length || nyEkskluder.length !== andreKriterie.ekskluder.length) {
       setValue('andreKriterie', { inkluder: nyInkluder, ekskluder: nyEkskluder }, { shouldDirty: true });
     }
-  }, [aktuelleKriterier]);
+  }, [aktuelleKriterier, getValues, setValue]);
 
   return aktuelleKriterier;
 };

--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/useDebounce.ts
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/useDebounce.ts
@@ -17,7 +17,7 @@ export const useDebounce = <VALUE, FORM_VALUES extends FieldValues>(
     void validationTrigger(feltNavn).then(isValid => isValid && funksjon(verdi));
   }, getTimeoutValue());
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup skal kun køyre ved unmount; lagre vert oppretta på nytt kvar render og skal ikkje vere dependency
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup berre ved unmount; lagre er ny kvar render og skal ikkje vere dependency
   useEffect(() => () => lagre.cancel(), []);
 
   return lagre;

--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/useDebounce.ts
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/useDebounce.ts
@@ -17,6 +17,7 @@ export const useDebounce = <VALUE, FORM_VALUES extends FieldValues>(
     void validationTrigger(feltNavn).then(isValid => isValid && funksjon(verdi));
   }, getTimeoutValue());
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup skal kun køyre ved unmount; lagre vert oppretta på nytt kvar render og skal ikkje vere dependency
   useEffect(() => () => lagre.cancel(), []);
 
   return lagre;

--- a/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/useDebounce.ts
+++ b/apps/fp-avdelingsleder/src/behandlingskoer/sakslisteForm/useDebounce.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { type FieldValues, type Path, useFormContext, type UseFormTrigger } from 'react-hook-form';
 
 import debounce from 'lodash.debounce';
@@ -13,12 +13,22 @@ export const useDebounce = <VALUE, FORM_VALUES extends FieldValues>(
   const context = useFormContext<FORM_VALUES>();
   const validationTrigger = trigger || context.trigger;
 
-  const lagre = debounce((verdi: VALUE) => {
-    void validationTrigger(feltNavn).then(isValid => isValid && funksjon(verdi));
-  }, getTimeoutValue());
+  const sisteArgsRef = useRef({ validationTrigger, feltNavn, funksjon });
+  useEffect(() => {
+    sisteArgsRef.current = { validationTrigger, feltNavn, funksjon };
+  });
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup berre ved unmount; lagre er ny kvar render og skal ikkje vere dependency
-  useEffect(() => () => lagre.cancel(), []);
+  const lagre = useMemo(
+    () =>
+      // eslint-disable-next-line react-hooks/refs -- lesinga skjer inne i debounce-callbacken (etter render), ikkje under render
+      debounce((verdi: VALUE) => {
+        const { validationTrigger: validate, feltNavn: felt, funksjon: fn } = sisteArgsRef.current;
+        void validate(felt).then(isValid => isValid && fn(verdi));
+      }, getTimeoutValue()),
+    [],
+  );
+
+  useEffect(() => () => lagre.cancel(), [lagre]);
 
   return lagre;
 };

--- a/apps/fp-avdelingsleder/src/data/localStorageHelper.ts
+++ b/apps/fp-avdelingsleder/src/data/localStorageHelper.ts
@@ -21,5 +21,5 @@ export const removeValueFromLocalStorage = (key: string): void => {
 export const useStoreValuesInLocalStorage = <T>(stateKey: string, values: T) => {
   useEffect(() => {
     setValueInLocalStorage(stateKey, JSON.stringify(values));
-  }, [values]);
+  }, [values, stateKey]);
 };

--- a/apps/fp-frontend/src/app/components/Home.tsx
+++ b/apps/fp-frontend/src/app/components/Home.tsx
@@ -44,7 +44,7 @@ export const Home = ({ headerHeight, navAnsatt }: Props) => {
     if (!erLosTilgjengelig) {
       addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: intl.formatMessage({ id: 'Los.IkkeTilgjengelig' }) });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun vise feilmelding når LOS-tilgjengelegheit endrar seg; intl/addErrorMessage er stabile dispatcharar
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- vis feilmelding berre når LOS-tilgjenge endrar seg; intl/addErrorMessage er stabile
   }, [erLosTilgjengelig]);
 
   const navigate = useNavigate();

--- a/apps/fp-frontend/src/app/components/Home.tsx
+++ b/apps/fp-frontend/src/app/components/Home.tsx
@@ -44,6 +44,7 @@ export const Home = ({ headerHeight, navAnsatt }: Props) => {
     if (!erLosTilgjengelig) {
       addErrorMessage({ type: ErrorType.GENERAL_ERROR, message: intl.formatMessage({ id: 'Los.IkkeTilgjengelig' }) });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun vise feilmelding når LOS-tilgjengelegheit endrar seg; intl/addErrorMessage er stabile dispatcharar
   }, [erLosTilgjengelig]);
 
   const navigate = useNavigate();
@@ -57,6 +58,7 @@ export const Home = ({ headerHeight, navAnsatt }: Props) => {
     if (location.pathname === '/') {
       removeErrorMessages();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun fjerne feilmeldingar ved navigasjonsendring; removeErrorMessages er stabil dispatcher
   }, [location]);
 
   const {

--- a/apps/fp-frontend/src/behandling/BehandlingIndex.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingIndex.tsx
@@ -47,6 +47,7 @@ export const BehandlingIndex = ({
 
   useEffect(() => {
     setBehandlingUuidFraUrl(behandlingUuid);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- synkroniserer berre når behandlingUuid frå URL endrar seg; setter-prop er stabil
   }, [behandlingUuid]);
 
   if (!behandling) {

--- a/apps/fp-frontend/src/behandling/felles/fakta/useFaktaMenyRegistrerer.ts
+++ b/apps/fp-frontend/src/behandling/felles/fakta/useFaktaMenyRegistrerer.ts
@@ -23,7 +23,7 @@ export const useFaktaMenyRegistrerer = (
       harÅpentAksjonspunkt,
       skalVisesIMeny,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere menydata når visningstilstand endrar seg; id/tekst er konstante for panelet og setter frå context er stabil
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- oppdater menydata berre ved endra visningstilstand; id/tekst er konstante, setter stabil
   }, [skalVisesIMeny, erAktiv, harÅpentAksjonspunkt]);
 
   return skalVisesIMeny && erAktiv;

--- a/apps/fp-frontend/src/behandling/felles/fakta/useFaktaMenyRegistrerer.ts
+++ b/apps/fp-frontend/src/behandling/felles/fakta/useFaktaMenyRegistrerer.ts
@@ -23,6 +23,7 @@ export const useFaktaMenyRegistrerer = (
       harÅpentAksjonspunkt,
       skalVisesIMeny,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere menydata når visningstilstand endrar seg; id/tekst er konstante for panelet og setter frå context er stabil
   }, [skalVisesIMeny, erAktiv, harÅpentAksjonspunkt]);
 
   return skalVisesIMeny && erAktiv;

--- a/apps/fp-frontend/src/behandling/felles/prosess/BehandlingHenlagtPanel.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/BehandlingHenlagtPanel.tsx
@@ -27,6 +27,7 @@ export const BehandlingHenlagtPanel = ({ valgtProsessSteg, settProsessPanelMenyD
       status: 'IKKE_VURDERT',
       skalVisesIMeny: true,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere menydata når valt prosesssteg endrar seg; resten av verdiane er konstante og setter frå context er stabil
   }, [valgtProsessSteg]);
 
   return (

--- a/apps/fp-frontend/src/behandling/felles/prosess/BehandlingHenlagtPanel.tsx
+++ b/apps/fp-frontend/src/behandling/felles/prosess/BehandlingHenlagtPanel.tsx
@@ -27,7 +27,7 @@ export const BehandlingHenlagtPanel = ({ valgtProsessSteg, settProsessPanelMenyD
       status: 'IKKE_VURDERT',
       skalVisesIMeny: true,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere menydata når valt prosesssteg endrar seg; resten av verdiane er konstante og setter frå context er stabil
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- oppdater menydata berre ved endra prosesssteg; resten er konstante, setter stabil
   }, [valgtProsessSteg]);
 
   return (

--- a/apps/fp-frontend/src/behandling/felles/prosess/useInngangsvilkarRegistrerer.ts
+++ b/apps/fp-frontend/src/behandling/felles/prosess/useInngangsvilkarRegistrerer.ts
@@ -23,5 +23,6 @@ export const useInngangsvilkarRegistrerer = (
         aksjonspunktTekst: erOverstyrt || erAksjonspunktApent ? aksjonspunktTekst : undefined,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere panel-data når synleg-/aksjonspunkt-tilstand endrar seg; id/status/tekst er konstante og setter frå context er stabil
   }, [erAksjonspunktApent, skalVises, erOverstyrt]);
 };

--- a/apps/fp-frontend/src/behandling/felles/prosess/useInngangsvilkarRegistrerer.ts
+++ b/apps/fp-frontend/src/behandling/felles/prosess/useInngangsvilkarRegistrerer.ts
@@ -23,6 +23,6 @@ export const useInngangsvilkarRegistrerer = (
         aksjonspunktTekst: erOverstyrt || erAksjonspunktApent ? aksjonspunktTekst : undefined,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere panel-data når synleg-/aksjonspunkt-tilstand endrar seg; id/status/tekst er konstante og setter frå context er stabil
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- oppdater panel-data berre ved endra synleg-/aksjonspunkt-tilstand; resten er konstant/stabilt
   }, [erAksjonspunktApent, skalVises, erOverstyrt]);
 };

--- a/apps/fp-frontend/src/behandling/felles/prosess/useProsessMenyRegistrerer.ts
+++ b/apps/fp-frontend/src/behandling/felles/prosess/useProsessMenyRegistrerer.ts
@@ -28,6 +28,7 @@ export const useProsessMenyRegistrerer = (
       status,
       skalVisesIMeny,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere menydata når visningstilstand/status endrar seg; id/tekst er konstante for panelet og setter frå context er stabil
   }, [skalVisesIMeny, erAktiv, harÅpentAksjonspunkt, status]);
 
   return skalVisesIMeny && erAktiv;

--- a/apps/fp-frontend/src/behandling/felles/prosess/useProsessMenyRegistrerer.ts
+++ b/apps/fp-frontend/src/behandling/felles/prosess/useProsessMenyRegistrerer.ts
@@ -28,7 +28,7 @@ export const useProsessMenyRegistrerer = (
       status,
       skalVisesIMeny,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere menydata når visningstilstand/status endrar seg; id/tekst er konstante for panelet og setter frå context er stabil
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- oppdater menydata berre ved endra visningstilstand/status; id/tekst konstante, setter stabil
   }, [skalVisesIMeny, erAktiv, harÅpentAksjonspunkt, status]);
 
   return skalVisesIMeny && erAktiv;

--- a/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
+++ b/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
@@ -99,7 +99,7 @@ export const FagsakIndex = () => {
     if (behandlingUuidFraUrl && fagsakBehandling) {
       hentOgSettBehandling();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun hente behandling når URL-uuid endrar seg; å inkludere hentOgSettBehandling/fagsakBehandling gjev gjentekne henteforsøk
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hent behandling berre ved endra URL-uuid; hentOgSettBehandling gjev gjentekne henteforsøk
   }, [behandlingUuidFraUrl, fagsakBehandling?.uuid]);
 
   const location = useLocation();

--- a/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
+++ b/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
@@ -99,6 +99,7 @@ export const FagsakIndex = () => {
     if (behandlingUuidFraUrl && fagsakBehandling) {
       hentOgSettBehandling();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun hente behandling når URL-uuid endrar seg; å inkludere hentOgSettBehandling/fagsakBehandling gjev gjentekne henteforsøk
   }, [behandlingUuidFraUrl, fagsakBehandling?.uuid]);
 
   const location = useLocation();

--- a/apps/fp-frontend/src/fagsak/useHentFagsak.tsx
+++ b/apps/fp-frontend/src/fagsak/useHentFagsak.tsx
@@ -31,7 +31,7 @@ export const useHentFagsak = (
       void refetchFagsak();
       void refetchFpTilbakeFagsak();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun refetche når behandlingUuid/-versjon endrar seg; refetch-funksjonane er stabile frå react-query
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refetch berre ved endra behandlingUuid/-versjon; refetch er stabil frå react-query
   }, [behandlingUuid, behandlingVersjon]);
 
   const harHentetFpSak = !!fagsak;

--- a/apps/fp-frontend/src/fagsak/useHentFagsak.tsx
+++ b/apps/fp-frontend/src/fagsak/useHentFagsak.tsx
@@ -31,6 +31,7 @@ export const useHentFagsak = (
       void refetchFagsak();
       void refetchFpTilbakeFagsak();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun refetche når behandlingUuid/-versjon endrar seg; refetch-funksjonane er stabile frå react-query
   }, [behandlingUuid, behandlingVersjon]);
 
   const harHentetFpSak = !!fagsak;

--- a/apps/fp-frontend/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.tsx
@@ -117,6 +117,7 @@ const RisikoklassifiseringBehandling = ({
     if (!!risikoAksjonspunkt && risikoAksjonspunkt.status === 'UTFO') {
       void navigate(getRiskPanelLocationCreator(location)(false));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun reagere på endra behandling/risikoaksjonspunkt; navigate/location/isRiskPanelOpen er bevisst utelatne for å unngå uønskt navigering
   }, [!!risikoAksjonspunkt, behandling.uuid, behandling.versjon]);
 
   const { lagreAksjonspunkter } = useBehandlingPollingOperasjoner(behandling, setBehandling);

--- a/apps/fp-frontend/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.tsx
@@ -117,7 +117,7 @@ const RisikoklassifiseringBehandling = ({
     if (!!risikoAksjonspunkt && risikoAksjonspunkt.status === 'UTFO') {
       void navigate(getRiskPanelLocationCreator(location)(false));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun reagere på endra behandling/risikoaksjonspunkt; navigate/location/isRiskPanelOpen er bevisst utelatne for å unngå uønskt navigering
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reager berre på endra behandling/risikoaksjonspunkt; navigate/location utelatne med vilje
   }, [!!risikoAksjonspunkt, behandling.uuid, behandling.versjon]);
 
   const { lagreAksjonspunkter } = useBehandlingPollingOperasjoner(behandling, setBehandling);

--- a/packages/app-felles/src/restApiError/RestApiErrorContext.spec.tsx
+++ b/packages/app-felles/src/restApiError/RestApiErrorContext.spec.tsx
@@ -14,6 +14,7 @@ const TestErrorMessage = ({ skalFjerne = false }) => {
     if (skalFjerne) {
       removeErrorMessages();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- testfixture: effekten skal kun køyre ein gong ved montering
   }, []);
 
   const feilmeldinger = useRestApiError();

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -135,7 +135,7 @@ const useAutoSaveDebouncer = () => {
     lagreFn();
   }, getTimeoutValue());
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup skal kun køyre ved unmount; lagre vert oppretta på nytt kvar render og skal ikkje vere dependency
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup berre ved unmount; lagre er ny kvar render og skal ikkje vere dependency
   useEffect(() => () => lagre.cancel(), []);
 
   return lagre;

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -98,6 +98,7 @@ export const useBrevEditorJs = (
         editorJsRef.current.destroy();
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- editor skal kun initialiserast ein gong ved montering
   }, []);
 
   const tilbakestillEndringer = async (opprinneligRedigerbartInnhold: string) => {
@@ -134,6 +135,7 @@ const useAutoSaveDebouncer = () => {
     lagreFn();
   }, getTimeoutValue());
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup skal kun køyre ved unmount; lagre vert oppretta på nytt kvar render og skal ikkje vere dependency
   useEffect(() => () => lagre.cancel(), []);
 
   return lagre;

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import EditorJS, { type EditorConfig, type I18nConfig, type ToolConstructable } from '@editorjs/editorjs';
 import Header from '@editorjs/header';
@@ -131,12 +131,9 @@ export const useBrevEditorJs = (
 const getTimeoutValue = () => (import.meta.env.MODE === 'test' ? 0 : 1000);
 
 const useAutoSaveDebouncer = () => {
-  const lagre = debounce((lagreFn: () => void) => {
-    lagreFn();
-  }, getTimeoutValue());
+  const lagre = useMemo(() => debounce((lagreFn: () => void) => lagreFn(), getTimeoutValue()), []);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup berre ved unmount; lagre er ny kvar render og skal ikkje vere dependency
-  useEffect(() => () => lagre.cancel(), []);
+  useEffect(() => () => lagre.cancel(), [lagre]);
 
   return lagre;
 };

--- a/packages/fakta/arbeid-og-inntekt/src/DirtyFormProvider.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/DirtyFormProvider.tsx
@@ -20,6 +20,7 @@ export const useSetDirtyForm = (isDirty: boolean): void => {
   const context = use(DirtyFormContext);
   useEffect(() => {
     context.setDirty(isDirty);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun oppdatere dirty-state når isDirty-arg endrar seg; context er stabil
   }, [isDirty]);
 };
 

--- a/packages/fakta/arbeid-og-inntekt/src/components/ArbeidOgInntektFaktaPanel.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/ArbeidOgInntektFaktaPanel.tsx
@@ -63,7 +63,7 @@ export const ArbeidOgInntektFaktaPanel = ({
     () => () => {
       setMellomlagretFormData(tabellRader);
     },
-    [tabellRader],
+    [tabellRader, setMellomlagretFormData],
   );
 
   const toggleÅpenRad = (index: number) => {

--- a/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
+++ b/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
@@ -75,7 +75,7 @@ export const BarnFieldArray = ({ isReadOnly }: Props) => {
 
   useEffect(() => {
     validateAlleFødselsdatoer(getValues, setError, clearErrors);
-  }, [barn, termindato]);
+  }, [barn, termindato, getValues, setError, clearErrors]);
 
   const today = dayjs().toDate();
 

--- a/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
@@ -59,7 +59,7 @@ export const VurderOmsorgsovertakelseVilkåretForm = ({ omsorgsovertakelse }: Pr
     return (omsorgsovertakelse.aktuelleDelvilkårAvslagsårsaker[delvilkår] ?? [])
       .map(kode => alleKodeverk['Avslagsårsak'].find(kodeverk => kodeverk.kode === kode))
       .sort(sortByNavn);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- avslagsårsaker skal kun reknast om når delvilkår endrar seg; alleKodeverk og aktuelleDelvilkårAvslagsårsaker er stabile etter lasting
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- avslagsårsaker reknast berre om ved endra delvilkår; alleKodeverk er stabil etter lasting
   }, [delvilkår]);
 
   return (

--- a/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
@@ -59,6 +59,7 @@ export const VurderOmsorgsovertakelseVilkåretForm = ({ omsorgsovertakelse }: Pr
     return (omsorgsovertakelse.aktuelleDelvilkårAvslagsårsaker[delvilkår] ?? [])
       .map(kode => alleKodeverk['Avslagsårsak'].find(kodeverk => kodeverk.kode === kode))
       .sort(sortByNavn);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- avslagsårsaker skal kun reknast om når delvilkår endrar seg; alleKodeverk og aktuelleDelvilkårAvslagsårsaker er stabile etter lasting
   }, [delvilkår]);
 
   return (

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -130,7 +130,7 @@ export const OpptjeningFaktaPanel = ({
     () => () => {
       setMellomlagretFormData(formVerdierForAlleAktiviteter);
     },
-    [formVerdierForAlleAktiviteter],
+    [formVerdierForAlleAktiviteter, setMellomlagretFormData],
   );
 
   const [forrigeFormVerdier, setForrigeFormVerdier] = useState(formVerdierForAlleAktiviteter);

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -63,7 +63,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
       annenForelderUttakEøsPerioder: perioder,
       begrunnelse: begrunnelse,
     });
-  }, [perioder, begrunnelse]);
+  }, [perioder, begrunnelse, setMellomlagretFormData]);
 
   return (
     <VStack gap="space-16">

--- a/packages/fakta/uttak/src/components/GraderingOgSamtidigUttakPanel.tsx
+++ b/packages/fakta/uttak/src/components/GraderingOgSamtidigUttakPanel.tsx
@@ -75,12 +75,12 @@ export const GraderingOgSamtidigUttakPanel = ({
       unregister('arbeidstidsprosent');
       unregister('arbeidsgiverId');
     }
-  }, [visGradering]);
+  }, [visGradering, unregister]);
   useEffect(() => {
     if (!visSamtidigUttaksgradering) {
       unregister('samtidigUttaksprosent');
     }
-  }, [visSamtidigUttaksgradering]);
+  }, [visSamtidigUttaksgradering, unregister]);
 
   return (
     <>

--- a/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
@@ -131,6 +131,7 @@ export const UttakFaktaDetailForm = ({
       formMethods.unregister('morsAktivitet');
       formMethods.unregister('flerbarnsdager');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun avregistrere felt når årsakstype endrar seg; formMethods er stabil
   }, [årsakstype]);
 
   const onSubmit = (values: FormValues) => oppdaterPeriode(transformValues(values));

--- a/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
@@ -196,7 +196,7 @@ export const UttakFaktaForm = ({
     () => () => {
       setMellomlagretFormData({ uttakPerioder, begrunnelse: formMethods.getValues('begrunnelse') });
     },
-    [uttakPerioder],
+    [uttakPerioder, formMethods, setMellomlagretFormData],
   );
 
   const automatiskeAksjonspunkter = aksjonspunkterForPanel.filter(

--- a/packages/los/felles/src/ReactECharts.tsx
+++ b/packages/los/felles/src/ReactECharts.tsx
@@ -35,8 +35,7 @@ export const ReactECharts = ({ option, style, height }: Props): JSX.Element => {
         chart.setOption(option, { notMerge: true });
       }
     }
-    // eslint-disable-next-line react-hooks/refs
-  }, [chartRef.current, option]);
+  }, [option]);
 
   return <div ref={chartRef} style={{ width: 'auto', height, ...style }} />;
 };

--- a/packages/los/saksbehandler/src/SaksbehandlerDashboard.tsx
+++ b/packages/los/saksbehandler/src/SaksbehandlerDashboard.tsx
@@ -26,7 +26,7 @@ export const SaksbehandlerDashboard = ({ setLosErIkkeTilgjengelig, åpneFagsak, 
     if (alleKodeverkQuery.isError) {
       setLosErIkkeTilgjengelig();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun reagere på feiltilstand; setLosErIkkeTilgjengelig-prop er ikkje memoisert og ville trigge effekten på nytt
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reager berre på feiltilstand; setLosErIkkeTilgjengelig er ikkje memoisert og ville trigge på nytt
   }, [alleKodeverkQuery.isError]);
 
   if (alleKodeverkQuery.isPending) {

--- a/packages/los/saksbehandler/src/SaksbehandlerDashboard.tsx
+++ b/packages/los/saksbehandler/src/SaksbehandlerDashboard.tsx
@@ -26,6 +26,7 @@ export const SaksbehandlerDashboard = ({ setLosErIkkeTilgjengelig, åpneFagsak, 
     if (alleKodeverkQuery.isError) {
       setLosErIkkeTilgjengelig();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun reagere på feiltilstand; setLosErIkkeTilgjengelig-prop er ikkje memoisert og ville trigge effekten på nytt
   }, [alleKodeverkQuery.isError]);
 
   if (alleKodeverkQuery.isPending) {

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
@@ -68,6 +68,7 @@ export const useOppgavePolling = (valgtSakslisteId: number) => {
 
   useEffect(() => {
     void pollEtterOppgaver({ oppgaveIder: undefined });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun starte polling ein gong ved montering
   }, []);
 
   useEffect(() => {
@@ -80,6 +81,7 @@ export const useOppgavePolling = (valgtSakslisteId: number) => {
 
       void pollEtterOppgaver({ oppgaveIder: tilBehandling.map(o => o.id).join(',') });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- polling-kjede som kun skal reagere på isSuccess; å inkludere oppgaver/pollEtterOppgaver ville gitt ny polling i loop
   }, [isSuccess]);
 
   useEffect(() => {

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
@@ -81,7 +81,7 @@ export const useOppgavePolling = (valgtSakslisteId: number) => {
 
       void pollEtterOppgaver({ oppgaveIder: tilBehandling.map(o => o.id).join(',') });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- polling-kjede som kun skal reagere på isSuccess; å inkludere oppgaver/pollEtterOppgaver ville gitt ny polling i loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- polling-kjede som berre skal reagere på isSuccess; oppgaver/pollEtterOppgaver ville gitt loop
   }, [isSuccess]);
 
   useEffect(() => {

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
@@ -49,6 +49,7 @@ export const SakslisteVelgerForm = ({ sakslister, setValgtSakslisteId, fetchAnta
       setValgtSakslisteId(id);
       fetchAntallOppgaver(id);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun reagere på endra sakslisteId; fetchAntallOppgaver/setValgtSakslisteId skal ikkje trigge effekten på nytt
   }, [sakslisteId]);
 
   if (sakslister.length === 0) {

--- a/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/sakslisteVelger/SakslisteVelgerForm.tsx
@@ -49,7 +49,7 @@ export const SakslisteVelgerForm = ({ sakslister, setValgtSakslisteId, fetchAnta
       setValgtSakslisteId(id);
       fetchAntallOppgaver(id);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun reagere på endra sakslisteId; fetchAntallOppgaver/setValgtSakslisteId skal ikkje trigge effekten på nytt
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reager berre på endra sakslisteId; fetchAntallOppgaver/setValgtSakslisteId skal ikkje trigge
   }, [sakslisteId]);
 
   if (sakslister.length === 0) {

--- a/packages/papirsoknad-ui-komponenter/src/andreYtelserPanel/components/RenderAndreYtelserPerioderFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/andreYtelserPanel/components/RenderAndreYtelserPerioderFieldArray.tsx
@@ -30,6 +30,7 @@ export const RenderAndreYtelserPerioderFieldArray = ({ readOnly, name }: Props) 
     if (fields.length === 0) {
       append({ periodeFom: '', periodeTom: '' });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
@@ -75,6 +75,7 @@ export const OmsorgOgAdopsjonPanel = ({
         append({ id: i, dato: undefined });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- synkroniser rader berre ved endra antallBarn; append/remove stabile, fields.length les med vilje
   }, [antallBarn]);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/PermisjonPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/PermisjonPanel.tsx
@@ -57,7 +57,7 @@ export const PermisjonPanel = ({ foreldreType, readOnly, alleKodeverk, erEndring
     } else {
       clearErrors(`${TIDSROM_PERMISJON_FORM_NAME_PREFIX}.notRegisteredInput`);
     }
-  }, [fulltUttak, skalGradere, skalUtsette, skalOvertaKvote]);
+  }, [fulltUttak, skalGradere, skalUtsette, skalOvertaKvote, setError, clearErrors, intl]);
 
   return (
     <BorderBox>

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/fulltUttak/RenderPermisjonPeriodeFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/fulltUttak/RenderPermisjonPeriodeFieldArray.tsx
@@ -80,6 +80,7 @@ export const RenderPermisjonPeriodeFieldArray = ({ søkerErMor, readOnly, alleKo
       // @ts-expect-error Fiks
       append({});
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/gradering/RenderGraderingPeriodeFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/gradering/RenderGraderingPeriodeFieldArray.tsx
@@ -74,6 +74,7 @@ export const RenderGraderingPeriodeFieldArray = ({ graderingKvoter, readOnly, ar
     if (fields.length === 0) {
       append(defaultGraderingPeriode);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/opphold/RenderOppholdPeriodeFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/opphold/RenderOppholdPeriodeFieldArray.tsx
@@ -79,6 +79,7 @@ export const RenderOppholdPeriodeFieldArray = ({ oppholdsReasons, readOnly }: Pr
     if (fields.length === 0) {
       append(defaultOppholdPeriode);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/overforeKvote/RenderOverforingAvKvoterFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/overforeKvote/RenderOverforingAvKvoterFieldArray.tsx
@@ -61,6 +61,7 @@ export const RenderOverforingAvKvoterFieldArray = ({ selectValues, readOnly }: P
     if (fields.length === 0) {
       append(defaultOverforingPeriode);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/utsettelse/RenderUtsettelsePeriodeFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/utsettelse/RenderUtsettelsePeriodeFieldArray.tsx
@@ -100,6 +100,7 @@ export const RenderUtsettelsePeriodeFieldArray = ({ utsettelseReasons, utsettels
     if (fields.length === 0) {
       append(defaultUtsettelsePeriode);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   const triggerValidationOnChange = () => (isSubmitted ? trigger() : undefined);

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.tsx
@@ -46,7 +46,7 @@ export const BehovForTilretteleggingPanel = ({ readOnly }: Props) => {
     } else {
       clearErrors(`${TILRETTELEGGING_NAME_PREFIX}.notRegisteredInput`);
     }
-  }, [sokSN, sokFrilans, sokArbeid]);
+  }, [sokSN, sokFrilans, sokArbeid, setError, clearErrors]);
 
   return (
     <RawIntlProvider value={intl}>

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
@@ -39,6 +39,7 @@ export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => 
     if (fields.length === 0) {
       append(defaultTilrettelegging);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/TilretteleggingForArbeidsgiverFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/TilretteleggingForArbeidsgiverFieldArray.tsx
@@ -43,6 +43,7 @@ export const TilretteleggingForArbeidsgiverFieldArray = ({ readOnly }: Props) =>
     if (fields.length === 0) {
       leggTilArbeidsgiver();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein rad ved montering; fields.length/leggTilArbeidsgiver skal ikkje trigge på nytt
   }, []);
 
   return (

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/RegistrerVirksomhetPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/RegistrerVirksomhetPanel.tsx
@@ -46,6 +46,7 @@ export const RegistrerVirksomhetPanel = ({ readOnly = false, alleKodeverk }: Pro
     if (fields.length === 0) {
       leggTilVirksomhet();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein rad ved montering; fields.length/leggTilVirksomhet skal ikkje trigge på nytt
   }, []);
 
   return (

--- a/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
+++ b/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
@@ -286,6 +286,7 @@ export const UttakProsessPanel = ({
       return true;
     }
     return valgtPeriodeIndex !== undefined || !isDirty;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- aksjonspunkterForPanel er ny referanse kvar render; bevisst utelaten for å unngå rekalkulering kvar render
   }, [perioder, stønadskonto, valgtPeriodeIndex, isDirty]);
 
   const feilmeldinger =

--- a/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
+++ b/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
@@ -286,7 +286,7 @@ export const UttakProsessPanel = ({
       return true;
     }
     return valgtPeriodeIndex !== undefined || !isDirty;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- aksjonspunkterForPanel er ny referanse kvar render; bevisst utelaten for å unngå rekalkulering kvar render
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- aksjonspunkterForPanel er ny ref kvar render; utelaten for å unngå rekalkulering
   }, [perioder, stønadskonto, valgtPeriodeIndex, isDirty]);
 
   const feilmeldinger =

--- a/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
+++ b/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
@@ -233,7 +233,7 @@ export const UttakProsessPanel = ({
 
   const [stønadskonto, setStønadskonto] = useState(uttakStonadskontoer);
 
-  useEffect(() => () => setMellomlagretFormData(perioder), [perioder]);
+  useEffect(() => () => setMellomlagretFormData(perioder), [perioder, setMellomlagretFormData]);
 
   const visPeriode = (per: (PeriodeSoker | AnnenforelderUttakEøsPeriode)[]) => {
     const index = per.findIndex(

--- a/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
+++ b/packages/prosess/uttak/src/components/UttakProsessPanel.tsx
@@ -286,8 +286,7 @@ export const UttakProsessPanel = ({
       return true;
     }
     return valgtPeriodeIndex !== undefined || !isDirty;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- aksjonspunkterForPanel er ny ref kvar render; utelaten for å unngå rekalkulering
-  }, [perioder, stønadskonto, valgtPeriodeIndex, isDirty]);
+  }, [aksjonspunkterForPanel, perioder, valgtPeriodeIndex, isDirty]);
 
   const feilmeldinger =
     !isDirty || valgtPeriodeIndex !== undefined ? [] : validerPerioder(perioder, stønadskonto, intl);

--- a/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
+++ b/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
@@ -250,13 +250,13 @@ export const UttakPeriodeForm = ({
   const sorterteAktiviteter = useMemo(() => {
     const sorterAktiviteter = hentSorterAktiviteterFn(arbeidsgiverOpplysningerPerId, intl);
     return [...valgtPeriode.aktiviteter].sort(sorterAktiviteter);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- bevisst utelating: arbeidsgiverOpplysningerPerId/intl gjev ny referanse kvar render og uendeleg oppdatering (sjå kommentar over)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bevisst utelating: arbeidsgiverOpplysningerPerId/intl gjev ny ref og uendeleg loop (sjå over)
   }, [valgtPeriode.aktiviteter]);
 
   // Her er det noko rart. Denne må ha useMemo, ellers blir testen aldri ferdig
   const defaultValues = useMemo(
     () => buildInitialValues(valgtPeriode, sorterteAktiviteter, muligeÅrsaker),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- bevisst utelating: muligeÅrsaker er ny referanse kvar render og ville gitt uendeleg oppdatering (sjå kommentar over)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bevisst utelating: muligeÅrsaker er ny ref kvar render og ville gitt uendeleg loop (sjå over)
     [valgtPeriode, sorterteAktiviteter, arbeidsgiverOpplysningerPerId],
   );
 

--- a/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
+++ b/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
@@ -250,11 +250,13 @@ export const UttakPeriodeForm = ({
   const sorterteAktiviteter = useMemo(() => {
     const sorterAktiviteter = hentSorterAktiviteterFn(arbeidsgiverOpplysningerPerId, intl);
     return [...valgtPeriode.aktiviteter].sort(sorterAktiviteter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bevisst utelating: arbeidsgiverOpplysningerPerId/intl gjev ny referanse kvar render og uendeleg oppdatering (sjå kommentar over)
   }, [valgtPeriode.aktiviteter]);
 
   // Her er det noko rart. Denne må ha useMemo, ellers blir testen aldri ferdig
   const defaultValues = useMemo(
     () => buildInitialValues(valgtPeriode, sorterteAktiviteter, muligeÅrsaker),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bevisst utelating: muligeÅrsaker er ny referanse kvar render og ville gitt uendeleg oppdatering (sjå kommentar over)
     [valgtPeriode, sorterteAktiviteter, arbeidsgiverOpplysningerPerId],
   );
 

--- a/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
+++ b/packages/prosess/uttak/src/components/periodeDetaljer/UttakPeriodeForm.tsx
@@ -264,7 +264,7 @@ export const UttakPeriodeForm = ({
 
   useEffect(() => {
     formMethods.reset(defaultValues);
-  }, [defaultValues]);
+  }, [defaultValues, formMethods]);
 
   const erOppfylt = useWatch({ control: formMethods.control, name: 'erOppfylt' });
   const graderingInnvilget = useWatch({ control: formMethods.control, name: 'graderingInnvilget' });

--- a/packages/prosess/uttak/src/components/stonadsdagerOversikt/DisponibleStonadskontoerPanel.tsx
+++ b/packages/prosess/uttak/src/components/stonadsdagerOversikt/DisponibleStonadskontoerPanel.tsx
@@ -122,7 +122,7 @@ export const DisponibleStonadskontoerPanel = ({ stønadskontoer, arbeidsgiverOpp
       navn: utledNavn(aktivitet.aktivitetIdentifikator, arbeidsgiverOpplysningerPerId, intl),
     }));
     return aktiviteterMedNavn.sort((akt1, akt2) => akt1.navn.localeCompare(akt2.navn));
-  }, [valgtKonto, stønadskontoerMedNavn, arbeidsgiverOpplysningerPerId, intl]);
+  }, [valgtKonto, arbeidsgiverOpplysningerPerId, intl]);
 
   return (
     <div className={styles['disponibeltUttak']}>

--- a/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
+++ b/packages/prosess/varsel-om-revurdering/src/components/VarselOmRevurderingForm.tsx
@@ -78,6 +78,7 @@ export const VarselOmRevurderingForm = ({ previewCallback, hentVarselHtml, mello
         })
         .catch(() => {});
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun hentast ein gong ved montering (styrt av hasFetchedBrevDataRef)
   }, []);
 
   const lukkModal = () => setSkalVisePåVentModal(false);

--- a/packages/prosess/vedtak/src/components/felles/OverstyringVedtaksbrev.tsx
+++ b/packages/prosess/vedtak/src/components/felles/OverstyringVedtaksbrev.tsx
@@ -38,6 +38,7 @@ export const OverstyringVedtaksbrev = ({ forhåndsvisBrev, setHarValgtÅRedigere
       hasFetchedBrevOverstyringRef.current = true;
       void hentBrevHtml().then(setBrevOverstyring);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun hentast ein gong ved montering (styrt av hasFetchedBrevOverstyringRef)
   }, []);
 
   const visFritekstModalOgHentBrev = async () => {

--- a/packages/prosess/vilkar-svangerskap/src/components/SvangerskapVilkarForm.tsx
+++ b/packages/prosess/vilkar-svangerskap/src/components/SvangerskapVilkarForm.tsx
@@ -93,7 +93,7 @@ export const SvangerskapVilkarForm = ({ svangerskapspengerTilrettelegging, statu
     if (erVilkårOk) {
       formMethods.clearErrors();
     }
-  }, [erVilkårOk]);
+  }, [erVilkårOk, formMethods]);
 
   const originalErVilkårOk = harÅpentAksjonspunkt ? undefined : 'OPPFYLT' === status;
 

--- a/packages/sak/dekorator/src/DekoratorMedFeilviserSakIndex.tsx
+++ b/packages/sak/dekorator/src/DekoratorMedFeilviserSakIndex.tsx
@@ -54,6 +54,7 @@ export const DekoratorMedFeilviserSakIndex = ({
     if (fixedHeaderRef.current) {
       setSiteHeight(fixedHeaderRef.current.clientHeight);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun måle høgd når talet på feilmeldingar endrar seg; setSiteHeight-prop skal ikkje trigge effekten på nytt
   }, [feilmeldinger.length]);
 
   return (

--- a/packages/sak/dekorator/src/DekoratorMedFeilviserSakIndex.tsx
+++ b/packages/sak/dekorator/src/DekoratorMedFeilviserSakIndex.tsx
@@ -54,7 +54,7 @@ export const DekoratorMedFeilviserSakIndex = ({
     if (fixedHeaderRef.current) {
       setSiteHeight(fixedHeaderRef.current.clientHeight);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- skal kun måle høgd når talet på feilmeldingar endrar seg; setSiteHeight-prop skal ikkje trigge effekten på nytt
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mål høgd berre når talet på feilmeldingar endrar seg; setSiteHeight er stabil
   }, [feilmeldinger.length]);
 
   return (

--- a/packages/sak/meny/src/verge/MenyVergeIndex.tsx
+++ b/packages/sak/meny/src/verge/MenyVergeIndex.tsx
@@ -47,7 +47,7 @@ export const MenyVergeIndex = ({ verge, type, fjernVerge, opprettVerge, lukkModa
     if (verge) {
       formMethods.reset(RegistrereVergeForm.buildInitialValues(verge));
     }
-  }, [verge]);
+  }, [verge, formMethods]);
 
   return (
     <RawIntlProvider value={intl}>

--- a/packages/utils/src/context/PanelOverstyringContext.tsx
+++ b/packages/utils/src/context/PanelOverstyringContext.tsx
@@ -29,6 +29,7 @@ export const PanelOverstyringProvider = (
 
   const { children, toggleOverstyring: toggle, ...otherProps } = props;
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- closure som les gjeldande erOverstyrt; bevisst ikkje memoisert for å halde toggle-semantikken
   const toggleOverstyring = () => {
     setErOverstyrt(!erOverstyrt);
     toggle?.(!erOverstyrt);

--- a/packages/utils/src/context/PanelOverstyringContext.tsx
+++ b/packages/utils/src/context/PanelOverstyringContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactElement, use, useMemo, useState } from 'react';
+import { createContext, type ReactElement, use, useCallback, useMemo, useState } from 'react';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 
@@ -29,11 +29,11 @@ export const PanelOverstyringProvider = (
 
   const { children, toggleOverstyring: toggle, ...otherProps } = props;
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- closure som les gjeldande erOverstyrt; bevisst ikkje memoisert for å halde toggle-semantikken
-  const toggleOverstyring = () => {
-    setErOverstyrt(!erOverstyrt);
-    toggle?.(!erOverstyrt);
-  };
+  const toggleOverstyring = useCallback(() => {
+    const neste = !erOverstyrt;
+    setErOverstyrt(neste);
+    toggle?.(neste);
+  }, [erOverstyrt, toggle]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
Legg til stabile referansar (setState-settere, react-hook-form-metodar, intl) i dependency-arrays og fjern overflødige/ugyldige deps (stønadskontoerMedNavn og chartRef.current). Endringane er reint lint-korrigerande og endrar ikkje køyretidsåtferd, sidan referansane er stabile mellom rendrar.