### PR TITLE
fix: rett tre bugs i prosess-paneler funnet ved kodegjennomgang

### DIFF
--- a/packages/prosess/beregningsresultat/src/components/BeregningsresultatEngangsstonadForm.tsx
+++ b/packages/prosess/beregningsresultat/src/components/BeregningsresultatEngangsstonadForm.tsx
@@ -34,11 +34,7 @@ export const BeregningsresultatEngangsstonadForm = ({
           <Detail>
             <FormattedMessage id="BeregningEngangsstonadForm.Sats" />
           </Detail>
-          <Label size="small">
-            {behandlingResultatstruktur.satsVerdi !== undefined
-              ? formatCurrencyWithKr(behandlingResultatstruktur.satsVerdi)
-              : '-'}
-          </Label>
+          <Label size="small">{formatCurrencyWithKr(behandlingResultatstruktur.satsVerdi)}</Label>
         </HStack>
         <HStack justify="space-between">
           <Detail>
@@ -51,11 +47,7 @@ export const BeregningsresultatEngangsstonadForm = ({
           <Detail>
             <FormattedMessage id="BeregningEngangsstonadForm.BeregnetEngangsstonad" />
           </Detail>
-          <Label size="small">
-            {behandlingResultatstruktur.beregnetTilkjentYtelse !== undefined
-              ? formatCurrencyWithKr(behandlingResultatstruktur.beregnetTilkjentYtelse)
-              : '-'}
-          </Label>
+          <Label size="small">{formatCurrencyWithKr(behandlingResultatstruktur.beregnetTilkjentYtelse)}</Label>
         </HStack>
       </VStack>
     </VStack>

--- a/packages/prosess/beregningsresultat/src/components/BeregningsresultatEngangsstonadForm.tsx
+++ b/packages/prosess/beregningsresultat/src/components/BeregningsresultatEngangsstonadForm.tsx
@@ -35,7 +35,9 @@ export const BeregningsresultatEngangsstonadForm = ({
             <FormattedMessage id="BeregningEngangsstonadForm.Sats" />
           </Detail>
           <Label size="small">
-            {behandlingResultatstruktur.satsVerdi ? formatCurrencyWithKr(behandlingResultatstruktur.satsVerdi) : '-'}
+            {behandlingResultatstruktur.satsVerdi !== undefined
+              ? formatCurrencyWithKr(behandlingResultatstruktur.satsVerdi)
+              : '-'}
           </Label>
         </HStack>
         <HStack justify="space-between">
@@ -50,7 +52,7 @@ export const BeregningsresultatEngangsstonadForm = ({
             <FormattedMessage id="BeregningEngangsstonadForm.BeregnetEngangsstonad" />
           </Detail>
           <Label size="small">
-            {behandlingResultatstruktur.beregnetTilkjentYtelse
+            {behandlingResultatstruktur.beregnetTilkjentYtelse !== undefined
               ? formatCurrencyWithKr(behandlingResultatstruktur.beregnetTilkjentYtelse)
               : '-'}
           </Label>

--- a/packages/prosess/simulering/src/components/SimuleringPanel.tsx
+++ b/packages/prosess/simulering/src/components/SimuleringPanel.tsx
@@ -154,7 +154,7 @@ const hentToggleDetaljer =
         : [
             ...showDetails.slice(0, tableIndex),
             { id, show: !showDetails[tableIndex]?.show },
-            ...showDetails.slice(tableIndex + 1, -1),
+            ...showDetails.slice(tableIndex + 1),
           ];
     setShowDetails(newShowDetailsArray);
   };

--- a/packages/prosess/vedtak-klage/src/components/VedtakKlageForm.tsx
+++ b/packages/prosess/vedtak-klage/src/components/VedtakKlageForm.tsx
@@ -44,7 +44,7 @@ export const VedtakKlageForm = ({ klageVurdering, previewVedtakCallback, behandl
   const [isSubmitting, setIsSubmitting] = useState(false);
   const lagreVedtak = () => {
     setIsSubmitting(true);
-    void submitCallback(transformValues(aksjonspunkterForPanel)).then(() => setIsSubmitting(false));
+    void submitCallback(transformValues(aksjonspunkterForPanel)).finally(() => setIsSubmitting(false));
   };
 
   return (


### PR DESCRIPTION
- simulering: slice(tableIndex + 1, -1) fjerna alltid siste rad i detaljlista ved toggle av detaljvisning i SimuleringPanel. Retta til slice(tableIndex + 1).
- vedtak-klage: isSubmitting vart berre nullstilt ved vellykka lagring (.then), slik at knappen kunne bli hengande i loading-tilstand ved feil under lagring. Bytta til .finally.
- beregningsresultat: satsVerdi og beregnetTilkjentYtelse vart vist som '-' når verdien var 0, fordi ein falsy-sjekk vart brukt i staden for ein eksplisitt undefined-sjekk.