### PR TITLE
fix: legg til cdn.nav.no i CSP connect-src for source maps

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -64,6 +64,7 @@ function startApp() {
             "https://graph.microsoft.com",
             "https://telemetry.nav.no",
             "https://telemetry.ekstern.dev.nav.no",
+            "https://cdn.nav.no",
           ],
           "font-src": ["'self'", "https://cdn.nav.no", "data:"],
           "img-src": ["'self'", "data:"],


### PR DESCRIPTION
Sentry henter .map-filer fra CDN via fetch, som krever connect-src.