### PR TITLE
fix: hindre dobbel innsending ved merk som haster

### DIFF
--- a/apps/fp-frontend/src/behandlingmenu/modaler/MerkSomHasterMenyModal.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/modaler/MerkSomHasterMenyModal.tsx
@@ -16,7 +16,7 @@ export const MerkSomHasterMenyModal = ({ behandling, hentOgSettBehandling, lukkM
   const api = getBehandlingApi(behandling);
   const queryClient = useQueryClient();
 
-  const { mutate: merkSomHaster } = useMutation({
+  const { mutate: merkSomHaster, isPending } = useMutation({
     mutationFn: () => api.merkSomHaster(behandling.uuid, behandling.versjon),
     onSuccess: () => {
       hentOgSettBehandling();
@@ -27,8 +27,9 @@ export const MerkSomHasterMenyModal = ({ behandling, hentOgSettBehandling, lukkM
       void queryClient.invalidateQueries({
         queryKey: [FagsakRel.FETCH_FAGSAKDATA_FPTILBAKE],
       });
+      lukkModal();
     },
   });
 
-  return <MenyMerkSomHasterIndex merkSomHaster={merkSomHaster} lukkModal={lukkModal} />;
+  return <MenyMerkSomHasterIndex merkSomHaster={merkSomHaster} lukkModal={lukkModal} isPending={isPending} />;
 };

--- a/packages/sak/meny-merk-som-haster/i18n/nb_NO.json
+++ b/packages/sak/meny-merk-som-haster/i18n/nb_NO.json
@@ -1,4 +1,7 @@
 {
   "MenyMerkSomHasterIndex.MerkSomHaster": "Merk som haster",
-  "MenyMerkSomHasterIndex.MerkSomHasterSpørsmål": "Merk som haster?"
+  "MenyMerkSomHasterIndex.MerkSomHasterSpørsmål": "Merk som haster?",
+
+  "MenyMerkSomHasterIndex.Ok": "OK",
+  "MenyMerkSomHasterIndex.Avbryt": "Avbryt"
 }

--- a/packages/sak/meny-merk-som-haster/package.json
+++ b/packages/sak/meny-merk-som-haster/package.json
@@ -18,7 +18,6 @@
     "storybook": "storybook dev --quiet -p 7052"
   },
   "dependencies": {
-    "@navikt/aksel-icons": "8.15.0",
     "@navikt/ds-react": "8.15.0",
     "@navikt/ft-utils": "5.1.0",
     "dayjs": "1.11.21",

--- a/packages/sak/meny-merk-som-haster/package.json
+++ b/packages/sak/meny-merk-som-haster/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@navikt/aksel-icons": "8.15.0",
     "@navikt/ds-react": "8.15.0",
-    "@navikt/ft-ui-komponenter": "8.1.1",
     "@navikt/ft-utils": "5.1.0",
     "dayjs": "1.11.21",
     "react": "19.2.8",

--- a/packages/sak/meny-merk-som-haster/src/MenyMerkSomHasterIndex.spec.tsx
+++ b/packages/sak/meny-merk-som-haster/src/MenyMerkSomHasterIndex.spec.tsx
@@ -6,8 +6,16 @@ import * as stories from './MenyMerkSomHasterIndex.stories';
 
 const { Default } = composeStories(stories);
 
+const finnKnapp = (tekst: string): HTMLButtonElement => {
+  const knapp = screen.getByText(tekst).closest('button');
+  if (!knapp) {
+    throw new Error(`Fant ikke <button> for teksten "${tekst}"`);
+  }
+  return knapp;
+};
+
 describe('MenyMerkSomHasterIndex', () => {
-  it('skal vise modal og velge å åpne behandling for endringer', async () => {
+  it('skal vise modal og merke sak som haster', async () => {
     const merkSomHaster = vi.fn();
     const lukkModal = vi.fn();
     render(<Default merkSomHaster={merkSomHaster} lukkModal={lukkModal} />);
@@ -17,6 +25,25 @@ describe('MenyMerkSomHasterIndex', () => {
     await userEvent.click(screen.getByText('OK'));
 
     await waitFor(() => expect(merkSomHaster).toHaveBeenCalledTimes(1));
-    expect(lukkModal).toHaveBeenCalledTimes(1);
+    expect(lukkModal).not.toHaveBeenCalled();
+  });
+
+  it('skal disable OK/Avbryt-knappene og hindre ny innsending når lagring er isPending', async () => {
+    const merkSomHaster = vi.fn();
+    const lukkModal = vi.fn();
+    render(<Default merkSomHaster={merkSomHaster} lukkModal={lukkModal} isPending />);
+
+    expect(await screen.findByText('Merk som haster?')).toBeInTheDocument();
+
+    const okKnapp = finnKnapp('OK');
+    const avbrytKnapp = finnKnapp('Avbryt');
+    expect(okKnapp).toBeDisabled();
+    expect(avbrytKnapp).toBeDisabled();
+
+    await userEvent.click(okKnapp);
+    await userEvent.click(avbrytKnapp);
+
+    expect(merkSomHaster).not.toHaveBeenCalled();
+    expect(lukkModal).not.toHaveBeenCalled();
   });
 });

--- a/packages/sak/meny-merk-som-haster/src/MenyMerkSomHasterIndex.tsx
+++ b/packages/sak/meny-merk-som-haster/src/MenyMerkSomHasterIndex.tsx
@@ -1,7 +1,8 @@
 import { RawIntlProvider } from 'react-intl';
 
-import { OkAvbrytModal } from '@navikt/ft-ui-komponenter';
 import { createIntl } from '@navikt/ft-utils';
+
+import { MerkSomHasterModal } from './components/MerkSomHasterModal';
 
 import messages from '../i18n/nb_NO.json';
 
@@ -12,22 +13,21 @@ export const getMenytekst = () => intl.formatMessage({ id: 'MenyMerkSomHasterInd
 interface Props {
   merkSomHaster: () => void;
   lukkModal: () => void;
+  isPending?: boolean;
 }
 
-export const MenyMerkSomHasterIndex = ({ merkSomHaster, lukkModal }: Props) => {
+export const MenyMerkSomHasterIndex = ({ merkSomHaster, lukkModal, isPending }: Props) => {
   const submit = () => {
     merkSomHaster();
-
-    lukkModal();
   };
 
   return (
     <RawIntlProvider value={intl}>
-      <OkAvbrytModal
+      <MerkSomHasterModal
         text={intl.formatMessage({ id: 'MenyMerkSomHasterIndex.MerkSomHasterSpørsmål' })}
-        showModal
-        submit={submit}
-        cancel={lukkModal}
+        submitCallback={submit}
+        cancelEvent={lukkModal}
+        isPending={isPending}
       />
     </RawIntlProvider>
   );

--- a/packages/sak/meny-merk-som-haster/src/components/MerkSomHasterModal.tsx
+++ b/packages/sak/meny-merk-som-haster/src/components/MerkSomHasterModal.tsx
@@ -1,0 +1,45 @@
+import { FormattedMessage } from 'react-intl';
+
+import { Button, Dialog, Heading } from '@navikt/ds-react';
+
+interface Props {
+  text: string;
+  cancelEvent: () => void;
+  submitCallback: () => void;
+  isPending?: boolean;
+}
+
+/**
+ * MerkSomHasterModal
+ *
+ * Denne modalen vises når saksbehandler velger å merke en sak som haster i behandlingsmenyen.
+ * OK/Avbryt-knappene deaktiveres mens lagringen pågår, slik at man ikke kan trigge en dobbel
+ * innsending mot fpsak (f.eks. ved raske dobbeltklikk).
+ */
+export const MerkSomHasterModal = ({ text, cancelEvent, submitCallback, isPending }: Props) => (
+  <Dialog open onOpenChange={cancelEvent} size="small">
+    <Dialog.Popup width="small" aria-label={text}>
+      <Dialog.Body>
+        <Heading size="small" level="2">
+          {text}
+        </Heading>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Button
+          size="small"
+          variant="primary"
+          onClick={submitCallback}
+          loading={isPending}
+          disabled={isPending}
+          autoFocus
+          type="button"
+        >
+          <FormattedMessage id="MenyMerkSomHasterIndex.Ok" />
+        </Button>
+        <Button size="small" variant="secondary" onClick={cancelEvent} disabled={isPending} type="button">
+          <FormattedMessage id="MenyMerkSomHasterIndex.Avbryt" />
+        </Button>
+      </Dialog.Footer>
+    </Dialog.Popup>
+  </Dialog>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4173,7 +4173,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/fp-sak-meny-merk-som-haster@workspace:packages/sak/meny-merk-som-haster"
   dependencies:
-    "@navikt/aksel-icons": "npm:8.15.0"
     "@navikt/ds-react": "npm:8.15.0"
     "@navikt/fp-config-eslint": "workspace:*"
     "@navikt/fp-config-typescript": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4178,7 +4178,6 @@ __metadata:
     "@navikt/fp-config-eslint": "workspace:*"
     "@navikt/fp-config-typescript": "workspace:*"
     "@navikt/fp-config-vite": "workspace:*"
-    "@navikt/ft-ui-komponenter": "npm:8.1.1"
     "@navikt/ft-utils": "npm:5.1.0"
     "@storybook/react": "npm:10.5.2"
     "@storybook/react-vite": "npm:10.5.2"


### PR DESCRIPTION
Merk som haster-modalen brukte delt OkAvbrytModal uten støtte for disabled/loading-state, og lukket modalen synkront uten å vente på mutasjonen. Dette kunne trigge dobbel innsending mot fpsak (f.eks. ved raske dobbeltklikk), samme feil som ble delvis rettet for Endre utland-flyten i haster2-branchen.

- Erstatt OkAvbrytModal med lokal MerkSomHasterModal (Dialog) som disabler/viser loading på OK/Avbryt-knappene når isPending
- Lukk modal først i onSuccess, ikke synkront ved submit
- Fjern nå ubrukt @navikt/ft-ui-komponenter-avhengighet