### PR TITLE
refactor(fp-frontend): gjer behandling-panelruting deklarativ via typ…

### DIFF
--- a/apps/fp-frontend/src/behandling/BehandlingPanelerIndex.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingPanelerIndex.tsx
@@ -6,20 +6,16 @@ import { useQuery } from '@tanstack/react-query';
 
 import { ErrorBoundary, parseQueryString, useRestApiErrorDispatcher } from '@navikt/fp-app-felles';
 import { ErrorPage } from '@navikt/fp-sak-infosider';
-import { notEmpty } from '@navikt/fp-utils';
 
 import { getBehandlingApi } from '../data/behandlingApi';
+import {
+  finnPanelConfig,
+  renderBehandlingPanel,
+  skalHenteArbeidsgivere,
+  skalViseFellesPaVent,
+} from './behandlingPanelRegistry';
 import { useBehandlingDataContext } from './felles/context/BehandlingDataContext';
 import { BehandlingPaVent } from './felles/modaler/paVent/BehandlingPaVent';
-import { lazyWithRetry } from './lazyUtils';
-
-const ForeldrepengerPaneler = lazyWithRetry(() => import('./foreldrepenger/ForeldrepengerPaneler'));
-const EngangsstonadPaneler = lazyWithRetry(() => import('./engangsstonad/EngangsstonadPaneler'));
-const SvangerskapspengerPaneler = lazyWithRetry(() => import('./svangerskapspenger/SvangerskapspengerPaneler'));
-const KlagePaneler = lazyWithRetry(() => import('./klage/KlagePaneler'));
-const InnsynPaneler = lazyWithRetry(() => import('./innsyn/InnsynPaneler'));
-const AnkePaneler = lazyWithRetry(() => import('./anke/AnkePaneler'));
-const TilbakekrevingPaneler = lazyWithRetry(() => import('./tilbakekreving/TilbakekrevingPaneler'));
 
 export const BehandlingPanelerIndex = () => {
   const { addErrorMessage } = useRestApiErrorDispatcher();
@@ -29,15 +25,16 @@ export const BehandlingPanelerIndex = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const erFørstegangssøknadEllerRevurdering = behandling.type === 'BT-002' || behandling.type === 'BT-004';
+  const panelConfig = finnPanelConfig(fagsak.fagsakYtelseType, behandling.type);
+  const hentArbeidsgivere = skalHenteArbeidsgivere(panelConfig);
 
   const behandlingApi = getBehandlingApi(behandling);
 
   const arbeidsgivereOversiktQuery = useQuery(
-    behandlingApi.arbeidsgiverOversiktOptions(behandling, erFørstegangssøknadEllerRevurdering),
+    behandlingApi.arbeidsgiverOversiktOptions(behandling, hentArbeidsgivere),
   );
 
-  if (erFørstegangssøknadEllerRevurdering && arbeidsgivereOversiktQuery.isPending) {
+  if (hentArbeidsgivere && arbeidsgivereOversiktQuery.isPending) {
     return <LoadingPanel />;
   }
 
@@ -45,13 +42,13 @@ export const BehandlingPanelerIndex = () => {
     return <ErrorPage />;
   }
 
-  const erTilbakekrevingsbehandling = erTilbakekreving(behandling.type);
-
   const query = parseQueryString(location.search);
+  const valgtProsessSteg = query['punkt'];
+  const valgtFaktaSteg = query['fakta'];
 
   return (
     <>
-      {!erTilbakekrevingsbehandling && (
+      {skalViseFellesPaVent(panelConfig, behandling.type) && (
         <BehandlingPaVent
           behandling={behandling}
           opneSokeside={() => {
@@ -60,70 +57,17 @@ export const BehandlingPanelerIndex = () => {
           kodeverk={alleKodeverk}
         />
       )}
-      {fagsak.fagsakYtelseType === 'FP' && erFørstegangssøknadEllerRevurdering && (
+      {panelConfig && (
         <Suspense fallback={<LoadingPanel />}>
           <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <ForeldrepengerPaneler
-              valgtProsessSteg={query['punkt']}
-              valgtFaktaSteg={query['fakta']}
-              arbeidsgivere={notEmpty(arbeidsgivereOversiktQuery.data).arbeidsgivere}
-            />
-          </ErrorBoundary>
-        </Suspense>
-      )}
-      {fagsak.fagsakYtelseType === 'SVP' && erFørstegangssøknadEllerRevurdering && (
-        <Suspense fallback={<LoadingPanel />}>
-          <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <SvangerskapspengerPaneler
-              valgtProsessSteg={query['punkt']}
-              valgtFaktaSteg={query['fakta']}
-              arbeidsgivere={notEmpty(arbeidsgivereOversiktQuery.data).arbeidsgivere}
-            />
-          </ErrorBoundary>
-        </Suspense>
-      )}
-      {fagsak.fagsakYtelseType === 'ES' && erFørstegangssøknadEllerRevurdering && (
-        <Suspense fallback={<LoadingPanel />}>
-          <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <EngangsstonadPaneler
-              valgtProsessSteg={query['punkt']}
-              valgtFaktaSteg={query['fakta']}
-              arbeidsgivere={notEmpty(arbeidsgivereOversiktQuery.data).arbeidsgivere}
-            />
-          </ErrorBoundary>
-        </Suspense>
-      )}
-      {behandling.type === 'BT-006' && (
-        <Suspense fallback={<LoadingPanel />}>
-          <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <InnsynPaneler valgtProsessSteg={query['punkt']} />
-          </ErrorBoundary>
-        </Suspense>
-      )}
-      {behandling.type === 'BT-008' && (
-        <Suspense fallback={<LoadingPanel />}>
-          <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <AnkePaneler valgtProsessSteg={query['punkt']} valgtFaktaSteg={query['fakta']} />
-          </ErrorBoundary>
-        </Suspense>
-      )}
-      {behandling.type === 'BT-003' && (
-        <Suspense fallback={<LoadingPanel />}>
-          <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <KlagePaneler valgtProsessSteg={query['punkt']} valgtFaktaSteg={query['fakta']} />
-          </ErrorBoundary>
-        </Suspense>
-      )}
-      {erTilbakekrevingsbehandling && (
-        <Suspense fallback={<LoadingPanel />}>
-          <ErrorBoundary errorMessageCallback={addErrorMessage}>
-            <TilbakekrevingPaneler valgtProsessSteg={query['punkt']} valgtFaktaSteg={query['fakta']} />
+            {renderBehandlingPanel(panelConfig, {
+              valgtProsessSteg,
+              valgtFaktaSteg,
+              arbeidsgivere: arbeidsgivereOversiktQuery.data?.arbeidsgivere,
+            })}
           </ErrorBoundary>
         </Suspense>
       )}
     </>
   );
 };
-
-const erTilbakekreving = (behandlingTypeKode?: string): boolean =>
-  behandlingTypeKode === 'BT-007' || behandlingTypeKode === 'BT-009';

--- a/apps/fp-frontend/src/behandling/anke/AnkePaneler.tsx
+++ b/apps/fp-frontend/src/behandling/anke/AnkePaneler.tsx
@@ -10,7 +10,7 @@ interface Props {
   valgtFaktaSteg: string | undefined;
 }
 
-const AnkePaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => (
+export const AnkePaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => (
   <>
     <ProsessMeny valgtProsessSteg={valgtProsessSteg} valgtFaktaSteg={valgtFaktaSteg}>
       <AnkeBehandlingProsessStegInitPanel />
@@ -22,7 +22,3 @@ const AnkePaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => (
     </FaktaMeny>
   </>
 );
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default AnkePaneler;

--- a/apps/fp-frontend/src/behandling/behandlingPanelRegistry.spec.ts
+++ b/apps/fp-frontend/src/behandling/behandlingPanelRegistry.spec.ts
@@ -1,0 +1,67 @@
+import {
+  finnPanelConfig,
+  skalHenteArbeidsgivere,
+  skalViseFellesPaVent,
+} from './behandlingPanelRegistry';
+
+describe('behandlingPanelRegistry', () => {
+  it('skal finne ytelsespanel for førstegangsbehandling og revurdering', () => {
+    expect(finnPanelConfig('FP', 'BT-002')).toMatchObject({
+      fagsakYtelseType: 'FP',
+      skalHenteArbeidsgivere: true,
+      skalViseFellesPaVent: true,
+    });
+    expect(finnPanelConfig('SVP', 'BT-004')).toMatchObject({
+      fagsakYtelseType: 'SVP',
+      skalHenteArbeidsgivere: true,
+      skalViseFellesPaVent: true,
+    });
+    expect(finnPanelConfig('ES', 'BT-002')).toMatchObject({
+      fagsakYtelseType: 'ES',
+      skalHenteArbeidsgivere: true,
+      skalViseFellesPaVent: true,
+    });
+  });
+
+  it('skal kreve ytelsetype for førstegangsbehandling og revurdering', () => {
+    expect(finnPanelConfig(undefined, 'BT-002')).toBeUndefined();
+    expect(finnPanelConfig(undefined, 'BT-004')).toBeUndefined();
+  });
+
+  it('skal finne panel for behandlingstypar som ikkje er ytelsspesifikke', () => {
+    expect(finnPanelConfig(undefined, 'BT-003')).toMatchObject({
+      skalHenteArbeidsgivere: false,
+      skalViseFellesPaVent: true,
+    });
+    expect(finnPanelConfig(undefined, 'BT-006')).toMatchObject({
+      skalHenteArbeidsgivere: false,
+      skalViseFellesPaVent: true,
+    });
+    expect(finnPanelConfig(undefined, 'BT-008')).toMatchObject({
+      skalHenteArbeidsgivere: false,
+      skalViseFellesPaVent: true,
+    });
+  });
+
+  it('skal finne tilbakekrevingspanel utan felles på-vent-panel', () => {
+    expect(finnPanelConfig(undefined, 'BT-007')).toMatchObject({
+      skalHenteArbeidsgivere: false,
+      skalViseFellesPaVent: false,
+    });
+    expect(finnPanelConfig(undefined, 'BT-009')).toMatchObject({
+      skalHenteArbeidsgivere: false,
+      skalViseFellesPaVent: false,
+    });
+  });
+
+  it('skal returnere undefined for ukjent behandlingstype', () => {
+    expect(finnPanelConfig('FP', 'BT-999')).toBeUndefined();
+    expect(finnPanelConfig('FP', undefined)).toBeUndefined();
+  });
+
+  it('skal ha trygg default for arbeidsgivarhenting og felles på-vent-panel', () => {
+    expect(skalHenteArbeidsgivere(undefined)).toBe(false);
+    expect(skalViseFellesPaVent(undefined, 'BT-002')).toBe(true);
+    expect(skalViseFellesPaVent(undefined, 'BT-007')).toBe(false);
+  });
+});

--- a/apps/fp-frontend/src/behandling/behandlingPanelRegistry.tsx
+++ b/apps/fp-frontend/src/behandling/behandlingPanelRegistry.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from 'react';
+
+import type { ArbeidsgiverOpplysningerPerId } from '@navikt/fp-types';
+import { notEmpty } from '@navikt/fp-utils';
+
+import { lazyNamedWithRetry } from './lazyUtils';
+
+type ValgtStegProps = {
+  valgtProsessSteg: string | undefined;
+  valgtFaktaSteg: string | undefined;
+};
+
+type ArbeidsgiverPanelProps = ValgtStegProps & {
+  arbeidsgivere: ArbeidsgiverOpplysningerPerId;
+};
+
+type InnsynPanelProps = Pick<ValgtStegProps, 'valgtProsessSteg'>;
+
+type PanelRenderProps = ValgtStegProps & {
+  arbeidsgivere: ArbeidsgiverOpplysningerPerId | undefined;
+};
+
+export type PanelConfig = {
+  fagsakYtelseType?: 'FP' | 'SVP' | 'ES';
+  behandlingTyper: readonly string[];
+  skalHenteArbeidsgivere: boolean;
+  skalViseFellesPaVent: boolean;
+  render: (props: PanelRenderProps) => ReactNode;
+};
+
+const førstegangsbehandlingEllerRevurdering: readonly string[] = ['BT-002', 'BT-004'];
+const tilbakekrevingBehandlingTyper: readonly string[] = ['BT-007', 'BT-009'];
+
+const ForeldrepengerPaneler = lazyNamedWithRetry<ArbeidsgiverPanelProps, 'ForeldrepengerPaneler'>(
+  () => import('./foreldrepenger/ForeldrepengerPaneler'),
+  'ForeldrepengerPaneler',
+);
+const EngangsstonadPaneler = lazyNamedWithRetry<ArbeidsgiverPanelProps, 'EngangsstonadPaneler'>(
+  () => import('./engangsstonad/EngangsstonadPaneler'),
+  'EngangsstonadPaneler',
+);
+const SvangerskapspengerPaneler = lazyNamedWithRetry<ArbeidsgiverPanelProps, 'SvangerskapspengerPaneler'>(
+  () => import('./svangerskapspenger/SvangerskapspengerPaneler'),
+  'SvangerskapspengerPaneler',
+);
+const KlagePaneler = lazyNamedWithRetry<ValgtStegProps, 'KlagePaneler'>(
+  () => import('./klage/KlagePaneler'),
+  'KlagePaneler',
+);
+const InnsynPaneler = lazyNamedWithRetry<InnsynPanelProps, 'InnsynPaneler'>(
+  () => import('./innsyn/InnsynPaneler'),
+  'InnsynPaneler',
+);
+const AnkePaneler = lazyNamedWithRetry<ValgtStegProps, 'AnkePaneler'>(
+  () => import('./anke/AnkePaneler'),
+  'AnkePaneler',
+);
+const TilbakekrevingPaneler = lazyNamedWithRetry<ValgtStegProps, 'TilbakekrevingPaneler'>(
+  () => import('./tilbakekreving/TilbakekrevingPaneler'),
+  'TilbakekrevingPaneler',
+);
+
+const panelConfigs = [
+  {
+    fagsakYtelseType: 'FP',
+    behandlingTyper: førstegangsbehandlingEllerRevurdering,
+    skalHenteArbeidsgivere: true,
+    skalViseFellesPaVent: true,
+    render: props => <ForeldrepengerPaneler {...props} arbeidsgivere={notEmpty(props.arbeidsgivere)} />,
+  },
+  {
+    fagsakYtelseType: 'SVP',
+    behandlingTyper: førstegangsbehandlingEllerRevurdering,
+    skalHenteArbeidsgivere: true,
+    skalViseFellesPaVent: true,
+    render: props => <SvangerskapspengerPaneler {...props} arbeidsgivere={notEmpty(props.arbeidsgivere)} />,
+  },
+  {
+    fagsakYtelseType: 'ES',
+    behandlingTyper: førstegangsbehandlingEllerRevurdering,
+    skalHenteArbeidsgivere: true,
+    skalViseFellesPaVent: true,
+    render: props => <EngangsstonadPaneler {...props} arbeidsgivere={notEmpty(props.arbeidsgivere)} />,
+  },
+  {
+    behandlingTyper: ['BT-006'],
+    skalHenteArbeidsgivere: false,
+    skalViseFellesPaVent: true,
+    render: props => <InnsynPaneler valgtProsessSteg={props.valgtProsessSteg} />,
+  },
+  {
+    behandlingTyper: ['BT-008'],
+    skalHenteArbeidsgivere: false,
+    skalViseFellesPaVent: true,
+    render: props => <AnkePaneler valgtProsessSteg={props.valgtProsessSteg} valgtFaktaSteg={props.valgtFaktaSteg} />,
+  },
+  {
+    behandlingTyper: ['BT-003'],
+    skalHenteArbeidsgivere: false,
+    skalViseFellesPaVent: true,
+    render: props => <KlagePaneler valgtProsessSteg={props.valgtProsessSteg} valgtFaktaSteg={props.valgtFaktaSteg} />,
+  },
+  {
+    behandlingTyper: tilbakekrevingBehandlingTyper,
+    skalHenteArbeidsgivere: false,
+    skalViseFellesPaVent: false,
+    render: props => (
+      <TilbakekrevingPaneler valgtProsessSteg={props.valgtProsessSteg} valgtFaktaSteg={props.valgtFaktaSteg} />
+    ),
+  },
+] satisfies PanelConfig[];
+
+export const finnPanelConfig = (
+  fagsakYtelseType: string | undefined,
+  behandlingType: string | undefined,
+): PanelConfig | undefined =>
+  panelConfigs.find(config => {
+    if (!behandlingType || !config.behandlingTyper.includes(behandlingType)) {
+      return false;
+    }
+
+    return !config.fagsakYtelseType || config.fagsakYtelseType === fagsakYtelseType;
+  });
+
+const erTilbakekreving = (behandlingType: string | undefined): boolean =>
+  tilbakekrevingBehandlingTyper.includes(behandlingType ?? '');
+
+export const skalHenteArbeidsgivere = (panelConfig: PanelConfig | undefined): boolean =>
+  panelConfig?.skalHenteArbeidsgivere ?? false;
+
+export const skalViseFellesPaVent = (panelConfig: PanelConfig | undefined, behandlingType: string | undefined): boolean =>
+  panelConfig?.skalViseFellesPaVent ?? !erTilbakekreving(behandlingType);
+
+export const renderBehandlingPanel = (panelConfig: PanelConfig, props: PanelRenderProps): ReactNode => panelConfig.render(props);

--- a/apps/fp-frontend/src/behandling/engangsstonad/EngangsstonadPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/engangsstonad/EngangsstonadPaneler.tsx
@@ -25,7 +25,7 @@ interface Props {
   arbeidsgivere: ArbeidsgiverOpplysningerPerId;
 }
 
-const EngangsstonadPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
+export const EngangsstonadPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
   const [faktaPanelMedÅpentApInfo, setFaktaPanelMedÅpentApInfo] = useState<FaktaPanelMedÅpentApInfo>();
   const emptyArbeidsgiverOpplysningerPerId = {};
 
@@ -55,7 +55,3 @@ const EngangsstonadPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere 
     </>
   );
 };
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default EngangsstonadPaneler;

--- a/apps/fp-frontend/src/behandling/foreldrepenger/ForeldrepengerPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/foreldrepenger/ForeldrepengerPaneler.tsx
@@ -42,7 +42,7 @@ interface Props {
   arbeidsgivere: ArbeidsgiverOpplysningerPerId;
 }
 
-const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
+export const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
   const [faktaPanelMedÅpentApInfo, setFaktaPanelMedÅpentApInfo] = useState<FaktaPanelMedÅpentApInfo>();
 
   return (
@@ -88,7 +88,3 @@ const ForeldrepengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere
     </>
   );
 };
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default ForeldrepengerPaneler;

--- a/apps/fp-frontend/src/behandling/innsyn/InnsynPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/innsyn/InnsynPaneler.tsx
@@ -6,13 +6,9 @@ interface Props {
   valgtProsessSteg: string | undefined;
 }
 
-const InnsynPaneler = ({ valgtProsessSteg }: Props) => (
+export const InnsynPaneler = ({ valgtProsessSteg }: Props) => (
   <ProsessMeny valgtProsessSteg={valgtProsessSteg} valgtFaktaSteg={undefined}>
     <BehandleInnsynProsessStegInitPanel />
     <InnsynVedtakProsessStegInitPanel />
   </ProsessMeny>
 );
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default InnsynPaneler;

--- a/apps/fp-frontend/src/behandling/klage/KlagePaneler.tsx
+++ b/apps/fp-frontend/src/behandling/klage/KlagePaneler.tsx
@@ -12,7 +12,7 @@ interface Props {
   valgtFaktaSteg?: string;
 }
 
-const KlagePaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => (
+export const KlagePaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => (
   <>
     <ProsessMeny valgtProsessSteg={valgtProsessSteg} valgtFaktaSteg={valgtFaktaSteg}>
       <FormKravFamOgPensjonProsessStegInitPanel />
@@ -26,7 +26,3 @@ const KlagePaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => (
     </FaktaMeny>
   </>
 );
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default KlagePaneler;

--- a/apps/fp-frontend/src/behandling/lazyUtils.ts
+++ b/apps/fp-frontend/src/behandling/lazyUtils.ts
@@ -28,3 +28,13 @@ export const lazyWithRetry = <T>(
       throw error;
     }
   });
+
+export const lazyNamedWithRetry = <T, ExportName extends string>(
+  componentImport: () => Promise<Record<ExportName, ComponentType<T>>>,
+  exportName: ExportName,
+): LazyExoticComponent<ComponentType<T>> =>
+  lazyWithRetry<T>(() =>
+    componentImport().then(module => ({
+      default: module[exportName],
+    })),
+  );

--- a/apps/fp-frontend/src/behandling/svangerskapspenger/SvangerskapspengerPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/svangerskapspenger/SvangerskapspengerPaneler.tsx
@@ -32,7 +32,7 @@ interface Props {
   arbeidsgivere: ArbeidsgiverOpplysningerPerId;
 }
 
-const SvangerskapspengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
+export const SvangerskapspengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgivere }: Props) => {
   const [faktaPanelMedÅpentApInfo, setFaktaPanelMedÅpentApInfo] = useState<FaktaPanelMedÅpentApInfo>();
 
   return (
@@ -68,7 +68,3 @@ const SvangerskapspengerPaneler = ({ valgtProsessSteg, valgtFaktaSteg, arbeidsgi
     </>
   );
 };
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default SvangerskapspengerPaneler;

--- a/apps/fp-frontend/src/behandling/tilbakekreving/TilbakekrevingPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/tilbakekreving/TilbakekrevingPaneler.tsx
@@ -21,7 +21,7 @@ interface Props {
   valgtFaktaSteg?: string;
 }
 
-const TilbakekrevingPaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => {
+export const TilbakekrevingPaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => {
   const { behandling } = useBehandlingDataContext<BehandlingFpTilbake>();
 
   const api = useFagsakApi();
@@ -54,7 +54,3 @@ const TilbakekrevingPaneler = ({ valgtProsessSteg, valgtFaktaSteg }: Props) => {
     </>
   );
 };
-
-// Default export grunna React.lazy
-// eslint-disable-next-line import-x/no-default-export
-export default TilbakekrevingPaneler;


### PR DESCRIPTION
…a register

Erstatt inline-conditionals i BehandlingPanelerIndex med eit typa PanelConfig-register (behandlingPanelRegistry). Konverter panel-komponentane frå default- til namngjevne eksportar og last dei lazy via ny lazyNamedWithRetry-hjelpar. Legg til einingstestar for mappinglogikken.