### PR TITLE
fix(brev-editor): tilpass CustomHeader.renderSettings() til @editorjs/header 2.8.9

### DIFF
--- a/packages/brev-editor/i18n/nb_NO.json
+++ b/packages/brev-editor/i18n/nb_NO.json
@@ -21,5 +21,6 @@
   "useBrevEditorJs.Delete": "Fjern",
   "useBrevEditorJs.KlikkForFjern": "Klikk for å fjerne",
   "useBrevEditorJs.MoveUp": "Flytt opp",
-  "useBrevEditorJs.MoveDown": "Flytt ned"
+  "useBrevEditorJs.MoveDown": "Flytt ned",
+  "useBrevEditorJs.Filter": "Filtrer"
 }

--- a/packages/brev-editor/i18n/nb_NO.json
+++ b/packages/brev-editor/i18n/nb_NO.json
@@ -15,7 +15,6 @@
   "useBrevEditorJs.Heading1": "Overskrift",
   "useBrevEditorJs.Heading2": "Underoverskrift",
   "useBrevEditorJs.UnorderedList": "Punktliste",
-  "useBrevEditorJs.Unordered": "Punkt",
   "useBrevEditorJs.AddALink": "Legg til en lenke",
   "useBrevEditorJs.NothingFound": "Ingenting funnet",
   "useBrevEditorJs.ConvertTo": "Endre til",

--- a/packages/brev-editor/package.json
+++ b/packages/brev-editor/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@editorjs/editorjs": "2.31.6",
-    "@editorjs/header": "2.8.8",
+    "@editorjs/header": "2.8.9",
     "@editorjs/list": "2.0.9",
     "@editorjs/paragraph": "2.11.7",
     "@navikt/aksel-icons": "8.15.0",

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -222,6 +222,9 @@ const lagEditorJsI18n = (): I18nConfig => ({
       link: {
         'Add a link': intl.formatMessage({ id: 'useBrevEditorJs.AddALink' }),
       },
+      list: {
+        Unordered: intl.formatMessage({ id: 'useBrevEditorJs.UnorderedList' }),
+      },
       header: {
         'Heading 1': intl.formatMessage({ id: 'useBrevEditorJs.Heading1' }),
         'Heading 2': intl.formatMessage({ id: 'useBrevEditorJs.Heading2' }),
@@ -231,6 +234,7 @@ const lagEditorJsI18n = (): I18nConfig => ({
       popover: {
         'Nothing found': intl.formatMessage({ id: 'useBrevEditorJs.NothingFound' }),
         'Convert to': intl.formatMessage({ id: 'useBrevEditorJs.ConvertTo' }),
+        Filter: intl.formatMessage({ id: 'useBrevEditorJs.Filter' }),
       },
     },
     blockTunes: {

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -138,6 +138,16 @@ const useAutoSaveDebouncer = () => {
   return lagre;
 };
 
+class CustomList extends EditorjsList {
+  override renderSettings() {
+    return super.renderSettings().filter(item =>
+      // https://github.com/editor-js/list/issues/119
+      // @ts-expect-error Fiks
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      ['Unordered'].includes(item.label),
+    );
+  }
+}
 // Denne blir overstyrt for å ikkje strippa vekk a-tags ved lagring.
 class CustomParagraph extends Paragraph {
   static override get sanitize() {
@@ -185,7 +195,7 @@ const getTools = (): EditorConfig['tools'] => ({
     ],
   },
   list: {
-    class: EditorjsList,
+    class: CustomList as unknown as ToolConstructable,
     inlineToolbar: ['bold'],
     config: {
       preservedBlank: true,

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -138,36 +138,6 @@ const useAutoSaveDebouncer = () => {
   return lagre;
 };
 
-class CustomList extends EditorjsList {
-  override renderSettings() {
-    return super
-      .renderSettings()
-      .filter(item =>
-        // https://github.com/editor-js/list/issues/119
-        // @ts-expect-error Fiks
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ['Unordered'].includes(item.label),
-      )
-      .map(item => ({
-        ...item,
-        label: 'Punktliste',
-      }));
-  }
-}
-
-//TODO (TOR) Hacka det til for å få endra til norsk tekst. Burde kunne legga til i18n-messages?
-class CustomHeader extends Header {
-  override renderSettings() {
-    const settings = super.renderSettings();
-    const items = Array.isArray(settings) ? settings : [settings];
-    return items.map(item => ({
-      ...item,
-      // @ts-expect-error label er ikkje tilgjengeleg på alle MenuConfigItem-typar
-      label: item.label === 'Heading 1' ? 'Overskrift' : 'Underoverskrift',
-    }));
-  }
-}
-
 // Denne blir overstyrt for å ikkje strippa vekk a-tags ved lagring.
 class CustomParagraph extends Paragraph {
   static override get sanitize() {
@@ -190,7 +160,7 @@ const getTools = (): EditorConfig['tools'] => ({
     },
   },
   header: {
-    class: CustomHeader as unknown as ToolConstructable,
+    class: Header,
     inlineToolbar: false,
     config: {
       levels: [2, 1],
@@ -200,12 +170,14 @@ const getTools = (): EditorConfig['tools'] => ({
     toolbox: [
       {
         title: intl.formatMessage({ id: 'useBrevEditorJs.Heading1' }),
+        icon: 'H1',
         data: {
           level: 1,
         },
       },
       {
         title: intl.formatMessage({ id: 'useBrevEditorJs.Heading2' }),
+        icon: 'H2',
         data: {
           level: 2,
         },
@@ -213,7 +185,7 @@ const getTools = (): EditorConfig['tools'] => ({
     ],
   },
   list: {
-    class: CustomList as unknown as ToolConstructable,
+    class: EditorjsList,
     inlineToolbar: ['bold'],
     config: {
       preservedBlank: true,
@@ -240,8 +212,9 @@ const lagEditorJsI18n = (): I18nConfig => ({
       link: {
         'Add a link': intl.formatMessage({ id: 'useBrevEditorJs.AddALink' }),
       },
-      List: {
-        Unordered: intl.formatMessage({ id: 'useBrevEditorJs.Unordered' }),
+      header: {
+        'Heading 1': intl.formatMessage({ id: 'useBrevEditorJs.Heading1' }),
+        'Heading 2': intl.formatMessage({ id: 'useBrevEditorJs.Heading2' }),
       },
     },
     ui: {

--- a/packages/brev-editor/src/useBrevEditorJs.tsx
+++ b/packages/brev-editor/src/useBrevEditorJs.tsx
@@ -158,9 +158,11 @@ class CustomList extends EditorjsList {
 //TODO (TOR) Hacka det til for å få endra til norsk tekst. Burde kunne legga til i18n-messages?
 class CustomHeader extends Header {
   override renderSettings() {
-    return super.renderSettings().map(item => ({
+    const settings = super.renderSettings();
+    const items = Array.isArray(settings) ? settings : [settings];
+    return items.map(item => ({
       ...item,
-      // @ts-expect-error Fiks
+      // @ts-expect-error label er ikkje tilgjengeleg på alle MenuConfigItem-typar
       label: item.label === 'Heading 1' ? 'Overskrift' : 'Underoverskrift',
     }));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,7 +513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@editorjs/editorjs@npm:2.31.6, @editorjs/editorjs@npm:^2.29.1":
+"@editorjs/editorjs@npm:2.31.6, @editorjs/editorjs@npm:^2.30.7":
   version: 2.31.6
   resolution: "@editorjs/editorjs@npm:2.31.6"
   dependencies:
@@ -524,13 +524,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@editorjs/header@npm:2.8.8":
-  version: 2.8.8
-  resolution: "@editorjs/header@npm:2.8.8"
+"@editorjs/header@npm:2.8.9":
+  version: 2.8.9
+  resolution: "@editorjs/header@npm:2.8.9"
   dependencies:
     "@codexteam/icons": "npm:^0.0.5"
-    "@editorjs/editorjs": "npm:^2.29.1"
-  checksum: 10/8d313e8e8846347347639add8e8d971eea3e07fad9aaa842a8efb09b0eb099f0c68966fa8b5b34e1b9c4a9836ed04488985070abc60bef656b533db8441b3b47
+    "@editorjs/editorjs": "npm:^2.30.7"
+  checksum: 10/be0c40434b2e6e1d8499e3d831f76685be453263e06ca6e0e420d11139d4a08fc4573eda04f56b20f9e9376b3c6e639a91f6c565471246957cda793eab592bc1
   languageName: node
   linkType: hard
 
@@ -1680,7 +1680,7 @@ __metadata:
   resolution: "@navikt/fp-brev-editor@workspace:packages/brev-editor"
   dependencies:
     "@editorjs/editorjs": "npm:2.31.6"
-    "@editorjs/header": "npm:2.8.8"
+    "@editorjs/header": "npm:2.8.9"
     "@editorjs/list": "npm:2.0.9"
     "@editorjs/paragraph": "npm:2.11.7"
     "@navikt/aksel-icons": "npm:8.15.0"


### PR DESCRIPTION
`@editorjs/header` 2.8.9 endret returtypen til `renderSettings()` fra `BlockTune[]` til `MenuConfig`, noe som brøt TypeScript-kompileringen i `CustomHeader`.

## Sammendrag
- Bumper `@editorjs/header` 2.8.8 → 2.8.9
- Fjerner `CustomHeader` — bruker `Header` direkte med i18n-config (`header.Heading 1` / `header.Heading 2`) for oversettelse i stedet
- Forenkler `CustomList.renderSettings()` — fjerner `.map()` som hardkodet label til `'Punktliste'`; oversettelse skjer nå via i18n (`list.Unordered`)
- Legger til H1/H2-ikoner(som tekst)
- Oppdaterer `List` → `list` (lowercase) i i18n-config for å matche ny EditorJS-konvensjon
- Bytter `useBrevEditorJs.Unordered` → `useBrevEditorJs.UnorderedList` i i18n-oppslaget
- Legger til `useBrevEditorJs.Filter: "Filtrer"` for ny popover-nøkkel i EditorJS

## Validering
- `yarn knip`
- `yarn lint-staged`
