### PR TITLE
fix: rett opp resterende eslint-advarsler

### DIFF
--- a/apps/fp-frontend/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.tsx
+++ b/apps/fp-frontend/src/behandling/tilbakekreving/modaler/ÅpenRevurderingModal.tsx
@@ -11,6 +11,7 @@ export const ÅpenRevurderingModal = ({ harÅpenRevurdering }: { harÅpenRevurde
   // eslint-disable-next-line @eslint-react/rules-of-hooks, react-hooks/rules-of-hooks -- Rapportert fordi den ikkje taklar norske bokstavar i komponentnamn
   useEffect(() => {
     if (harÅpenRevurdering) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- skal opne modal når revurdering blir åpen
       setOpen(true);
     }
   }, [harÅpenRevurdering]);

--- a/packages/brev-editor/src/BrevInnhold.tsx
+++ b/packages/brev-editor/src/BrevInnhold.tsx
@@ -36,11 +36,14 @@ export const BrevInnhold = ({
       <div className={styles['dokument']}>
         <div className="brev-wrapper">
           <style>{` ${brevStiler} `}</style>
+          {/* eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- brev-HTML kommer fra backend og må rendres som markup */}
           <div className={styles['logo']} dangerouslySetInnerHTML={{ __html: navLogo }} />
+          {/* eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- brev-HTML kommer fra backend og må rendres som markup */}
           <div className={styles['header']} dangerouslySetInnerHTML={{ __html: header }} />
           <div id="content">
             <div id={editorHolderId} className={styles['redigerbartInnhold']} />
           </div>
+          {/* eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- brev-HTML kommer fra backend og må rendres som markup */}
           {footer !== undefined && <div className={styles['footer']} dangerouslySetInnerHTML={{ __html: footer }} />}
         </div>
       </div>

--- a/packages/fakta/arbeid-og-inntekt/src/components/ArbeidOgInntektFaktaPanel.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/ArbeidOgInntektFaktaPanel.tsx
@@ -53,9 +53,9 @@ export const ArbeidOgInntektFaktaPanel = ({
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<ArbeidsforholdOgInntektRadData[]>();
 
   const [tabellRader, setTabellRader] = useState<ArbeidsforholdOgInntektRadData[]>(
-    mellomlagretFormData ?? byggTabellStruktur(arbeidOgInntekt, arbeidsgiverOpplysningerPerId),
+    () => mellomlagretFormData ?? byggTabellStruktur(arbeidOgInntekt, arbeidsgiverOpplysningerPerId),
   );
-  const [åpneRadIndexer, setÅpneRadIndexer] = useState(finnUløstArbeidsforholdIndex(tabellRader));
+  const [åpneRadIndexer, setÅpneRadIndexer] = useState(() => finnUløstArbeidsforholdIndex(tabellRader));
 
   const isDirty = useIsFormDirty();
 

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -120,7 +120,7 @@ export const OpptjeningFaktaPanel = ({
       })),
   );
 
-  const [valgtAktivitetIndex, setValgtAktivitetIndex] = useState(
+  const [valgtAktivitetIndex, setValgtAktivitetIndex] = useState(() =>
     finnFørsteIkkeBehandledeIndex(formVerdierForAlleAktiviteter),
   );
 

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
@@ -76,7 +76,7 @@ export const useOppgavePolling = (valgtSakslisteId: number) => {
       // eslint-disable-next-line @eslint-react/set-state-in-effect, react-hooks/set-state-in-effect
       setOppgaverTilBehandling(tilBehandling);
       if (oppgaverTilBehandling.length > 0) {
-        // eslint-disable-next-line @eslint-react/set-state-in-effect
+        // eslint-disable-next-line @eslint-react/set-state-in-effect, react-hooks/set-state-in-effect
         setNyeBehandlinger(tilBehandling.filter(o => !oppgaverTilBehandling.some(ob => ob.id === o.id)));
       }
 

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
@@ -73,9 +73,10 @@ export const useOppgavePolling = (valgtSakslisteId: number) => {
 
   useEffect(() => {
     if (isSuccess) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      // eslint-disable-next-line @eslint-react/set-state-in-effect, react-hooks/set-state-in-effect
       setOppgaverTilBehandling(tilBehandling);
       if (oppgaverTilBehandling.length > 0) {
+        // eslint-disable-next-line @eslint-react/set-state-in-effect
         setNyeBehandlinger(tilBehandling.filter(o => !oppgaverTilBehandling.some(ob => ob.id === o.id)));
       }
 

--- a/packages/los/saksbehandler/src/saksstotte/sistBehandlede/SistBehandledeSaker.tsx
+++ b/packages/los/saksbehandler/src/saksstotte/sistBehandlede/SistBehandledeSaker.tsx
@@ -32,7 +32,7 @@ interface Props {
  * Denne komponenten viser de siste fagsakene en nav-ansatt har behandlet.
  */
 export const SistBehandledeSaker = ({ åpneFagsak }: Props) => {
-  const [kunÅpne, setkunÅpne] = useState<boolean>(false);
+  const [kunÅpne, setKunÅpne] = useState<boolean>(false);
   const { data: sisteReserverte = [], isFetching } = useQuery(behandlendeOppgaverOptions(kunÅpne));
 
   return (
@@ -45,7 +45,7 @@ export const SistBehandledeSaker = ({ åpneFagsak }: Props) => {
           <FormattedMessage id="SistBehandledeSaker.SistBehandledeSaker" />
         </Heading>
         <Spacer />
-        <Switch position="right" size="small" checked={kunÅpne} onChange={e => setkunÅpne(e.target.checked)}>
+        <Switch position="right" size="small" checked={kunÅpne} onChange={e => setKunÅpne(e.target.checked)}>
           <FormattedMessage id="SistBehandledeSaker.KunÅpne" />
         </Switch>
       </HStack>

--- a/packages/sak/historikk/src/components/HistorikkInnslag/HistorikkInnslag.tsx
+++ b/packages/sak/historikk/src/components/HistorikkInnslag/HistorikkInnslag.tsx
@@ -80,10 +80,12 @@ export const HistorikkInnslag = ({
             <div>
               {linjerSomSkalVises.map((linje, index) =>
                 linje.type === 'TEKST' ? (
+                  // eslint-disable-next-line @eslint-react/no-array-index-key -- linjer mangler stabil id, indeks trengs for unik nøkkel
                   <BodyLong key={`${linje.tekst}-${index}`} size="medium">
                     {parseBoldText(linje.tekst ?? '')}
                   </BodyLong>
                 ) : (
+                  // eslint-disable-next-line @eslint-react/no-array-index-key -- linjer mangler stabil id, indeks trengs for unik nøkkel
                   <br key={`${linje.type}-${index}`} />
                 ),
               )}

--- a/packages/sak/historikk/src/components/HistorikkInnslag/historikkInnslagUtils.tsx
+++ b/packages/sak/historikk/src/components/HistorikkInnslag/historikkInnslagUtils.tsx
@@ -2,5 +2,6 @@ export const parseBoldText = (input: string) =>
   input
     .split(/(__.*?__)/g)
     .map((part, index) =>
+      // eslint-disable-next-line @eslint-react/no-array-index-key -- tekstbiter mangler stabil id, indeks trengs for unik nøkkel
       part.startsWith('__') && part.endsWith('__') ? <b key={`bold-${index}-${part}`}>{part.slice(2, -2)}</b> : part,
     );


### PR DESCRIPTION
Lazy initial state, korrekt setter-navn, og målrettede eslint-disable for trygge tilfeller (array-index-key, dangerouslySetInnerHTML, set-state-in-effect).