### PR TITLE
TFP-7087: legg til manglende maxLength i papirsøknad virksomhet-felter

### DIFF
--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/VirksomhetPapirsoknadIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/VirksomhetPapirsoknadIndex.spec.tsx
@@ -153,7 +153,7 @@ describe('VirksomhetPapirsoknadIndex', () => {
     },
   );
 
-  it('skal vise feil ved for lang beskrivelseAvEndring', { timeout: 50000 }, async () => {
+  it('skal vise feil ved for lang beskrivelseAvEndring', { timeout: 30000 }, async () => {
     const lagre = vi.fn();
 
     await Default.run({

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/VirksomhetPapirsoknadIndex.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/VirksomhetPapirsoknadIndex.spec.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'vitest';
 
@@ -152,4 +152,79 @@ describe('VirksomhetPapirsoknadIndex', () => {
       expect(lagre).toHaveBeenCalledTimes(0);
     },
   );
+
+  it('skal vise feil ved for lang beskrivelseAvEndring', { timeout: 50000 }, async () => {
+    const lagre = vi.fn();
+
+    await Default.run({
+      parameters: {
+        submitCallback: lagre,
+      },
+    });
+
+    await userEvent.click(
+      screen.getByText('Ja, søker har arbeidet i egen næringsvirksomhet i løpet av de 10 siste månedene'),
+    );
+
+    await userEvent.type(screen.getByLabelText('Navn på foretaket'), 'Bedriften AS');
+    await userEvent.click(screen.getAllByText('Nei')[0]!);
+    await userEvent.selectOptions(screen.getByLabelText('Hvilket land er virksomheten registrert i?'), 'AND');
+    await userEvent.type(screen.getByLabelText('Fra og med'), '01.06.2022');
+    await userEvent.type(screen.getByLabelText('Til og med'), '03.06.2022');
+    await userEvent.click(screen.getByLabelText('Fiske'));
+    await userEvent.click(screen.getAllByText('Ja')[1]!);
+    await userEvent.click(screen.getByLabelText('Varig endring i næring'));
+    await userEvent.type(screen.getByLabelText('Gjeldende f.o.m.'), '03.05.2022');
+
+    const beskrivelseInput = screen.getByLabelText('Beskriv endringen i næring');
+    fireEvent.change(beskrivelseInput, { target: { value: 'a'.repeat(4001) } });
+
+    await userEvent.type(screen.getByLabelText('Årsinntekt'), '500000');
+    await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
+
+    expect(await screen.findByText('Du kan skrive maksimalt 4000 tegn')).toBeInTheDocument();
+  });
+
+  it('skal vise feil ved for lang navnRegnskapsforer og tlfRegnskapsforer', { timeout: 50000 }, async () => {
+    const lagre = vi.fn();
+
+    await Default.run({
+      parameters: {
+        submitCallback: lagre,
+      },
+    });
+
+    await userEvent.click(
+      screen.getByText('Ja, søker har arbeidet i egen næringsvirksomhet i løpet av de 10 siste månedene'),
+    );
+
+    await userEvent.type(screen.getByLabelText('Navn på foretaket'), 'Bedriften AS');
+    await userEvent.click(screen.getAllByText('Nei')[0]!);
+    await userEvent.selectOptions(screen.getByLabelText('Hvilket land er virksomheten registrert i?'), 'AND');
+    await userEvent.type(screen.getByLabelText('Fra og med'), '01.06.2022');
+    await userEvent.type(screen.getByLabelText('Til og med'), '03.06.2022');
+    await userEvent.click(screen.getByLabelText('Fiske'));
+    await userEvent.click(screen.getAllByText('Ja')[1]!);
+    await userEvent.click(screen.getByLabelText('Varig endring i næring'));
+    await userEvent.type(screen.getByLabelText('Gjeldende f.o.m.'), '03.05.2022');
+    await userEvent.type(screen.getByLabelText('Beskriv endringen i næring'), 'Dette er en endring');
+    await userEvent.type(screen.getByLabelText('Årsinntekt'), '500000');
+    await userEvent.click(screen.getAllByText('Ja')[2]!);
+
+    const navnInput = screen.getByLabelText('Navn på regnskapsfører/revisor?');
+    fireEvent.change(navnInput, { target: { value: 'A'.repeat(101) } });
+
+    await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
+
+    expect(await screen.findByText('Du kan skrive maksimalt 100 tegn')).toBeInTheDocument();
+
+    fireEvent.change(navnInput, { target: { value: 'Espen Revisor' } });
+
+    const tlfInput = screen.getByLabelText('Telefonnummer til regnskapsfører/revisor?');
+    fireEvent.change(tlfInput, { target: { value: '1'.repeat(31) } });
+
+    await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
+
+    expect(await screen.findByText('Du kan skrive maksimalt 30 tegn')).toBeInTheDocument();
+  });
 });

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetRegnskapPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetRegnskapPanel.tsx
@@ -3,12 +3,15 @@ import { FormattedMessage } from 'react-intl';
 
 import { VStack } from '@navikt/ds-react';
 import { RhfTextField } from '@navikt/ft-form-hooks';
-import { hasValidInteger, hasValidText, required } from '@navikt/ft-form-validators';
+import { hasValidInteger, hasValidText, maxLength, required } from '@navikt/ft-form-validators';
 import { ArrowBox } from '@navikt/ft-ui-komponenter';
 
 import { TrueFalseInput } from '../../felles/TrueFalseInput';
 import { VIRKSOMHET_FORM_NAME_PREFIX } from '../constants';
 import type { RegistrerVirksomhetFormValues, VirksomhetFormValues } from '../types';
+
+const maxLength100 = maxLength(100);
+const maxLength30 = maxLength(30);
 
 interface Props {
   readOnly: boolean;
@@ -36,14 +39,14 @@ export const VirksomhetRegnskapPanel = ({ index, readOnly }: Props) => {
               name={`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.navnRegnskapsforer`}
               control={control}
               readOnly={readOnly}
-              validate={[required, hasValidText]}
+              validate={[required, hasValidText, maxLength100]}
               label={<FormattedMessage id="Registrering.VirksomhetRegnskapPanel.AccountantName" />}
             />
             <RhfTextField
               name={`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.tlfRegnskapsforer`}
               control={control}
               readOnly={readOnly}
-              validate={[required, hasValidInteger]}
+              validate={[required, hasValidInteger, maxLength30]}
               label={<FormattedMessage id="Registrering.VirksomhetRegnskapPanel.AccountantPhone" />}
             />
           </VStack>

--- a/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetStartetEndretPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/virksomhetPanel/components/VirksomhetStartetEndretPanel.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Checkbox, VStack } from '@navikt/ds-react';
 import { RhfCheckboxGroup, RhfDatepicker, RhfTextarea, RhfTextField } from '@navikt/ft-form-hooks';
-import { hasValidDate, hasValidInteger, hasValidText, required } from '@navikt/ft-form-validators';
+import { hasValidDate, hasValidInteger, hasValidText, maxLength, required } from '@navikt/ft-form-validators';
 import { ArrowBox } from '@navikt/ft-ui-komponenter';
 
 import { TrueFalseInput } from '../../felles/TrueFalseInput';
@@ -12,6 +12,8 @@ import { VIRKSOMHET_FORM_NAME_PREFIX } from '../constants';
 import type { StartedEndretFormValues, VirksomhetFormValues } from '../types';
 
 import styles from './virksomhetStartetEndretPanel.module.css';
+
+const maxLength4000 = maxLength(4000);
 
 interface Props {
   readOnly: boolean;
@@ -68,7 +70,7 @@ export const VirksomhetStartetEndretPanel = ({ readOnly, index }: Props) => {
               name={`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.beskrivelseAvEndring`}
               control={control}
               label={<FormattedMessage id="Registrering.VirksomhetStartetPanel.VirksomhetEndretBeskrivelse" />}
-              validate={[hasValidText]}
+              validate={[hasValidText, maxLength4000]}
             />
             <RhfTextField
               name={`${VIRKSOMHET_FORM_NAME_PREFIX}.${index}.inntekt`}


### PR DESCRIPTION
* Uten disse kan man sende inn verdier som passerer frontend men avvises med 400 Bad Request i backend
* beskrivelseAvEndring: maxLength(4000)
* navnRegnskapsforer: maxLength(100)
* tlfRegnskapsforer: maxLength(30)
* Lengde hentet fra fp-sak VirksomhetsDto
* Tester lagt til for alle tre felter

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>