### PR TITLE
TFP-7098: fjern unødvendige typeannoteringer på tvers av komponenter

### DIFF
--- a/apps/fp-journalforing/package.json
+++ b/apps/fp-journalforing/package.json
@@ -19,7 +19,7 @@
     "stylelint": "stylelint \"src/**/*.module.css\"",
     "dev": "vite serve",
     "preview": "vite preview",
-    "clean": "rm -rf ./dist ./node_modules ./coverage ./.storybook-static-build",
+    "clean": "rm -rf ./dist ./node_modules ./.turbo ./.storybook-static-build",
     "storybook": "storybook dev --quiet -p 7005"
   },
   "dependencies": {

--- a/packages/fakta/omsorg/src/components/OmsorgInfoPanel.tsx
+++ b/packages/fakta/omsorg/src/components/OmsorgInfoPanel.tsx
@@ -54,7 +54,7 @@ export const OmsorgInfoPanel = ({ personoversikt, ytelsefordeling }: Props) => {
       {harAksjonspunkt && (
         <RhfForm
           formMethods={formMethods}
-          onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+          onSubmit={values => submitCallback(transformValues(values))}
           setDataOnUnmount={setMellomlagretFormData}
         >
           <VStack gap="space-24">

--- a/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
@@ -69,10 +69,7 @@ export const VurderOmsorgsovertakelseVilkåretForm = ({ omsorgsovertakelse }: Pr
       })}
       merknaderFraBeslutter={alleMerknaderFraBeslutter[AksjonspunktKode.VURDER_OMSORGSOVERTAKELSEVILKÅRET]}
     >
-      <RhfForm
-        formMethods={formMethods}
-        onSubmit={(values: FormValues) => submitCallback(transformValues(values, alleBarn))}
-      >
+      <RhfForm formMethods={formMethods} onSubmit={values => submitCallback(transformValues(values, alleBarn))}>
         <VStack gap="space-20">
           <RhfDatepicker
             name="omsorgsovertakelseDato"

--- a/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
+++ b/packages/fakta/saken/src/components/InnhentDokOpptjeningUtlandAP.tsx
@@ -47,7 +47,7 @@ export const InnhentDokOpptjeningUtlandAP = ({ aksjonspunkt, dokStatus }: Props)
         </Heading>
         <RhfForm
           formMethods={formMethods}
-          onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+          onSubmit={values => submitCallback(transformValues(values))}
           setDataOnUnmount={setMellomlagretFormData}
         >
           <VStack gap="space-16">

--- a/packages/fakta/saken/src/components/dekningsgrad/DekningradOverstyring.tsx
+++ b/packages/fakta/saken/src/components/dekningsgrad/DekningradOverstyring.tsx
@@ -95,7 +95,7 @@ export const DekningradOverstyring = ({ aksjonspunkt, ytelseFordeling, kanOverst
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values)).then(slåAvEditeringAvDekningsgrad)}
+      onSubmit={values => submitCallback(transformValues(values)).then(slåAvEditeringAvDekningsgrad)}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <AksjonspunktBoks

--- a/packages/fakta/verge/src/components/RegistrereVergeInfoPanel.tsx
+++ b/packages/fakta/verge/src/components/RegistrereVergeInfoPanel.tsx
@@ -71,7 +71,7 @@ export const RegistrereVergeInfoPanel = ({ verge, alleKodeverk }: Props) => {
       )}
       <RhfForm
         formMethods={formMethods}
-        onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+        onSubmit={values => submitCallback(transformValues(values))}
         setDataOnUnmount={setMellomlagretFormData}
       >
         <VStack gap="space-24">

--- a/packages/kodeverk/src/aksjonspunktCodes.ts
+++ b/packages/kodeverk/src/aksjonspunktCodes.ts
@@ -224,5 +224,4 @@ export type VilkårOverstyringAksjonspunkter =
   | AksjonspunktKode.OVERSTYRING_AV_OPPTJENINGSVILKÅRET;
 
 export type OverstyringAksjonspunkter =
-  | VilkårOverstyringAksjonspunkter
-  | AksjonspunktKode.OVERSTYRING_AV_FAKTA_OM_FØDSEL;
+  VilkårOverstyringAksjonspunkter | AksjonspunktKode.OVERSTYRING_AV_FAKTA_OM_FØDSEL;

--- a/packages/papirsoknad-ui-komponenter/src/bekreftelseFp/BekreftelsePanel.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/bekreftelseFp/BekreftelsePanel.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     const formMethods = useForm();
 
     return (
-      <RhfForm formMethods={formMethods} onSubmit={val => submitCallback(BekreftelsePanel.tranformValues(val))}>
+      <RhfForm formMethods={formMethods} onSubmit={values => submitCallback(BekreftelsePanel.transformValues(values))}>
         <VStack gap="space-40">
           <BekreftelsePanel {...args} />
           <Button size="small" variant="primary">

--- a/packages/papirsoknad-ui-komponenter/src/bekreftelseFp/BekreftelsePanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/bekreftelseFp/BekreftelsePanel.tsx
@@ -42,6 +42,7 @@ export const BekreftelsePanel = ({ readOnly, annenForelderInformertRequired = fa
 BekreftelsePanel.initialValues = (): BekreftelseFormValues => ({
   annenForelderInformert: undefined,
 });
-BekreftelsePanel.tranformValues = ({ annenForelderInformert }: BekreftelseFormValues) => ({
+
+BekreftelsePanel.transformValues = ({ annenForelderInformert }: BekreftelseFormValues) => ({
   annenForelderInformert,
 });

--- a/packages/papirsoknad-ui-komponenter/src/dekningsgradFp/DekningsgradIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/dekningsgradFp/DekningsgradIndex.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     });
 
     return (
-      <RhfForm formMethods={formMethods} onSubmit={val => submitCallback(DekningsgradIndex.transformValues(val))}>
+      <RhfForm formMethods={formMethods} onSubmit={values => submitCallback(DekningsgradIndex.transformValues(values))}>
         <VStack gap="space-40">
           <DekningsgradIndex {...args} />
           <Button size="small" variant="primary">

--- a/packages/papirsoknad-ui-komponenter/src/inntektsgivendeArbeidPanel/InntektsgivendeArbeidPapirsoknadIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/inntektsgivendeArbeidPanel/InntektsgivendeArbeidPapirsoknadIndex.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
     return (
       <RhfForm
         formMethods={formMethods}
-        onSubmit={val => submitCallback(InntektsgivendeArbeidPapirsoknadIndex.transformValues(val))}
+        onSubmit={values => submitCallback(InntektsgivendeArbeidPapirsoknadIndex.transformValues(values))}
       >
         <VStack gap="space-40">
           <InntektsgivendeArbeidPapirsoknadIndex {...args} />

--- a/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/LagreSoknadPapirsoknadIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/lagreSoknadPanel/LagreSoknadPapirsoknadIndex.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     return (
       <RhfForm
         formMethods={formMethods}
-        onSubmit={val => submitCallback(LagreSoknadPapirsoknadIndex.transformValues(val))}
+        onSubmit={values => submitCallback(LagreSoknadPapirsoknadIndex.transformValues(values))}
       >
         <LagreSoknadPapirsoknadIndex {...args} />
       </RhfForm>

--- a/packages/papirsoknad-ui-komponenter/src/mottattDatoPanel/MottattDatoPapirsoknadIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/mottattDatoPanel/MottattDatoPapirsoknadIndex.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     return (
       <RhfForm
         formMethods={formMethods}
-        onSubmit={val => submitCallback(MottattDatoPapirsoknadIndex.transformValues(val))}
+        onSubmit={values => submitCallback(MottattDatoPapirsoknadIndex.transformValues(values))}
       >
         <VStack gap="space-40">
           <MottattDatoPapirsoknadIndex {...args} />

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/PermisjonIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/PermisjonIndex.stories.tsx
@@ -8,7 +8,6 @@ import { action } from 'storybook/actions';
 import { alleKodeverk } from '@navikt/fp-storybook-utils';
 
 import { PermisjonIndex } from './PermisjonIndex';
-import type { PermisjonFormValues } from './types';
 
 const meta = {
   title: 'ui-komponenter/permisjon',
@@ -26,10 +25,7 @@ const meta = {
     });
 
     return (
-      <RhfForm
-        formMethods={formMethods}
-        onSubmit={(values: PermisjonFormValues) => submitCallback(PermisjonIndex.transformValues(values))}
-      >
+      <RhfForm formMethods={formMethods} onSubmit={values => submitCallback(PermisjonIndex.transformValues(values))}>
         <VStack gap="space-40">
           <PermisjonIndex {...args} />
           <Button size="small" variant="primary">

--- a/packages/papirsoknad-ui-komponenter/src/rettigheterPanel/RettigheterPapirsoknadIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/rettigheterPanel/RettigheterPapirsoknadIndex.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     return (
       <RhfForm
         formMethods={formMethods}
-        onSubmit={val => submitCallback(RettigheterPapirsoknadIndex.transformValues(val))}
+        onSubmit={values => submitCallback(RettigheterPapirsoknadIndex.transformValues(values))}
       >
         <VStack gap="space-40">
           <RettigheterPapirsoknadIndex {...args} />

--- a/packages/papirsoknad-ui-komponenter/src/sprakPanel/SprakPapirsoknadIndex.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/sprakPanel/SprakPapirsoknadIndex.stories.tsx
@@ -20,7 +20,10 @@ const meta = {
     const formMethods = useForm();
 
     return (
-      <RhfForm formMethods={formMethods} onSubmit={val => submitCallback(SprakPapirsoknadIndex.transformValues(val))}>
+      <RhfForm
+        formMethods={formMethods}
+        onSubmit={values => submitCallback(SprakPapirsoknadIndex.transformValues(values))}
+      >
         <VStack gap="space-40">
           <SprakPapirsoknadIndex {...args} />
           <Button size="small" variant="primary">

--- a/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminFodselSvpPanel.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/terminOgFodselPanelSvp/TerminFodselSvpPanel.stories.tsx
@@ -20,7 +20,10 @@ const meta = {
     const formMethods = useForm();
 
     return (
-      <RhfForm formMethods={formMethods} onSubmit={val => submitCallback(TerminOgFodselPanelSvp.transformValues(val))}>
+      <RhfForm
+        formMethods={formMethods}
+        onSubmit={values => submitCallback(TerminOgFodselPanelSvp.transformValues(values))}
+      >
         <VStack gap="space-40">
           <TerminOgFodselPanelSvp {...args} />
           <Button size="small" variant="primary">

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.stories.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
     return (
       <RhfForm
         formMethods={formMethods}
-        onSubmit={val => submitCallback(BehovForTilretteleggingPanel.transformValues(val))}
+        onSubmit={values => submitCallback(BehovForTilretteleggingPanel.transformValues(values))}
       >
         <VStack gap="space-40">
           <BehovForTilretteleggingPanel {...args} />

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerEndringssøknadForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerEndringssøknadForm.tsx
@@ -35,7 +35,7 @@ const transformValues = (
     søker: soknadData.foreldreType,
     ...MottattDatoPapirsoknadIndex.transformValues(formValues),
     ...PermisjonIndex.transformValues(formValues),
-    ...BekreftelsePanel.tranformValues(formValues),
+    ...BekreftelsePanel.transformValues(formValues),
     ...LagreSoknadPapirsoknadIndex.transformValues(formValues),
   };
 };

--- a/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
+++ b/packages/papirsoknad/src/foreldrepenger/components/ForeldrepengerForm.tsx
@@ -67,7 +67,7 @@ const transformValues = (
     ...OmsorgOgAdopsjonPapirsoknadIndex.transformValues(formValues),
     ...AnnenForelderPapirsoknadIndex.transformValues(formValues),
     ...PermisjonIndex.transformValues(formValues),
-    ...BekreftelsePanel.tranformValues(formValues),
+    ...BekreftelsePanel.transformValues(formValues),
     ...SprakPapirsoknadIndex.transformValues(formValues),
     ...LagreSoknadPapirsoknadIndex.transformValues(formValues),
   };

--- a/packages/prosess/formkrav/src/components/FormkravKlageFormNfp.tsx
+++ b/packages/prosess/formkrav/src/components/FormkravKlageFormNfp.tsx
@@ -122,7 +122,7 @@ export const FormkravKlageFormNfp = ({ klageVurdering, avsluttedeBehandlinger, l
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values, avsluttedeBehandlinger))}
+      onSubmit={values => submitCallback(transformValues(values, avsluttedeBehandlinger))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <VStack gap="space-16">

--- a/packages/prosess/innsyn/src/components/InnsynForm.tsx
+++ b/packages/prosess/innsyn/src/components/InnsynForm.tsx
@@ -82,7 +82,7 @@ export const InnsynForm = ({ innsyn, alleDokumenter = [] }: Props) => {
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: InnsynFormValues) => submitCallback(transformValues(values, alleDokumenter))}
+      onSubmit={values => submitCallback(transformValues(values, alleDokumenter))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <VStack gap="space-16">

--- a/packages/prosess/simulering/src/components/SimuleringPanel.tsx
+++ b/packages/prosess/simulering/src/components/SimuleringPanel.tsx
@@ -105,7 +105,7 @@ export const SimuleringPanel = ({
       {skalHaForm && (
         <RhfForm
           formMethods={formMethods}
-          onSubmit={(values: FormValues) => submitCallback(transformValues(values, aksjonspunkterForPanel))}
+          onSubmit={values => submitCallback(transformValues(values, aksjonspunkterForPanel))}
           setDataOnUnmount={setMellomlagretFormData}
         >
           <VStack gap="space-16">

--- a/packages/prosess/soknadsfrist/src/components/VurderSoknadsfristForeldrepengerForm.tsx
+++ b/packages/prosess/soknadsfrist/src/components/VurderSoknadsfristForeldrepengerForm.tsx
@@ -78,7 +78,7 @@ export const VurderSoknadsfristForeldrepengerForm = ({ mottattDato, søknadsfris
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(formValues: FormValues) => submitCallback(transformValues(formValues))}
+      onSubmit={values => submitCallback(transformValues(values))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <VStack gap="space-24">

--- a/packages/prosess/vedtak-innsyn/src/components/InnsynVedtakForm.tsx
+++ b/packages/prosess/vedtak-innsyn/src/components/InnsynVedtakForm.tsx
@@ -136,7 +136,7 @@ export const InnsynVedtakForm = ({
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+      onSubmit={values => submitCallback(transformValues(values))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <VStack gap="space-16">

--- a/packages/prosess/vilkar-fodsel/src/components/FodselVilkarForm.tsx
+++ b/packages/prosess/vilkar-fodsel/src/components/FodselVilkarForm.tsx
@@ -56,7 +56,7 @@ export const FodselVilkarForm = ({ status }: Props) => {
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values, aksjonspunkterForPanel))}
+      onSubmit={values => submitCallback(transformValues(values, aksjonspunkterForPanel))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <ProsessPanelTemplate

--- a/packages/prosess/vilkar-opptjening/src/components/OpptjeningVilkarAksjonspunktPanel.tsx
+++ b/packages/prosess/vilkar-opptjening/src/components/OpptjeningVilkarAksjonspunktPanel.tsx
@@ -58,10 +58,12 @@ export const OpptjeningVilkarAksjonspunktPanel = ({ status, fastsattOpptjening }
 
   const originalErVilkårOk = harÅpentAksjonspunkt ? undefined : 'OPPFYLT' === status;
 
-  const onSubmit = (values: FormValues) => submitCallback(transformValues(values));
-
   return (
-    <RhfForm formMethods={formMethods} onSubmit={onSubmit} setDataOnUnmount={setMellomlagretFormData}>
+    <RhfForm
+      formMethods={formMethods}
+      onSubmit={values => submitCallback(transformValues(values))}
+      setDataOnUnmount={setMellomlagretFormData}
+    >
       <ProsessPanelTemplate
         title={<FormattedMessage id="OpptjeningVilkarAksjonspunktPanel.Opptjeningsvilkaret" />}
         harÅpentAksjonspunkt={harÅpentAksjonspunkt}

--- a/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
+++ b/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
@@ -111,7 +111,7 @@ export const VilkarresultatMedOverstyringForm = ({
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values, overstyringApKode))}
+      onSubmit={values => submitCallback(transformValues(values, overstyringApKode))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <HStack gap="space-16">

--- a/packages/prosess/vilkar-sokers-opplysningsplikt/src/components/SokersOpplysningspliktForm.tsx
+++ b/packages/prosess/vilkar-sokers-opplysningsplikt/src/components/SokersOpplysningspliktForm.tsx
@@ -62,7 +62,7 @@ export const SokersOpplysningspliktForm = ({ søknad, status, arbeidsgiverOpplys
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+      onSubmit={values => submitCallback(transformValues(values))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <ProsessPanelTemplate

--- a/packages/prosess/vilkar-soknadsfrist/src/components/ErSoknadsfristVilkaretOppfyltForm.tsx
+++ b/packages/prosess/vilkar-soknadsfrist/src/components/ErSoknadsfristVilkaretOppfyltForm.tsx
@@ -75,7 +75,7 @@ export const ErSoknadsfristVilkaretOppfyltForm = ({ soknad, gjeldendeFamiliehend
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+      onSubmit={values => submitCallback(transformValues(values))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <ProsessPanelTemplate

--- a/packages/prosess/vilkar-svangerskap/src/components/SvangerskapVilkarForm.tsx
+++ b/packages/prosess/vilkar-svangerskap/src/components/SvangerskapVilkarForm.tsx
@@ -100,7 +100,7 @@ export const SvangerskapVilkarForm = ({ svangerskapspengerTilrettelegging, statu
   return (
     <RhfForm
       formMethods={formMethods}
-      onSubmit={(values: FormValues) => submitCallback(transformValues(values))}
+      onSubmit={values => submitCallback(transformValues(values))}
       setDataOnUnmount={setMellomlagretFormData}
     >
       <ProsessPanelTemplate

--- a/packages/sak/meldinger/src/components/Messages.tsx
+++ b/packages/sak/meldinger/src/components/Messages.tsx
@@ -133,7 +133,7 @@ export const Messages = ({
     <>
       <RhfForm
         formMethods={formMethods}
-        onSubmit={(values: FormValues) => submitCallback(values)}
+        onSubmit={values => submitCallback(values)}
         setDataOnUnmount={setMeldingFormData}
       >
         <VStack gap="space-16">

--- a/packages/sak/meny-ny-behandling/src/components/NyBehandlingModal.tsx
+++ b/packages/sak/meny-ny-behandling/src/components/NyBehandlingModal.tsx
@@ -173,8 +173,6 @@ export const NyBehandlingModal = ({
 
   const formMethods = useForm<FormValues>();
 
-  const onSubmit = (values: FormValues) => submitCallback(transformValues(values, uuidForSistLukkede, ytelseType));
-
   const valgtBehandlingTypeKode = useWatch({ control: formMethods.control, name: 'behandlingType' });
 
   const behandlingTyper = getBehandlingTyper(behandlingstyper);
@@ -193,7 +191,10 @@ export const NyBehandlingModal = ({
   return (
     <Dialog open onOpenChange={cancelEvent}>
       <Dialog.Popup className={styles['modal']}>
-        <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
+        <RhfForm
+          formMethods={formMethods}
+          onSubmit={values => submitCallback(transformValues(values, uuidForSistLukkede, ytelseType))}
+        >
           <Dialog.Header>
             <Dialog.Title>
               <FormattedMessage id="MenyNyBehandlingIndex.OpprettNyForstegangsbehandling" />


### PR DESCRIPTION
Fjerner eksplisitte typeannoteringer der TypeScript kan utlede typen selv, bl.a. på onSubmit-callbacks, komponent-props og hjelpefunksjoner i fakta-, prosess-, papirsøknad- og sak-pakker.

TFP-7098