### PR TITLE
fix: deaktiver lagre-knapp i endre-utland modal mens lagring pågår

### DIFF
--- a/apps/fp-frontend/src/behandlingmenu/modaler/EndreFagsakMarkeringMenyModal.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/modaler/EndreFagsakMarkeringMenyModal.tsx
@@ -25,7 +25,7 @@ export const EndreFagsakMarkeringMenyModal = ({
     a.navn.localeCompare(b.navn),
   );
 
-  const { mutate: endreFagsakMarkering } = useMutation({
+  const { mutate: endreFagsakMarkering, isPending } = useMutation({
     mutationFn: (valuesToStore: EndreUtlandFormValues) => api.endreSakMarkering(valuesToStore),
     onSuccess: () => {
       hentOgSettBehandling();
@@ -42,6 +42,7 @@ export const EndreFagsakMarkeringMenyModal = ({
       endreFagsakMarkering={endreFagsakMarkering}
       lukkModal={lukkModal}
       fagsakMarkeringerKodeverk={fagsakMarkeringerKodeverk}
+      isPending={isPending}
     />
   );
 };

--- a/apps/fp-frontend/src/behandlingmenu/modaler/EndreFagsakMarkeringMenyModal.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/modaler/EndreFagsakMarkeringMenyModal.tsx
@@ -32,6 +32,7 @@ export const EndreFagsakMarkeringMenyModal = ({
       void queryClient.invalidateQueries({
         queryKey: [FagsakRel.FETCH_FAGSAK],
       });
+      lukkModal();
     },
   });
 

--- a/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.spec.tsx
+++ b/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.spec.tsx
@@ -17,12 +17,12 @@ describe('MenyEndreUtlandIndex', () => {
 
     await userEvent.click(screen.getByText('OK'));
 
-    await waitFor(() => expect(lukkModal).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(endreFagsakMarkering).toHaveBeenCalledTimes(1));
     expect(endreFagsakMarkering).toHaveBeenNthCalledWith(1, {
       fagsakMarkeringer: ['EØS_BOSATT_NORGE'],
       saksnummer: '123',
     });
+    expect(lukkModal).not.toHaveBeenCalled();
   });
 
   it('skal endre fra eøs til bosatt utland', async () => {
@@ -35,11 +35,11 @@ describe('MenyEndreUtlandIndex', () => {
 
     await userEvent.click(screen.getByText('OK'));
 
-    await waitFor(() => expect(lukkModal).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(endreFagsakMarkering).toHaveBeenCalledTimes(1));
     expect(endreFagsakMarkering).toHaveBeenNthCalledWith(1, {
       fagsakMarkeringer: ['BOSATT_UTLAND'],
       saksnummer: '123',
     });
+    expect(lukkModal).not.toHaveBeenCalled();
   });
 });

--- a/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.spec.tsx
+++ b/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.spec.tsx
@@ -6,6 +6,14 @@ import * as stories from './MenyEndreUtlandIndex.stories';
 
 const { Default } = composeStories(stories);
 
+const finnKnapp = (tekst: string): HTMLButtonElement => {
+  const knapp = screen.getByText(tekst).closest('button');
+  if (!knapp) {
+    throw new Error(`Fant ikke <button> for teksten "${tekst}"`);
+  }
+  return knapp;
+};
+
 describe('MenyEndreUtlandIndex', () => {
   it('skal endre fra ingenting til eøs', async () => {
     const endreFagsakMarkering = vi.fn();
@@ -40,6 +48,24 @@ describe('MenyEndreUtlandIndex', () => {
       fagsakMarkeringer: ['BOSATT_UTLAND'],
       saksnummer: '123',
     });
+    expect(lukkModal).not.toHaveBeenCalled();
+  });
+
+  it('skal disable OK/Avbryt-knappene og hindre ny innsending når lagring er isPending', async () => {
+    const endreFagsakMarkering = vi.fn();
+    const lukkModal = vi.fn();
+    render(<Default endreFagsakMarkering={endreFagsakMarkering} lukkModal={lukkModal} isPending />);
+    expect(await screen.findByText('Saksmarkering')).toBeInTheDocument();
+
+    const okKnapp = finnKnapp('OK');
+    const avbrytKnapp = finnKnapp('Avbryt');
+    expect(okKnapp).toBeDisabled();
+    expect(avbrytKnapp).toBeDisabled();
+
+    await userEvent.click(okKnapp);
+    await userEvent.click(avbrytKnapp);
+
+    expect(endreFagsakMarkering).not.toHaveBeenCalled();
     expect(lukkModal).not.toHaveBeenCalled();
   });
 });

--- a/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.tsx
+++ b/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.tsx
@@ -18,6 +18,7 @@ interface Props {
   endreFagsakMarkering: (formData: FormValues) => void;
   lukkModal: () => void;
   fagsakMarkeringerKodeverk: KodeverkMedNavn<'FagsakMarkering'>[];
+  isPending?: boolean;
 }
 
 export const MenyEndreUtlandIndex = ({ endreFagsakMarkering, lukkModal, ...rest }: Props) => {

--- a/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.tsx
+++ b/packages/sak/meny-endre-utland/src/MenyEndreUtlandIndex.tsx
@@ -24,7 +24,6 @@ interface Props {
 export const MenyEndreUtlandIndex = ({ endreFagsakMarkering, lukkModal, ...rest }: Props) => {
   const submit = (formValues: FormValues) => {
     endreFagsakMarkering(formValues);
-    lukkModal();
   };
 
   return (

--- a/packages/sak/meny-endre-utland/src/components/EndreUtlandModal.tsx
+++ b/packages/sak/meny-endre-utland/src/components/EndreUtlandModal.tsx
@@ -17,6 +17,7 @@ interface Props {
   cancelEvent: () => void;
   submitCallback: (formData: FormValues) => void;
   fagsakMarkeringerKodeverk: KodeverkMedNavn<'FagsakMarkering'>[];
+  isPending?: boolean;
 }
 
 /**
@@ -31,6 +32,7 @@ export const EndreUtlandModal = ({
   saksnummer,
   fagsakMarkeringer,
   fagsakMarkeringerKodeverk,
+  isPending,
 }: Props) => {
   const formMethods = useForm<FormValues>({
     defaultValues: {
@@ -58,10 +60,10 @@ export const EndreUtlandModal = ({
             </RhfCheckboxGroup>
           </Dialog.Body>
           <Dialog.Footer>
-            <Button size="small" variant="secondary" onClick={cancelEvent} type="button">
+            <Button size="small" variant="secondary" onClick={cancelEvent} type="button" disabled={isPending}>
               <FormattedMessage id="MenyEndreUtlandIndex.Avbryt" />
             </Button>
-            <Button size="small" variant="primary">
+            <Button size="small" variant="primary" loading={isPending} disabled={isPending}>
               <FormattedMessage id="MenyEndreUtlandIndex.Ok" />
             </Button>
           </Dialog.Footer>


### PR DESCRIPTION
Saksbehandler kunne trigge dobbel innsending mot fpsak (f.eks. ved raske dobbeltklikk) siden lagre/avbryt-knappene forble aktive mens mutasjonen var underveis. Dette kunne bidra til at fpsak fikk to aktive FagsakEgenskap-rader for samme fagsak/markering (f.eks. HASTER), som igjen feilet med F-108088 ved uttrekk.

Dette adresserer kun frontend-symptomet (defense-in-depth). Rotårsaken er en race condition i fpsak sin check-then-insert-logikk uten låsing eller unik databaseconstraint, og må fikses der.