### PR TITLE
feat: aktiver CDN-serving av assets for alle apper

### DIFF
--- a/.github/workflows/build-fp-avdelingsleder.yml
+++ b/.github/workflows/build-fp-avdelingsleder.yml
@@ -66,7 +66,7 @@ jobs:
     name: Deploy prod
     permissions:
       id-token: write
-    if: github.ref_name == 'master'
+    if: false # Midlertidig deaktivert for CDN-testing i dev
     needs: [build-app, deploy-dev]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:

--- a/.github/workflows/build-fp-avdelingsleder.yml
+++ b/.github/workflows/build-fp-avdelingsleder.yml
@@ -28,16 +28,32 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: fp-avdelingsleder
       image_suffix: '/fp-avdelingsleder'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at fp-avdelingsleder laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /fp-avdelingsleder).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/fp-avdelingsleder/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
+
+  upload-to-CDN:
+    name: Upload assets to CDN
+    if: github.ref_name == 'master'
+    needs: build-app
+    permissions:
+      contents: read
+      id-token: write
+    uses: navikt/fp-gha-workflows/.github/workflows/cdn-upload.yml@main
+    with:
+      image: ${{ needs.build-app.outputs.build-version }}
+      image_suffix: '/fp-avdelingsleder'
+      destination: '/fp-avdelingsleder'
 
   deploy-dev:
     name: Deploy dev
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-fp-frontend.yml
+++ b/.github/workflows/build-fp-frontend.yml
@@ -28,16 +28,32 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: fp-frontend
       image_suffix: '/fp-frontend'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at fp-frontend laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /fp-frontend).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/fp-frontend/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
+
+  upload-to-CDN:
+    name: Upload assets to CDN
+    if: github.ref_name == 'master'
+    needs: build-app
+    permissions:
+      contents: read
+      id-token: write
+    uses: navikt/fp-gha-workflows/.github/workflows/cdn-upload.yml@main
+    with:
+      image: ${{ needs.build-app.outputs.build-version }}
+      image_suffix: '/fp-frontend'
+      destination: '/fp-frontend'
 
   deploy-dev:
     name: Deploy dev
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build-fp-frontend.yml
+++ b/.github/workflows/build-fp-frontend.yml
@@ -66,7 +66,7 @@ jobs:
     name: Deploy prod
     permissions:
       id-token: write
-    if: github.ref_name == 'master'
+    if: false # Midlertidig deaktivert for CDN-testing i dev
     needs: [build-app, deploy-dev]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:

--- a/.github/workflows/build-fp-journalforing.yml
+++ b/.github/workflows/build-fp-journalforing.yml
@@ -66,7 +66,7 @@ jobs:
     name: Deploy prod
     permissions:
       id-token: write
-    if: github.ref_name == 'master'
+    if: false # Midlertidig deaktivert for CDN-testing i dev
     needs: [build-app, deploy-dev]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:

--- a/.github/workflows/build-fp-journalforing.yml
+++ b/.github/workflows/build-fp-journalforing.yml
@@ -28,16 +28,32 @@ jobs:
       push-image: ${{ github.ref_name == 'master' }} # default: false
       app: fp-journalforing
       image_suffix: '/fp-journalforing'
+      # Bakes inn i asset-referansene (renderBuiltUrl) slik at fp-journalforing laster assets fra CDN.
+      # Må matche upload-to-CDN destination (teamforeldrepenger + /fp-journalforing).
+      vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/fp-journalforing/'
     secrets:
       READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
+
+  upload-to-CDN:
+    name: Upload assets to CDN
+    if: github.ref_name == 'master'
+    needs: build-app
+    permissions:
+      contents: read
+      id-token: write
+    uses: navikt/fp-gha-workflows/.github/workflows/cdn-upload.yml@main
+    with:
+      image: ${{ needs.build-app.outputs.build-version }}
+      image_suffix: '/fp-journalforing'
+      destination: '/fp-journalforing'
 
   deploy-dev:
     name: Deploy dev
     permissions:
       id-token: write
     if: github.ref_name == 'master'
-    needs: build-app
+    needs: [build-app, upload-to-CDN]
     uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
     with:
       gar: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         description: App som skal bygges
+      vite-cdn-url:
+        required: false
+        type: string
+        description: 'CDN-URL som bakes inn i appens asset-referanser ved bygg'
+        default: ''
     outputs:
       build-version:
         description: 'Build version'
@@ -89,6 +94,7 @@ jobs:
         env:
           VITE_SENTRY_RELEASE: ${{ steps.sentry_release_key.outputs.SENTRY_RELEASE }}
           VITE_SENTRY_AUTH_TOKEN: ${{ inputs.push-image && secrets.SENTRY_AUTH_TOKEN || '' }}
+          VITE_CDN_URL: ${{ inputs.vite-cdn-url }}
 
       - name: Bygg server
         run: cd ./server && yarn install --immutable && yarn build

--- a/apps/fp-avdelingsleder/vite.config.ts
+++ b/apps/fp-avdelingsleder/vite.config.ts
@@ -4,8 +4,19 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 import { createSharedAppConfig } from '@navikt/fp-config-vite';
 
+// Settes i build-workflowen (build-fp-avdelingsleder.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens routing og API-prefiks styres av serveren.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedAppConfig(), {
+  ...(cdnUrl
+    ? {
+        experimental: {
+          renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+        },
+      }
+    : {}),
   server: {
     port: 9014,
     cors: {

--- a/apps/fp-frontend/vite.config.ts
+++ b/apps/fp-frontend/vite.config.ts
@@ -4,8 +4,19 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 import { createSharedAppConfig } from '@navikt/fp-config-vite';
 
+// Settes i build-workflowen (build-fp-frontend.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens routing og API-prefiks styres av serveren.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedAppConfig(), {
+  ...(cdnUrl
+    ? {
+        experimental: {
+          renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+        },
+      }
+    : {}),
   server: {
     port: 9010,
     cors: {

--- a/apps/fp-journalforing/vite.config.ts
+++ b/apps/fp-journalforing/vite.config.ts
@@ -4,8 +4,19 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 import { createSharedAppConfig } from '@navikt/fp-config-vite';
 
+// Settes i build-workflowen (build-fp-journalforing.yml -> build.yml). Når den er satt serveres de bygde
+// assetene fra CDN, mens routing og API-prefiks styres av serveren.
+const cdnUrl = process.env.VITE_CDN_URL;
+
 // eslint-disable-next-line import-x/no-default-export
 export default mergeConfig(createSharedAppConfig(), {
+  ...(cdnUrl
+    ? {
+        experimental: {
+          renderBuiltUrl: (filename: string) => `${cdnUrl}${filename}`,
+        },
+      }
+    : {}),
   server: {
     port: 9015,
     cors: {


### PR DESCRIPTION
Alle apper følger nå samme mønster som planlegger i foreldrepengesoknad:
- vite.config.ts leser VITE_CDN_URL og bruker renderBuiltUrl
- build.yml får nytt vite-cdn-url input og eksponerer VITE_CDN_URL
- build-workflow sender vite-cdn-url til build-jobben
- upload-to-CDN-jobb er lagt til i alle workflows
- deploy-dev venter på upload-to-CDN før deploy

CDN-URLer:
- fp-frontend:      cdn.nav.no/teamforeldrepenger/fp-frontend/
- fp-avdelingsleder: cdn.nav.no/teamforeldrepenger/fp-avdelingsleder/
- fp-journalforing: cdn.nav.no/teamforeldrepenger/fp-journalforing/