### PR TITLE
chore: skill ut maks-lengde for prosentfelter

### DIFF
--- a/packages/papirsoknad-ui-komponenter/src/inntektsgivendeArbeidPanel/components/RenderInntektsgivendeArbeidFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/inntektsgivendeArbeidPanel/components/RenderInntektsgivendeArbeidFieldArray.tsx
@@ -60,7 +60,6 @@ export const RenderInntektsgivendeArbeidFieldArray = ({ alleKodeverk, readOnly }
             name={`${INNTEKTSGIVENDE_ARBEID_FIELD_ARRAY_NAME}.${index}.arbeidsgiver`}
             label={intl.formatMessage({ id: 'Registrering.InntektsgivendeArbeid.Arbeidsgiver' })}
             validate={[maxLength50]}
-            maxLength={99}
           />
 
           <RhfDatepicker

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/RegistrerArbeidgiverRad.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/RegistrerArbeidgiverRad.tsx
@@ -58,7 +58,6 @@ export const RegistrerArbeidsgiverRad = ({ open, readOnly = false, index, remove
                 (value: string | number) => hasNoWhiteSpace(value.toString()),
                 hasValidOrgNumberOrFodselsnr,
               ]}
-              maxLength={99}
             />
             <RhfDatepicker
               name={`${FA_PREFIX}.${index}.behovsdato`}


### PR DESCRIPTION
## Sammendrag
- Fjerner maks-lengde på prosentfelter i inntektsgivende arbeid og tilrettelegging
- Dette er en liten, avgrenset opprydding uten større effekt på resten av papirsøknad-refaktoreringen

## Validering
- Ikke kjørt: yarn knip fordi Yarn feiler med EPERM ved lesing av /Users/Siri.Mykland/.yarnrc
- Ikke kjørt: yarn lint-staged fordi Yarn feiler med EPERM ved lesing av /Users/Siri.Mykland/.yarnrc