### PR TITLE
chore: erstatt @formatjs/cli-lib med eigen TS-AST-ekstraktor i intl-testar

### DIFF
--- a/packages/app-felles/i18n/intl.spec.ts
+++ b/packages/app-felles/i18n/intl.spec.ts
@@ -1,5 +1,6 @@
-import { extract } from '@formatjs/cli-lib';
 import { globSync } from 'node:fs';
+
+import { extractMessageIds } from '@navikt/fp-utils-test';
 
 import nb from './nb_NO.json';
 
@@ -7,13 +8,10 @@ import nb from './nb_NO.json';
 const writeToConsole = (text: string) => console.log(text);
 
 describe('intl', () => {
-  it('Check that i18n strings in code and in language file match', async () => {
+  it('Check that i18n strings in code and in language file match', () => {
     const files = globSync('src/**/*.{ts,tsx}');
 
-    const foundTranslations = await extract(files, {
-      idInterpolationPattern: '[sha512:contenthash:base64:6]',
-    });
-    const stringsInCode = Object.keys(JSON.parse(foundTranslations) as Record<string, string>);
+    const stringsInCode = extractMessageIds(files);
 
     const missingKeysBokmål = stringsInCode.filter(key => !Object.keys(nb).includes(key));
     if (missingKeysBokmål.length > 0) {

--- a/packages/app-felles/package.json
+++ b/packages/app-felles/package.json
@@ -35,10 +35,10 @@
     "react-router-dom": "7.18.1"
   },
   "devDependencies": {
-    "@formatjs/cli-lib": "8.6.0",
     "@navikt/fp-config-eslint": "workspace:*",
     "@navikt/fp-config-typescript": "workspace:*",
     "@navikt/fp-config-vite": "workspace:*",
+    "@navikt/fp-utils-test": "workspace:*",
     "@storybook/react": "10.5.5",
     "@storybook/react-vite": "10.5.5",
     "@testing-library/dom": "10.4.1",

--- a/packages/fakta/omsorgsovertakelse/i18n/intl.spec.ts
+++ b/packages/fakta/omsorgsovertakelse/i18n/intl.spec.ts
@@ -1,5 +1,6 @@
-import { extract } from '@formatjs/cli-lib';
 import { globSync } from 'node:fs';
+
+import { extractMessageIds } from '@navikt/fp-utils-test';
 
 import nb from './nb_NO.json';
 
@@ -20,14 +21,10 @@ const NOT_FOUND_BECAUSE_ID_IS_STRING_UNION_IN_CODE = new Set([
 ]);
 
 describe('intl', () => {
-  it('Check that i18n strings in code and in language file match', async () => {
+  it('Check that i18n strings in code and in language file match', () => {
     const files = globSync('src/**/*.{ts,tsx}');
 
-    const foundTranslations = await extract(files, {
-      idInterpolationPattern: '[sha512:contenthash:base64:6]',
-    });
-
-    const stringsInCode = new Set(Object.keys(JSON.parse(foundTranslations) as Record<string, string>));
+    const stringsInCode = new Set(extractMessageIds(files));
     const stringsInFile = new Set(Object.keys(nb));
 
     const missingKeysBokmål = stringsInCode.difference(stringsInFile);

--- a/packages/fakta/omsorgsovertakelse/package.json
+++ b/packages/fakta/omsorgsovertakelse/package.json
@@ -36,11 +36,11 @@
     "react-intl": "10.1.18"
   },
   "devDependencies": {
-    "@formatjs/cli-lib": "8.6.0",
     "@navikt/fp-config-eslint": "workspace:*",
     "@navikt/fp-config-typescript": "workspace:*",
     "@navikt/fp-config-vite": "workspace:*",
     "@navikt/fp-storybook-utils": "workspace:*",
+    "@navikt/fp-utils-test": "workspace:*",
     "@storybook/react": "10.5.5",
     "@storybook/react-vite": "10.5.5",
     "@testing-library/dom": "10.4.1",

--- a/packages/fakta/tilrettelegging/i18n/intl.spec.ts
+++ b/packages/fakta/tilrettelegging/i18n/intl.spec.ts
@@ -1,5 +1,6 @@
-import { extract } from '@formatjs/cli-lib';
 import { globSync } from 'node:fs';
+
+import { extractMessageIds } from '@navikt/fp-utils-test';
 
 import nb from './nb_NO.json';
 
@@ -7,13 +8,10 @@ import nb from './nb_NO.json';
 const writeToConsole = (text: string) => console.log(text);
 
 describe('intl', () => {
-  it('Check that i18n strings in code and in language file match', async () => {
+  it('Check that i18n strings in code and in language file match', () => {
     const files = globSync('src/**/*.{ts,tsx}');
 
-    const foundTranslations = await extract(files, {
-      idInterpolationPattern: '[sha512:contenthash:base64:6]',
-    });
-    const stringsInCode = Object.keys(JSON.parse(foundTranslations) as Record<string, string>);
+    const stringsInCode = extractMessageIds(files);
 
     const missingKeysBokmål = stringsInCode.filter(key => !Object.keys(nb).includes(key));
     if (missingKeysBokmål.length > 0) {

--- a/packages/fakta/tilrettelegging/package.json
+++ b/packages/fakta/tilrettelegging/package.json
@@ -37,10 +37,10 @@
     "react-intl": "10.1.18"
   },
   "devDependencies": {
-    "@formatjs/cli-lib": "8.6.0",
     "@navikt/fp-config-eslint": "workspace:*",
     "@navikt/fp-config-typescript": "workspace:*",
     "@navikt/fp-config-vite": "workspace:*",
+    "@navikt/fp-utils-test": "workspace:*",
     "@storybook/react": "10.5.5",
     "@storybook/react-vite": "10.5.5",
     "@testing-library/dom": "10.4.1",

--- a/packages/utbetalingsdata-is15/i18n/intl.spec.ts
+++ b/packages/utbetalingsdata-is15/i18n/intl.spec.ts
@@ -1,5 +1,6 @@
-import { extract } from '@formatjs/cli-lib';
 import { globSync } from 'node:fs';
+
+import { extractMessageIds } from '@navikt/fp-utils-test';
 
 import nb from './nb_NO.json';
 
@@ -7,13 +8,10 @@ import nb from './nb_NO.json';
 const writeToConsole = (text: string) => console.log(text);
 
 describe('intl', () => {
-  it('Check that i18n strings in code and in language file match', async () => {
+  it('Check that i18n strings in code and in language file match', () => {
     const files = globSync('src/**/*.{ts,tsx}');
 
-    const foundTranslations = await extract(files, {
-      idInterpolationPattern: '[sha512:contenthash:base64:6]',
-    });
-    const stringsInCode = Object.keys(JSON.parse(foundTranslations) as Record<string, string>);
+    const stringsInCode = extractMessageIds(files);
 
     const missingKeysBokmål = stringsInCode.filter(key => !Object.keys(nb).includes(key));
     if (missingKeysBokmål.length > 0) {

--- a/packages/utbetalingsdata-is15/package.json
+++ b/packages/utbetalingsdata-is15/package.json
@@ -28,10 +28,10 @@
     "react-intl": "10.1.18"
   },
   "devDependencies": {
-    "@formatjs/cli-lib": "8.6.0",
     "@navikt/fp-config-eslint": "workspace:*",
     "@navikt/fp-config-typescript": "workspace:*",
     "@navikt/fp-config-vite": "workspace:*",
+    "@navikt/fp-utils-test": "workspace:*",
     "@storybook/react": "10.5.5",
     "@storybook/react-vite": "10.5.5",
     "@testing-library/dom": "10.4.1",

--- a/packages/utils-test/index.ts
+++ b/packages/utils-test/index.ts
@@ -1,1 +1,2 @@
+export { extractMessageIds } from './src/intl/extractMessageIds';
 export { getIntlMock } from './src/intl-test-helper';

--- a/packages/utils-test/index.ts
+++ b/packages/utils-test/index.ts
@@ -1,2 +1,2 @@
-export { extractMessageIds } from './src/intl/extractMessageIds';
+export { extractMessageIds } from './src/extractMessageIds';
 export { getIntlMock } from './src/intl-test-helper';

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -15,13 +15,14 @@
   },
   "dependencies": {
     "react": "19.2.8",
-    "react-intl": "10.1.18"
+    "react-intl": "10.1.18",
+    "typescript": "6.0.3"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",
     "@navikt/fp-config-typescript": "workspace:*",
+    "@types/node": "24.12.0",
     "@types/react": "19.2.17",
-    "eslint": "10.8.0",
-    "typescript": "6.0.3"
+    "eslint": "10.8.0"
   }
 }

--- a/packages/utils-test/src/extractMessageIds.ts
+++ b/packages/utils-test/src/extractMessageIds.ts
@@ -16,7 +16,7 @@ import * as ts from 'typescript';
 export const extractMessageIds = (files: string[]): string[] => {
   const ids: string[] = [];
   for (const file of files) {
-    const content = readFileSync(file).toString();
+    const content = readFileSync(file, 'utf8');
     const scriptKind = file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
     const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, scriptKind);
     visit(sourceFile, ids);

--- a/packages/utils-test/src/intl/extractMessageIds.ts
+++ b/packages/utils-test/src/intl/extractMessageIds.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import * as ts from 'typescript';
+
+/**
+ * Henter ut statiske i18n-nøkler (`id`) som koden refererer til, via TypeScript sin AST.
+ *
+ * Erstatter `extract` fra `@formatjs/cli-lib`. Vi bruker aldri auto-genererte ID-er
+ * (alle meldinger har eksplisitte streng-ID-er), så vi trenger kun å plukke ut `id` fra:
+ * - `formatMessage({ id: '...' })` (typisk `intl.formatMessage(...)`)
+ * - `<FormattedMessage id="..." />`
+ * - `defineMessages({ ... })`
+ *
+ * Dynamiske ID-er (template-literaler med innsetting, f.eks. `` `ettersendelse.${x}` ``)
+ * ignoreres – akkurat som FormatJS gjorde.
+ */
+export const extractMessageIds = (files: string[]): string[] => {
+  const ids: string[] = [];
+  for (const file of files) {
+    const content = readFileSync(file).toString();
+    const scriptKind = file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+    const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, scriptKind);
+    visit(sourceFile, ids);
+  }
+  return [...new Set(ids)];
+};
+
+const visit = (node: ts.Node, ids: string[]): void => {
+  if (ts.isCallExpression(node)) {
+    const fnName = getCalleeName(node.expression);
+    const firstArgument = node.arguments[0];
+    if (firstArgument !== undefined) {
+      if (fnName === 'formatMessage') {
+        collectIdFromObject(firstArgument, ids);
+      } else if (fnName === 'defineMessages') {
+        collectIdsFromMessagesObject(firstArgument, ids);
+      }
+    }
+  } else if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+    if (getJsxTagName(node.tagName) === 'FormattedMessage') {
+      collectIdFromJsxAttributes(node.attributes, ids);
+    }
+  }
+  ts.forEachChild(node, child => visit(child, ids));
+};
+
+/** Returnerer funksjonsnavnet for `foo()` og `obj.foo()`. */
+const getCalleeName = (expression: ts.Expression): string | undefined => {
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+  return undefined;
+};
+
+/** Returnerer JSX-tagnavnet, f.eks. `FormattedMessage` for `<Intl.FormattedMessage>`. */
+const getJsxTagName = (tagName: ts.JsxTagNameExpression): string | undefined => {
+  if (ts.isIdentifier(tagName)) {
+    return tagName.text;
+  }
+  if (ts.isPropertyAccessExpression(tagName)) {
+    return tagName.name.text;
+  }
+  return undefined;
+};
+
+/** Plukker ut `id` fra et meldingsdeskriptor-objekt: `{ id: '...' }`. */
+const collectIdFromObject = (node: ts.Node, ids: string[]): void => {
+  if (!ts.isObjectLiteralExpression(node)) {
+    return;
+  }
+  for (const property of node.properties) {
+    if (ts.isPropertyAssignment(property) && getPropertyName(property.name) === 'id') {
+      const id = getStaticString(property.initializer);
+      if (id !== undefined) {
+        ids.push(id);
+      }
+    }
+  }
+};
+
+/** Plukker ut `id` fra hvert deskriptor-objekt i `defineMessages({ a: {...}, b: {...} })`. */
+const collectIdsFromMessagesObject = (node: ts.Node, ids: string[]): void => {
+  if (!ts.isObjectLiteralExpression(node)) {
+    return;
+  }
+  for (const property of node.properties) {
+    if (ts.isPropertyAssignment(property)) {
+      collectIdFromObject(property.initializer, ids);
+    }
+  }
+};
+
+/** Plukker ut `id="..."` eller `id={'...'}` fra JSX-attributter. */
+const collectIdFromJsxAttributes = (attributes: ts.JsxAttributes, ids: string[]): void => {
+  for (const attribute of attributes.properties) {
+    if (ts.isJsxAttribute(attribute) && attribute.name.getText() === 'id' && attribute.initializer !== undefined) {
+      const id = getJsxAttributeString(attribute.initializer);
+      if (id !== undefined) {
+        ids.push(id);
+      }
+    }
+  }
+};
+
+const getPropertyName = (name: ts.PropertyName): string | undefined => {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return undefined;
+};
+
+const getJsxAttributeString = (initializer: ts.JsxAttributeValue): string | undefined => {
+  if (ts.isStringLiteral(initializer)) {
+    return initializer.text;
+  }
+  if (ts.isJsxExpression(initializer) && initializer.expression !== undefined) {
+    return getStaticString(initializer.expression);
+  }
+  return undefined;
+};
+
+/** Returnerer verdien for statiske strenger, men ignorerer dynamiske template-literaler. */
+const getStaticString = (node: ts.Expression): string | undefined => {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  return undefined;
+};

--- a/packages/utils-test/tsconfig.json
+++ b/packages/utils-test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@navikt/fp-config-typescript",
   "compilerOptions": {
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom", "node"]
+    "types": ["node"]
   },
   "include": ["./", "../../@types/externals.d.ts"]
 }

--- a/packages/utils-test/tsconfig.json
+++ b/packages/utils-test/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@navikt/fp-config-typescript",
+  "compilerOptions": {
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom", "node"]
+  },
   "include": ["./", "../../@types/externals.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,70 +1070,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/cli-lib@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@formatjs/cli-lib@npm:8.6.0"
-  dependencies:
-    "@formatjs/cli-native-darwin-arm64": "npm:1.1.0"
-    "@formatjs/cli-native-linux-x64": "npm:1.1.0"
-    "@formatjs/icu-messageformat-parser": "npm:3.5.8"
-    "@formatjs/icu-skeleton-parser": "npm:2.1.8"
-    "@formatjs/ts-transformer": "npm:4.4.8"
-    "@types/estree": "npm:^1.0.8"
-    "@types/fs-extra": "npm:^11.0.4"
-    "@types/node": "npm:22 || 24"
-    commander: "npm:^14.0.0"
-    fast-glob: "npm:^3.3.3"
-    fs-extra: "npm:^11.3.3"
-    json-stable-stringify: "npm:^1.3.0"
-    loud-rejection: "npm:^2"
-    typescript: "npm:^5.6 || 6"
-  peerDependencies:
-    "@glimmer/syntax": ^0.84.3 || ^0.95.0
-    "@vue/compiler-core": ^3.5.0
-    content-tag: ^4.1.0
-    svelte: ^5.0.0
-    vue: ^3.5.0
-  dependenciesMeta:
-    "@formatjs/cli-native-darwin-arm64":
-      optional: true
-    "@formatjs/cli-native-linux-x64":
-      optional: true
-  peerDependenciesMeta:
-    "@glimmer/env":
-      optional: true
-    "@glimmer/reference":
-      optional: true
-    "@glimmer/syntax":
-      optional: true
-    "@glimmer/validator":
-      optional: true
-    "@vue/compiler-core":
-      optional: true
-    content-tag:
-      optional: true
-    svelte:
-      optional: true
-    vue:
-      optional: true
-  checksum: 10/9dd065e56ae1ee2e249750d2cb4dec2f80f8927f8ac6d12f6fbf17348419eab0217c9a150f9d6c13030453bfc02b67e215d1e6487f65e7ed10be2ba01eb43c2c
-  languageName: node
-  linkType: hard
-
-"@formatjs/cli-native-darwin-arm64@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@formatjs/cli-native-darwin-arm64@npm:1.1.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@formatjs/cli-native-linux-x64@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@formatjs/cli-native-linux-x64@npm:1.1.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@formatjs/fast-memoize@npm:3.1.7":
   version: 3.1.7
   resolution: "@formatjs/fast-memoize@npm:3.1.7"
@@ -1150,26 +1086,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/icu-messageformat-parser@npm:3.5.8":
-  version: 3.5.8
-  resolution: "@formatjs/icu-messageformat-parser@npm:3.5.8"
-  dependencies:
-    "@formatjs/icu-skeleton-parser": "npm:2.1.8"
-  checksum: 10/e082fe0c1abf0cbd5d65fb154710a894351ac7855e807ffb274e1dc7b3728bd6c8e0dc68cfdb88266e5554d31f0ca623514467d7d2c166698c17354415e7a073
-  languageName: node
-  linkType: hard
-
 "@formatjs/icu-skeleton-parser@npm:2.1.11":
   version: 2.1.11
   resolution: "@formatjs/icu-skeleton-parser@npm:2.1.11"
   checksum: 10/492f42bd4ad72b2cdb4fd75a07e3874aa78e88f346027058f74c58e3828378092784176c9f7c77f4b5baf58ffaa1a4e8f5efcb53143552def2990510d0ac3c16
-  languageName: node
-  linkType: hard
-
-"@formatjs/icu-skeleton-parser@npm:2.1.8":
-  version: 2.1.8
-  resolution: "@formatjs/icu-skeleton-parser@npm:2.1.8"
-  checksum: 10/004ea08c6106c4eb3b073f4d7e231232508817b9d081499ec338479f89e41b874e1b02dee951d9ca32b16692a208f9e6a1c38ca3d8160837206a002d024d3b50
   languageName: node
   linkType: hard
 
@@ -1181,23 +1101,6 @@ __metadata:
     "@formatjs/icu-messageformat-parser": "npm:3.5.15"
     intl-messageformat: "npm:11.2.12"
   checksum: 10/36cdbd1ba1dcb324f1758f7ad32b7488f3cf7021eec4aac10e054ce7e2e6f106ed190269ce09f134360bca1bea04db48d2d89e993a9a01288e46e5586028f07a
-  languageName: node
-  linkType: hard
-
-"@formatjs/ts-transformer@npm:4.4.8":
-  version: 4.4.8
-  resolution: "@formatjs/ts-transformer@npm:4.4.8"
-  dependencies:
-    "@formatjs/icu-messageformat-parser": "npm:3.5.8"
-    "@types/node": "npm:22 || 24"
-    json-stable-stringify: "npm:^1.3.0"
-    typescript: "npm:^5.6 || 6"
-  peerDependencies:
-    ts-jest: ^29
-  peerDependenciesMeta:
-    ts-jest:
-      optional: true
-  checksum: 10/85910bff44d31565acc47d760ed88ebfd5d21e7a4a9f51ca1ff7f3574aefcb65c3f1cd032a6a73889ef773555219651b6f6012e5739c8b56d190d8e45eb26fd6
   languageName: node
   linkType: hard
 
@@ -1685,7 +1588,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/fp-app-felles@workspace:packages/app-felles"
   dependencies:
-    "@formatjs/cli-lib": "npm:8.6.0"
     "@nais/apm": "npm:0.5.0"
     "@navikt/ds-react": "npm:8.15.0"
     "@navikt/fp-config-eslint": "workspace:*"
@@ -1694,6 +1596,7 @@ __metadata:
     "@navikt/fp-konstanter": "workspace:*"
     "@navikt/fp-sak-dekorator": "workspace:*"
     "@navikt/fp-sak-infosider": "workspace:*"
+    "@navikt/fp-utils-test": "workspace:*"
     "@navikt/ft-utils": "npm:5.1.0"
     "@sentry/browser": "npm:10.68.0"
     "@storybook/react": "npm:10.5.5"
@@ -2234,7 +2137,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/fp-fakta-omsorgsovertakelse@workspace:packages/fakta/omsorgsovertakelse"
   dependencies:
-    "@formatjs/cli-lib": "npm:8.6.0"
     "@navikt/aksel-icons": "npm:8.15.0"
     "@navikt/ds-react": "npm:8.15.0"
     "@navikt/fp-config-eslint": "workspace:*"
@@ -2247,6 +2149,7 @@ __metadata:
     "@navikt/fp-types-avklar-aksjonspunkter": "workspace:*"
     "@navikt/fp-ui-komponenter": "workspace:*"
     "@navikt/fp-utils": "workspace:*"
+    "@navikt/fp-utils-test": "workspace:*"
     "@navikt/ft-form-hooks": "npm:12.4.1"
     "@navikt/ft-form-validators": "npm:6.1.0"
     "@navikt/ft-ui-komponenter": "npm:8.1.1"
@@ -2387,7 +2290,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/fp-fakta-tilrettelegging@workspace:packages/fakta/tilrettelegging"
   dependencies:
-    "@formatjs/cli-lib": "npm:8.6.0"
     "@navikt/aksel-icons": "npm:8.15.0"
     "@navikt/ds-react": "npm:8.15.0"
     "@navikt/fp-config-eslint": "workspace:*"
@@ -2399,6 +2301,7 @@ __metadata:
     "@navikt/fp-types": "workspace:*"
     "@navikt/fp-types-avklar-aksjonspunkter": "workspace:*"
     "@navikt/fp-utils": "workspace:*"
+    "@navikt/fp-utils-test": "workspace:*"
     "@navikt/ft-form-hooks": "npm:12.4.1"
     "@navikt/ft-form-validators": "npm:6.1.0"
     "@navikt/ft-ui-komponenter": "npm:8.1.1"
@@ -4552,13 +4455,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/fp-utbetalingsdata-is15@workspace:packages/utbetalingsdata-is15"
   dependencies:
-    "@formatjs/cli-lib": "npm:8.6.0"
     "@navikt/aksel-icons": "npm:8.15.0"
     "@navikt/ds-react": "npm:8.15.0"
     "@navikt/fp-config-eslint": "workspace:*"
     "@navikt/fp-config-typescript": "workspace:*"
     "@navikt/fp-config-vite": "workspace:*"
     "@navikt/fp-types": "workspace:*"
+    "@navikt/fp-utils-test": "workspace:*"
     "@navikt/ft-ui-komponenter": "npm:8.1.1"
     "@navikt/ft-utils": "npm:5.1.0"
     "@storybook/react": "npm:10.5.5"
@@ -4585,6 +4488,7 @@ __metadata:
   dependencies:
     "@navikt/fp-config-eslint": "workspace:*"
     "@navikt/fp-config-typescript": "workspace:*"
+    "@types/node": "npm:24.12.0"
     "@types/react": "npm:19.2.17"
     eslint: "npm:10.8.0"
     react: "npm:19.2.8"
@@ -6737,16 +6641,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/fs-extra@npm:^11.0.4":
-  version: 11.0.4
-  resolution: "@types/fs-extra@npm:11.0.4"
-  dependencies:
-    "@types/jsonfile": "npm:*"
-    "@types/node": "npm:*"
-  checksum: 10/acc4c1eb0cde7b1f23f3fe6eb080a14832d8fa9dc1761aa444c5e2f0f6b6fa657ed46ebae32fb580a6700fc921b6165ce8ac3e3ba030c3dd15f10ad4dd4cae98
-  languageName: node
-  linkType: hard
-
 "@types/history@npm:^4.7.11":
   version: 4.7.11
   resolution: "@types/history@npm:4.7.11"
@@ -6758,15 +6652,6 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10/1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
-  languageName: node
-  linkType: hard
-
-"@types/jsonfile@npm:*":
-  version: 6.1.4
-  resolution: "@types/jsonfile@npm:6.1.4"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/309fda20eb5f1cf68f2df28931afdf189c5e7e6bec64ac783ce737bb98908d57f6f58757ad5da9be37b815645a6f914e2d4f3ac66c574b8fe1ba6616284d0e97
   languageName: node
   linkType: hard
 
@@ -6786,7 +6671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:22 || 24":
+"@types/node@npm:*, @types/node@npm:24.12.0":
   version: 24.12.0
   resolution: "@types/node@npm:24.12.0"
   dependencies:
@@ -7532,13 +7417,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-find-index@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "array-find-index@npm:1.0.2"
-  checksum: 10/aac128bf369e1ac6c06ff0bb330788371c0e256f71279fb92d745e26fb4b9db8920e485b4ec25e841c93146bf71a34dcdbcefa115e7e0f96927a214d237b7081
-  languageName: node
-  linkType: hard
-
 "array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
   version: 3.1.9
   resolution: "array-includes@npm:3.1.9"
@@ -7984,13 +7862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^14.0.0":
-  version: 14.0.3
-  resolution: "commander@npm:14.0.3"
-  checksum: 10/dfa9ebe2a433d277de5cb0252d23b10a543d245d892db858d23b516336a835c50fd4f52bee4cd13c705cc8acb6f03dc632c73dd806f7d06d3353eb09953dd17a
-  languageName: node
-  linkType: hard
-
 "comment-parser@npm:^1.4.1":
   version: 1.4.6
   resolution: "comment-parser@npm:1.4.6"
@@ -8105,15 +7976,6 @@ __metadata:
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10/ad41baf7e2ffac65ab544d79107bf7cd1a4bb9bab9ac3302f59ab4ba655d5e30942a8ae46e10ba160c6f4ecea464cc95b975ca2fefbdeeacd6ac63f12f99fe1f
-  languageName: node
-  linkType: hard
-
-"currently-unhandled@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "currently-unhandled@npm:0.4.1"
-  dependencies:
-    array-find-index: "npm:^1.0.1"
-  checksum: 10/53fb803e582737bdb5de6b150f0924dd9abf7be606648b4c2871db1c682bf288e248e8066ef10548979732a680cfb6c047294e3877846c2cf2f8d40437d8a741
   languageName: node
   linkType: hard
 
@@ -9277,17 +9139,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"fs-extra@npm:^11.3.3":
-  version: 11.3.3
-  resolution: "fs-extra@npm:11.3.3"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10/daeaefafbebe8fa6efd2fb96fc926f2c952be5877811f00a6794f0d64e0128e3d0d93368cd328f8f063b45deacf385c40e3d931aa46014245431cd2f4f89c67a
-  languageName: node
-  linkType: hard
-
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
   resolution: "fs-minipass@npm:3.0.3"
@@ -9516,7 +9367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -10261,19 +10112,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stable-stringify@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "json-stable-stringify@npm:1.3.0"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    isarray: "npm:^2.0.5"
-    jsonify: "npm:^0.0.1"
-    object-keys: "npm:^1.1.1"
-  checksum: 10/6661e9704733d2826b2012fea7b152ca216c82d8c725c8d390ee6434eabdf43c66fa6e6b423cce9bf95f8fec0ef52004c09a99043c7daf6e58595a0cff204629
-  languageName: node
-  linkType: hard
-
 "json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
@@ -10287,26 +10125,6 @@ __metadata:
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
-  languageName: node
-  linkType: hard
-
-"jsonfile@npm:^6.0.1":
-  version: 6.2.0
-  resolution: "jsonfile@npm:6.2.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.6"
-    universalify: "npm:^2.0.0"
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 10/513aac94a6eff070767cafc8eb4424b35d523eec0fcd8019fe5b975f4de5b10a54640c8d5961491ddd8e6f562588cf62435c5ddaf83aaf0986cd2ee789e0d7b9
-  languageName: node
-  linkType: hard
-
-"jsonify@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "jsonify@npm:0.0.1"
-  checksum: 10/7b86b6f4518582ff1d8b7624ed6c6277affd5246445e864615dbdef843a4057ac58587684faf129ea111eeb80e01c15f0a4d9d03820eb3f3985fa67e81b12398
   languageName: node
   linkType: hard
 
@@ -10586,16 +10404,6 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 10/6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
-  languageName: node
-  linkType: hard
-
-"loud-rejection@npm:^2":
-  version: 2.2.0
-  resolution: "loud-rejection@npm:2.2.0"
-  dependencies:
-    currently-unhandled: "npm:^0.4.1"
-    signal-exit: "npm:^3.0.2"
-  checksum: 10/2499c593d9a09a6fd305c6185826bcf546144b445ce730bdc275433674d1f411c23ce5dfcc7971feb22add7b47dc7e5f8c89c589f3720944d7e6945b617e392e
   languageName: node
   linkType: hard
 
@@ -12291,13 +12099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2":
-  version: 3.0.7
-  resolution: "signal-exit@npm:3.0.7"
-  checksum: 10/a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
-  languageName: node
-  linkType: hard
-
 "signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -13045,7 +12846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.3, typescript@npm:^5.6 || 6":
+"typescript@npm:6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
@@ -13055,7 +12856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6 || 6#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
@@ -13111,13 +12912,6 @@ __metadata:
   version: 0.4.0
   resolution: "unicorn-magic@npm:0.4.0"
   checksum: 10/5a02923ac75a322b6ea8b0835cd106180cce01b67110f933ebd446757c708591ea45fbbe576f1e027c44a69642926d1d5b94ddf3a64082f4ff420296c84caff9
-  languageName: node
-  linkType: hard
-
-"universalify@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "universalify@npm:2.0.1"
-  checksum: 10/ecd8469fe0db28e7de9e5289d32bd1b6ba8f7183db34f3bfc4ca53c49891c2d6aa05f3fb3936a81285a905cc509fb641a0c3fc131ec786167eff41236ae32e60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Gjør som i https://github.com/navikt/foreldrepengesoknad/pull/5661

## Sammendrag
- `@formatjs/cli-lib` ble kun brukt til å plukke statiske i18n-nøkler i `intl.spec.ts`-filene, men måtte oppgraderes ofte og brakk stadig
- Erstatter `extract()` med en liten TS-AST-ekstraktor (`extractMessageIds`) som henter statiske id-strenger fra `formatMessage`, `FormattedMessage` og `defineMessages`
- Ekstraktoren er lagt i `packages/utils-test/src/extractMessageIds.ts` og eksportert som delt verktøy fra `@navikt/fp-utils-test`
- Dynamiske template-ID-er ignoreres som før
- Testene er nå synkrone i stedet for async

## Endrede filer
- **Ny:** `packages/utils-test/src/extractMessageIds.ts`
- **Oppdatert (×4):** `intl.spec.ts` i `app-felles`, `utbetalingsdata-is15`, `fakta/omsorgsovertakelse`, `fakta/tilrettelegging`
- **Avhengigheter:** `@formatjs/cli-lib` fjernet og `@navikt/fp-utils-test` lagt til i de 4 pakkene; `typescript` flyttet til `dependencies` og `@types/node` lagt til i `utils-test`

## Validering
- `yarn knip`
- `yarn lint-staged`
- Alle fire `intl.spec.ts`-tester kjørt og bestått
