### PR TITLE
refactor: bytt react-router-dom med react-router

### DIFF
--- a/apps/fp-avdelingsleder/package.json
+++ b/apps/fp-avdelingsleder/package.json
@@ -49,7 +49,7 @@
     "react-dom": "19.2.8",
     "react-hook-form": "7.84.0",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/fp-avdelingsleder/src/app/AvdelingslederIndex.tsx
+++ b/apps/fp-avdelingsleder/src/app/AvdelingslederIndex.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { Box, Heading, Select, Tabs, VStack } from '@navikt/ds-react';
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';

--- a/apps/fp-avdelingsleder/src/app/Dekorator.tsx
+++ b/apps/fp-avdelingsleder/src/app/Dekorator.tsx
@@ -1,6 +1,6 @@
 import { type ComponentProps } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import type { Theme } from '@navikt/ds-react';
 

--- a/apps/fp-avdelingsleder/src/app/Home.tsx
+++ b/apps/fp-avdelingsleder/src/app/Home.tsx
@@ -1,4 +1,4 @@
-import { Link, Route, Routes } from 'react-router-dom';
+import { Link, Route, Routes } from 'react-router';
 
 import { NotFoundPage } from '@navikt/fp-sak-infosider';
 import type { InitLinksDto } from '@navikt/fp-types';

--- a/apps/fp-avdelingsleder/src/main.tsx
+++ b/apps/fp-avdelingsleder/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import dayjs from 'dayjs';
 

--- a/apps/fp-frontend/package.json
+++ b/apps/fp-frontend/package.json
@@ -122,7 +122,7 @@
     "react-hook-form": "7.84.0",
     "react-intl": "10.1.19",
     "react-responsive": "10.0.1",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/apps/fp-frontend/src/aktoer/AktørIndex.stories.tsx
+++ b/apps/fp-frontend/src/aktoer/AktørIndex.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';

--- a/apps/fp-frontend/src/aktoer/AktørIndex.tsx
+++ b/apps/fp-frontend/src/aktoer/AktørIndex.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/app/AppIndex.stories.tsx
+++ b/apps/fp-frontend/src/app/AppIndex.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { cleanUrl, http, HttpResponse, type JsonBodyType } from 'msw';

--- a/apps/fp-frontend/src/app/AppIndex.tsx
+++ b/apps/fp-frontend/src/app/AppIndex.tsx
@@ -1,5 +1,5 @@
 import { RawIntlProvider } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { createIntl } from '@navikt/ft-utils';
 import { useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/app/components/Dekorator.tsx
+++ b/apps/fp-frontend/src/app/components/Dekorator.tsx
@@ -1,6 +1,6 @@
 import { type ComponentProps } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import type { Theme } from '@navikt/ds-react';
 

--- a/apps/fp-frontend/src/app/components/Home.stories.tsx
+++ b/apps/fp-frontend/src/app/components/Home.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, StoryObj } from '@storybook/react';

--- a/apps/fp-frontend/src/app/components/Home.tsx
+++ b/apps/fp-frontend/src/app/components/Home.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Link, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Link, Route, Routes, useLocation, useNavigate } from 'react-router';
 
 import { useMutation } from '@tanstack/react-query';
 

--- a/apps/fp-frontend/src/behandling/BehandlingIndex.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingIndex.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useMemo, useState } from 'react';
-import { type NavigateFunction, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { type NavigateFunction, useLocation, useNavigate, useParams } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { replaceNorwegianCharacters } from '@navikt/ft-utils';

--- a/apps/fp-frontend/src/behandling/BehandlingPanelerIndex.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingPanelerIndex.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/behandling/BehandlingerIndex.spec.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingerIndex.spec.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { render, screen } from '@testing-library/react';
 

--- a/apps/fp-frontend/src/behandling/BehandlingerIndex.tsx
+++ b/apps/fp-frontend/src/behandling/BehandlingerIndex.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { IngenBehandlingValgtPanel } from '@navikt/fp-sak-infosider';
 import type { Behandling } from '@navikt/fp-types';

--- a/apps/fp-frontend/src/behandling/fellesPaneler/prosess/VarselProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/fellesPaneler/prosess/VarselProsessStegInitPanel.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { forhandsvisDokument } from '@navikt/ft-utils';
 import { useMutation } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/behandling/fellesPaneler/prosess/VedtakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/fellesPaneler/prosess/VedtakProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend/src/behandling/innsyn/prosessPaneler/InnsynVedtakProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/innsyn/prosessPaneler/InnsynVedtakProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend/src/behandling/klage/prosessPaneler/KlageresultatProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/klage/prosessPaneler/KlageresultatProsessStegInitPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend/src/behandling/klage/prosessPaneler/VurderingFellesProsessStegInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/klage/prosessPaneler/VurderingFellesProsessStegInitPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend/src/behandling/tilbakekreving/TilbakekrevingPaneler.tsx
+++ b/apps/fp-frontend/src/behandling/tilbakekreving/TilbakekrevingPaneler.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import { useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
+++ b/apps/fp-frontend/src/behandling/tilbakekreving/prosessPaneler/VedtakTilbakekrevingProsessInitPanel.tsx
@@ -1,6 +1,6 @@
 import { type ComponentProps, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import {
   type ForhandsvisData,

--- a/apps/fp-frontend/src/behandlingmenu/modaler/HenleggMenyModal.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/modaler/HenleggMenyModal.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { forhandsvisDokument } from '@navikt/ft-utils';
 import { useMutation, useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/behandlingmenu/modaler/NyBehandlingMenyModal.tsx
+++ b/apps/fp-frontend/src/behandlingmenu/modaler/NyBehandlingMenyModal.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { useQuery } from '@tanstack/react-query';
 

--- a/apps/fp-frontend/src/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/BehandlingSupportIndex.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import {
   ArrowUndoIcon,

--- a/apps/fp-frontend/src/behandlingsupport/historikk/HistorikkIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/historikk/HistorikkIndex.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useQuery } from '@tanstack/react-query';
 

--- a/apps/fp-frontend/src/behandlingsupport/melding/MeldingIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/melding/MeldingIndex.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useCallback, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { Alert, VStack } from '@navikt/ds-react';
 import { forhandsvisDokument } from '@navikt/ft-utils';

--- a/apps/fp-frontend/src/behandlingsupport/totrinnskontroll/TotrinnskontrollIndex.tsx
+++ b/apps/fp-frontend/src/behandlingsupport/totrinnskontroll/TotrinnskontrollIndex.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { forhandsvisDokument } from '@navikt/ft-utils';
 import { useMutation, useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/fagsak/FagsakIndex.stories.tsx
+++ b/apps/fp-frontend/src/fagsak/FagsakIndex.stories.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import { LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Meta, ReactRenderer, StoryObj } from '@storybook/react';

--- a/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
+++ b/apps/fp-frontend/src/fagsak/FagsakIndex.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 
 import { DataFetchPendingModal, LoadingPanel } from '@navikt/ft-ui-komponenter';
 import type { Location } from 'history';

--- a/apps/fp-frontend/src/fagsakSearch/FagsakSearchIndex.tsx
+++ b/apps/fp-frontend/src/fagsakSearch/FagsakSearchIndex.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { HTTPError } from 'ky';

--- a/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Navigate, NavLink, useLocation, useMatch } from 'react-router-dom';
+import { Navigate, NavLink, useLocation, useMatch } from 'react-router';
 
 import { HStack, VStack } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';

--- a/apps/fp-frontend/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.tsx
+++ b/apps/fp-frontend/src/fagsakprofile/risikoklassifisering/RisikoklassifiseringIndex.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { useQuery } from '@tanstack/react-query';
 

--- a/apps/fp-frontend/src/main.tsx
+++ b/apps/fp-frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import dayjs from 'dayjs';
 

--- a/apps/fp-journalforing/package.json
+++ b/apps/fp-journalforing/package.json
@@ -44,7 +44,7 @@
     "react-dom": "19.2.8",
     "react-hook-form": "7.84.0",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/ds-css": "8.16.1",

--- a/apps/fp-journalforing/src/app/Dekorator.tsx
+++ b/apps/fp-journalforing/src/app/Dekorator.tsx
@@ -1,6 +1,6 @@
 import { type ComponentProps } from 'react';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import type { Theme } from '@navikt/ds-react';
 

--- a/apps/fp-journalforing/src/app/Home.tsx
+++ b/apps/fp-journalforing/src/app/Home.tsx
@@ -1,4 +1,4 @@
-import { Link, Route, Routes } from 'react-router-dom';
+import { Link, Route, Routes } from 'react-router';
 
 import { NotFoundPage } from '@navikt/fp-sak-infosider';
 

--- a/apps/fp-journalforing/src/main.tsx
+++ b/apps/fp-journalforing/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import dayjs from 'dayjs';
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@testing-library/jest-dom": "7.0.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "@types/react-router-dom": "5.3.3",
     "eslint": "10.8.0",
     "husky": "9.1.7",
     "jsdom": "30.0.1",

--- a/packages/app-felles/package.json
+++ b/packages/app-felles/package.json
@@ -32,7 +32,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/app-felles/src/app-shell/AppShell.tsx
+++ b/packages/app-felles/src/app-shell/AppShell.tsx
@@ -1,5 +1,5 @@
 import { type ComponentProps, createContext, type ReactNode, use, useCallback, useMemo, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 
 import { Theme } from '@navikt/ds-react';
 import { QueryClientProvider } from '@tanstack/react-query';

--- a/packages/brev-editor/package.json
+++ b/packages/brev-editor/package.json
@@ -34,7 +34,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/brev-editor/src/BrevRedigeringModal.tsx
+++ b/packages/brev-editor/src/BrevRedigeringModal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
-import { useHref, useLocation } from 'react-router-dom';
+import { useHref, useLocation } from 'react-router';
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { Alert, Button, Dialog } from '@navikt/ds-react';

--- a/packages/papirsoknad/package.json
+++ b/packages/papirsoknad/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.2.8",
     "react-hook-form": "7.84.0",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/papirsoknad/src/modal/SoknadRegistrertModal.tsx
+++ b/packages/papirsoknad/src/modal/SoknadRegistrertModal.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { Alert, BodyShort, Button, Dialog, HStack } from '@navikt/ds-react';
 import { createIntl } from '@navikt/ft-utils';

--- a/packages/sak/historikk/package.json
+++ b/packages/sak/historikk/package.json
@@ -29,7 +29,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/sak/historikk/src/components/HistorikkInnslag/Skjermlenke.tsx
+++ b/packages/sak/historikk/src/components/HistorikkInnslag/Skjermlenke.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { BodyShort, Link } from '@navikt/ds-react';
 import { type Location } from 'history';

--- a/packages/sak/totrinnskontroll/package.json
+++ b/packages/sak/totrinnskontroll/package.json
@@ -35,7 +35,7 @@
     "react-dom": "19.2.8",
     "react-hook-form": "7.84.0",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2"
+    "react-router": "7.18.2"
   },
   "devDependencies": {
     "@navikt/fp-config-eslint": "workspace:*",

--- a/packages/sak/totrinnskontroll/src/components/AksjonspunktGodkjenningFieldArray.tsx
+++ b/packages/sak/totrinnskontroll/src/components/AksjonspunktGodkjenningFieldArray.tsx
@@ -1,5 +1,5 @@
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { BodyShort, Link, VStack } from '@navikt/ds-react';
 import { type Location } from 'history';
@@ -35,8 +35,7 @@ export type AksjonspunktGodkjenningData = {
 type Props = {
   behandling: FagsakBehandlingDto;
   totrinnskontrollSkjermlenkeContext: (
-    | TotrinnskontrollSkjermlenkeContext
-    | TotrinnskontrollSkjermlenkeContextDtoFpTilbake
+    TotrinnskontrollSkjermlenkeContext | TotrinnskontrollSkjermlenkeContextDtoFpTilbake
   )[];
   readOnly: boolean;
   erTilbakekreving: boolean;

--- a/packages/sak/totrinnskontroll/src/components/TotrinnskontrollSaksbehandlerPanel.tsx
+++ b/packages/sak/totrinnskontroll/src/components/TotrinnskontrollSaksbehandlerPanel.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { CheckmarkIcon, XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { BodyShort, HStack, Link } from '@navikt/ds-react';
@@ -41,8 +41,7 @@ const VurderPåNyttPunkter = ({
 interface Props {
   behandling: FagsakBehandlingDto;
   totrinnskontrollSkjermlenkeContext: (
-    | TotrinnskontrollSkjermlenkeContext
-    | TotrinnskontrollSkjermlenkeContextDtoFpTilbake
+    TotrinnskontrollSkjermlenkeContext | TotrinnskontrollSkjermlenkeContextDtoFpTilbake
   )[];
   erTilbakekreving: boolean;
   skjemalenkeTyper: KodeverkMedNavn<'SkjermlenkeType'>[] | KodeverkMedNavnTilbakekreving<'SkjermlenkeType'>[];

--- a/packages/storybook-utils/decorators/withRouter.tsx
+++ b/packages/storybook-utils/decorators/withRouter.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import { type ReactRenderer } from '@storybook/react';
 import type { DecoratorFunction } from 'storybook/internal/types';

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -23,7 +23,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-intl": "10.1.19",
-    "react-router-dom": "7.18.2",
+    "react-router": "7.18.2",
     "storybook": "10.5.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,7 +1610,7 @@ __metadata:
     react: "npm:19.2.8"
     react-dom: "npm:19.2.8"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     typescript: "npm:6.0.3"
     vite: "npm:8.2.0"
@@ -1662,7 +1662,7 @@ __metadata:
     react-dom: "npm:19.2.8"
     react-hook-form: "npm:7.84.0"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     stylelint: "npm:17.14.1"
     tailwindcss: "npm:4.3.3"
@@ -1704,7 +1704,7 @@ __metadata:
     react: "npm:19.2.8"
     react-dom: "npm:19.2.8"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     stylelint: "npm:17.14.1"
     typescript: "npm:6.0.3"
@@ -2624,7 +2624,7 @@ __metadata:
     react-hook-form: "npm:7.84.0"
     react-intl: "npm:10.1.19"
     react-responsive: "npm:10.0.1"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     tailwindcss: "npm:4.3.3"
     typescript: "npm:6.0.3"
@@ -2672,7 +2672,7 @@ __metadata:
     react-dom: "npm:19.2.8"
     react-hook-form: "npm:7.84.0"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     stylelint: "npm:17.14.1"
     tailwindcss: "npm:4.3.3"
@@ -2884,7 +2884,7 @@ __metadata:
     react-dom: "npm:19.2.8"
     react-hook-form: "npm:7.84.0"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     typescript: "npm:6.0.3"
     vite: "npm:8.2.0"
@@ -3863,7 +3863,7 @@ __metadata:
     react: "npm:19.2.8"
     react-dom: "npm:19.2.8"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     stylelint: "npm:17.14.1"
     typescript: "npm:6.0.3"
@@ -4295,7 +4295,7 @@ __metadata:
     react-dom: "npm:19.2.8"
     react-hook-form: "npm:7.84.0"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     stylelint: "npm:17.14.1"
     typescript: "npm:6.0.3"
@@ -4380,7 +4380,7 @@ __metadata:
     react: "npm:19.2.8"
     react-dom: "npm:19.2.8"
     react-intl: "npm:10.1.19"
-    react-router-dom: "npm:7.18.2"
+    react-router: "npm:7.18.2"
     storybook: "npm:10.5.5"
     typescript: "npm:6.0.3"
   languageName: unknown
@@ -6631,13 +6631,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/history@npm:^4.7.11":
-  version: 4.7.11
-  resolution: "@types/history@npm:4.7.11"
-  checksum: 10/1da529a3485f3015daf794effa3185493bf7dd2551c26932389c614f5a0aab76ab97645897d1eef9c74ead216a3848fcaa019f165bbd6e4b71da6eff164b4c68
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:7.0.15, @types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -6676,36 +6669,6 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.2.0
   checksum: 10/616c4a8aee250ea05fb1e7b98e7e00475dd3a6c1c30d7be18b4b93caba832f4203106b3a496a6b147e5acc2da14575eca47bce234c633bca1f8430ef8ffb234a
-  languageName: node
-  linkType: hard
-
-"@types/react-router-dom@npm:5.3.3":
-  version: 5.3.3
-  resolution: "@types/react-router-dom@npm:5.3.3"
-  dependencies:
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-    "@types/react-router": "npm:*"
-  checksum: 10/28c4ea48909803c414bf5a08502acbb8ba414669b4b43bb51297c05fe5addc4df0b8fd00e0a9d1e3535ec4073ef38aaafac2c4a2b95b787167d113bc059beff3
-  languageName: node
-  linkType: hard
-
-"@types/react-router@npm:*":
-  version: 5.1.20
-  resolution: "@types/react-router@npm:5.1.20"
-  dependencies:
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-  checksum: 10/72d78d2f4a4752ec40940066b73d7758a0824c4d0cbeb380ae24c8b1cdacc21a6fc835a99d6849b5b295517a3df5466fc28be038f1040bd870f8e39e5ded43a4
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*":
-  version: 19.2.14
-  resolution: "@types/react@npm:19.2.14"
-  dependencies:
-    csstype: "npm:^3.2.2"
-  checksum: 10/fbff239089ee64b6bd9b00543594db498278b06de527ef1b0f71bb0eb09cc4445a71b5dd3c0d3d0257255c4eed94406be40a74ad4a987ade8a8d5dd65c82bc5f
   languageName: node
   linkType: hard
 
@@ -9096,7 +9059,6 @@ __metadata:
     "@testing-library/jest-dom": "npm:7.0.0"
     "@types/react": "npm:19.2.17"
     "@types/react-dom": "npm:19.2.3"
-    "@types/react-router-dom": "npm:5.3.3"
     eslint: "npm:10.8.0"
     husky: "npm:9.1.7"
     jsdom: "npm:30.0.1"
@@ -11743,18 +11705,6 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
   checksum: 10/4f3659be972be889445f396ceb680b26ba01886c906ae6efce2985c9a9cd58ef1de6907d37658ed74f41cbc9071823a3cdcb41887da84ebfeb563e329b453ea5
-  languageName: node
-  linkType: hard
-
-"react-router-dom@npm:7.18.2":
-  version: 7.18.2
-  resolution: "react-router-dom@npm:7.18.2"
-  dependencies:
-    react-router: "npm:7.18.2"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10/354a7af84963fe7acaf32c583f180b636b5071d9cf1f83090dba8ff2616ac65bba82aaf8e3cfa425d2a523a3318df3cfcf526462a154211c8abbf7ee70045a07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Sammendrag
- Bytter alle imports fra `react-router-dom` til `react-router` (44 kildefiler)
- Erstatter `react-router-dom` med `react-router` i alle relevante `package.json`
- Fjerner den ubrukte `@types/react-router-dom` (v5.3.3) fra rot

I react-router v7 er pakkene forenklet slik at alt kan importeres direkte fra
`react-router`. Se [oppgraderingsguiden](https://reactrouter.com/7.18.2/upgrading/v6).

## Validering
- `yarn install`
- `yarn tsc` (82 pakker, alle grønne)
- `yarn lint-staged`
- Tester: `@navikt/fp-frontend` (137), `fp-sak-totrinnskontroll` (50), `fp-sak-historikk` (5), `fp-brev-editor` (43), `fp-papirsoknad` (3), `fp-app-felles` (12) — alle grønne
