### PR TITLE
chore: skill ut sideendringer fra #7423

### DIFF
--- a/packages/app-felles/src/initFaro.ts
+++ b/packages/app-felles/src/initFaro.ts
@@ -1,8 +1,8 @@
 import { init } from '@nais/apm';
 
 export const initFaro = () => {
-    if (import.meta.env.MODE === 'development') {
-        return;
-    }
-    init();
+  if (import.meta.env.MODE === 'development') {
+    return;
+  }
+  init();
 };

--- a/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
+++ b/packages/los/saksbehandler/src/behandlingskoer/oppgaveTabeller/ledigOppgaveTabell/useOppgavePolling.tsx
@@ -76,7 +76,7 @@ export const useOppgavePolling = (valgtSakslisteId: number) => {
       // eslint-disable-next-line @eslint-react/set-state-in-effect, react-hooks/set-state-in-effect
       setOppgaverTilBehandling(tilBehandling);
       if (oppgaverTilBehandling.length > 0) {
-        // eslint-disable-next-line @eslint-react/set-state-in-effect, react-hooks/set-state-in-effect
+        // eslint-disable-next-line @eslint-react/set-state-in-effect
         setNyeBehandlinger(tilBehandling.filter(o => !oppgaverTilBehandling.some(ob => ob.id === o.id)));
       }
 

--- a/packages/sak/historikk/src/components/HistorikkInnslag/historikkInnslagUtils.tsx
+++ b/packages/sak/historikk/src/components/HistorikkInnslag/historikkInnslagUtils.tsx
@@ -1,7 +1,5 @@
 export const parseBoldText = (input: string) =>
-  input
-    .split(/(__.*?__)/g)
-    .map((part, index) =>
-      // eslint-disable-next-line @eslint-react/no-array-index-key -- tekstbiter mangler stabil id, indeks trengs for unik nøkkel
-      part.startsWith('__') && part.endsWith('__') ? <b key={`bold-${index}-${part}`}>{part.slice(2, -2)}</b> : part,
-    );
+  input.split(/(__.*?__)/g).map((part, index) =>
+    // eslint-disable-next-line @eslint-react/no-array-index-key -- tekstbiter mangler stabil id, indeks trengs for unik nøkkel
+    part.startsWith('__') && part.endsWith('__') ? <b key={`bold-${index}-${part}`}>{part.slice(2, -2)}</b> : part,
+  );

--- a/packages/sak/meldinger/src/components/Messages.tsx
+++ b/packages/sak/meldinger/src/components/Messages.tsx
@@ -106,7 +106,11 @@ export const Messages = ({
     if (brukBreveditor && !brevData && (!erVarselOmRevurdering || årsakskode)) {
       void hentBrevHtml(brevmalkode, årsakskode)
         .then(result => {
-          setBrevDataState({ key: aktivBrevKey, opprinneligHtml: result.opprinneligHtml, redigertHtml: result.redigertHtml });
+          setBrevDataState({
+            key: aktivBrevKey,
+            opprinneligHtml: result.opprinneligHtml,
+            redigertHtml: result.redigertHtml,
+          });
         })
         .catch(() => {});
     }


### PR DESCRIPTION
## Sammendrag
- Skiller ut sideendringer fra #7423 som ikke er direkte knyttet til papirsoknad-refaktoreringen
- Inneholder formattering/opprydding i app-felles, los, sak/historikk, sak/meldinger
