### PR TITLE
fix: rett fleire konkrete bugs i fakta-panel etter kodegjennomgang

### DIFF
--- a/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.spec.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.spec.tsx
@@ -19,6 +19,7 @@ const {
   ArbeidsforholdErManueltLagtTilOgLagretOgReåpnet,
   ArbeidsforholdErOK,
   ArbeidsforholdErOKDerDetErToArbeidsforholdFraSammeVirksomhet,
+  ArbeidsforholdMedSammeOrgNr,
   FlereArbeidsforholdOgInntekstemeldinger,
   ArbeidsforholdMedSammeOrgNrDerEnManglerInntektsmeldingMenIkkeDetAndre,
   FoerRegisterinnhenting,
@@ -216,6 +217,33 @@ describe('ArbeidOgInntektFaktaIndex', () => {
       internArbeidsforholdRef: 'bc9a409c-a15f-4416-856b-5b1ee42eb75c',
       vurdering: 'MELDING_TIL_ARBEIDSGIVER_NAV_NO',
     });
+  });
+
+  it('skal beholde skjemaet dirty når lagring av manglende arbeidsforhold feiler', async () => {
+    const lagreVurdering = vi.fn(() => {
+      const promise = Promise.reject(new Error('Lagring feilet'));
+      void promise.catch(() => undefined);
+      return promise;
+    });
+
+    render(<AvklarManglendeArbeidsforhold lagreVurdering={lagreVurdering} />);
+
+    expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Jeg kontakter arbeidsgiver'));
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+
+    const lagreKnapp = screen.getByText('Lagre').closest('button');
+    expect(lagreKnapp).toBeEnabled();
+
+    await userEvent.click(screen.getByText('Lagre'));
+
+    await waitFor(() => expect(lagreVurdering).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(lagreKnapp).toBeEnabled());
+
+    expect(screen.getByLabelText('Jeg kontakter arbeidsgiver')).toBeChecked();
+    expect(screen.getByLabelText('Begrunn valget')).toHaveValue('Dette er en begrunnelse');
+    expect(screen.queryByText('Sett på vent')).not.toBeInTheDocument();
   });
 
   it('skal avklare manglende arbeidsforhold og så se bort fra inntektsmelding', async () => {
@@ -612,6 +640,33 @@ describe('ArbeidOgInntektFaktaIndex', () => {
       frist,
       ventearsak: 'VENT_OPDT_INNTEKTSMELDING',
     });
+  });
+
+  it('skal bare oppdatere raden som matcher internArbeidsforholdId ved lagring av manglende arbeidsforhold', async () => {
+    const registrerArbeidsforhold = vi.fn(() => Promise.resolve());
+
+    render(<ArbeidsforholdMedSammeOrgNr registrerArbeidsforhold={registrerArbeidsforhold} />);
+
+    expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
+    expect(screen.getAllByAltText('Åpent aksjonspunkt')).toHaveLength(3);
+
+    await userEvent.click(screen.getByText('Opprett arbeidsforhold basert på inntektsmeldingen'));
+
+    const periodeFra = screen.getByText('Periode fra');
+    await userEvent.type(periodeFra, '01.02.2020');
+    fireEvent.blur(periodeFra);
+
+    const periodeTil = screen.getByText('Periode til');
+    await userEvent.type(periodeTil, '01.02.2022');
+    fireEvent.blur(periodeTil);
+
+    await userEvent.type(screen.getByLabelText('Stillingsprosent'), '100');
+    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+
+    await userEvent.click(screen.getByText('Lagre'));
+
+    await waitFor(() => expect(registrerArbeidsforhold).toHaveBeenCalledTimes(1));
+    expect(screen.getAllByAltText('Åpent aksjonspunkt')).toHaveLength(2);
   });
 
   it('skal vise to arbeidsforhold fra samme virksomhet der kun ett har fått inntektsmelding', async () => {

--- a/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.spec.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.spec.tsx
@@ -1,6 +1,6 @@
 import { ISO_DATE_FORMAT } from '@navikt/ft-utils';
 import { composeStories } from '@storybook/react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
 
@@ -648,25 +648,40 @@ describe('ArbeidOgInntektFaktaIndex', () => {
     render(<ArbeidsforholdMedSammeOrgNr registrerArbeidsforhold={registrerArbeidsforhold} />);
 
     expect(await screen.findByText('Fakta om arbeid og inntekt')).toBeInTheDocument();
-    expect(screen.getAllByAltText('Åpent aksjonspunkt')).toHaveLength(3);
 
-    await userEvent.click(screen.getByText('Opprett arbeidsforhold basert på inntektsmeldingen'));
+    // Autoservice AS har to inntektsmeldinger utan tilhøyrande arbeidsforhold (same arbeidsgjevar-ident).
+    // Opne begge radene slik at kvar sin ManglendeArbeidsforholdForm-instans blir rendra.
+    const table = document.querySelector('table')!;
+    const rader = Array.from(table.querySelectorAll<HTMLTableRowElement>('tbody > tr:not(.aksel-table__expanded-row)'));
+    await userEvent.click(within(rader[1]!).getByText('Vis mer'));
 
-    const periodeFra = screen.getByText('Periode fra');
+    expect(screen.getAllByTitle('Åpent aksjonspunkt')).toHaveLength(5);
+
+    // Vel "Opprett arbeidsforhold basert på inntektsmeldingen" for berre den FØRSTE av dei to Autoservice-radene.
+    await userEvent.click(screen.getAllByText('Opprett arbeidsforhold basert på inntektsmeldingen')[0]!);
+
+    const skjema = within(screen.getByLabelText('Stillingsprosent').closest('form')!);
+
+    const periodeFra = skjema.getByText('Periode fra');
     await userEvent.type(periodeFra, '01.02.2020');
     fireEvent.blur(periodeFra);
 
-    const periodeTil = screen.getByText('Periode til');
+    const periodeTil = skjema.getByText('Periode til');
     await userEvent.type(periodeTil, '01.02.2022');
     fireEvent.blur(periodeTil);
 
-    await userEvent.type(screen.getByLabelText('Stillingsprosent'), '100');
-    await userEvent.type(screen.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
+    await userEvent.type(skjema.getByLabelText('Stillingsprosent'), '100');
+    await userEvent.type(skjema.getByLabelText('Begrunn valget'), 'Dette er en begrunnelse');
 
-    await userEvent.click(screen.getByText('Lagre'));
+    await userEvent.click(skjema.getByText('Lagre'));
 
     await waitFor(() => expect(registrerArbeidsforhold).toHaveBeenCalledTimes(1));
-    expect(screen.getAllByAltText('Åpent aksjonspunkt')).toHaveLength(2);
+    expect(registrerArbeidsforhold).toHaveBeenCalledWith(
+      expect.objectContaining({ internArbeidsforholdRef: '8ff2c608-6bab-4f83-9732-d26f8cwds' }),
+    );
+    // Berre den redigerte rada skal ha blitt oppdatert - den andre inntektsmeldinga med same
+    // arbeidsgjevar-ident skal framleis vise ope aksjonspunkt.
+    expect(screen.getAllByTitle('Åpent aksjonspunkt')).toHaveLength(4);
   });
 
   it('skal vise to arbeidsforhold fra samme virksomhet der kun ett har fått inntektsmelding', async () => {

--- a/packages/fakta/arbeid-og-inntekt/src/components/ArbeidOgInntektFaktaPanel.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/ArbeidOgInntektFaktaPanel.tsx
@@ -159,7 +159,7 @@ export const ArbeidOgInntektFaktaPanel = ({
         <Table.Body>
           {tabellRader.map((radData, index) => (
             <ArbeidsforholdRad
-              key={`${radData.arbeidsgiverNavn}${radData.arbeidsgiverIdent}`}
+              key={lagRadNøkkel(radData, index)}
               saksnummer={fagsak.saksnummer}
               behandlingUuid={behandling.uuid}
               behandlingVersjon={behandling.versjon}
@@ -236,4 +236,25 @@ export const ArbeidOgInntektFaktaPanel = ({
       )}
     </VStack>
   );
+};
+
+const lagRadNøkkel = (radData: ArbeidsforholdOgInntektRadData, index: number): string => {
+  const inntektsmeldingsnøkkel = radData.inntektsmeldingerForRad
+    .map(im =>
+      [
+        im.journalpostId ?? '',
+        im.dokumentId ?? '',
+        im.innsendingstidspunkt,
+        im.internArbeidsforholdId ?? '',
+        im.eksternArbeidsforholdId ?? '',
+        im.mottattDato,
+      ].join('-'),
+    )
+    .join('--');
+
+  const arbeidsforholdsnøkkel = radData.arbeidsforholdForRad
+    .map(af => [af.internArbeidsforholdId ?? '', af.eksternArbeidsforholdId ?? '', af.fom, af.tom].join('-'))
+    .join('--');
+
+  return [radData.arbeidsgiverIdent, inntektsmeldingsnøkkel || arbeidsforholdsnøkkel || 'rad', `${index}`].join('-');
 };

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
@@ -89,7 +89,7 @@ export const ManglendeArbeidsforholdForm = ({
   const inntektsmelding = radData.inntektsmeldingerForRad[0]!;
 
   const lagre = (formValues: FormValues) => {
-    const oppdater = getOppdaterTabell(oppdaterTabell, radData, inntektsmelding, formValues);
+    const oppdater = getOppdaterTabell(oppdaterTabell, inntektsmelding, formValues);
     if (formValues.saksbehandlersVurdering === 'OPPRETT_BASERT_PÅ_INNTEKTSMELDING') {
       return registrerArbeidsforhold({
         behandlingUuid,
@@ -242,19 +242,23 @@ const validerPeriodeRekkefølge = (getValues: UseFormGetValues<FormValues>) => (
   return fom && tom ? dateAfterOrEqual(fom)(tom) : null;
 };
 
+// Vurderinga lagrast i backend på (arbeidsgiverIdent, internArbeidsforholdRef). Rader som deler
+// denne nøkkelen deler difor same vurdering, og må oppdaterast likt lokalt.
+const erSammeVurdering = (inntektsmelding: Inntektsmelding, annen: Inntektsmelding): boolean =>
+  inntektsmelding.arbeidsgiverIdent === annen.arbeidsgiverIdent &&
+  (inntektsmelding.internArbeidsforholdId ?? undefined) === (annen.internArbeidsforholdId ?? undefined);
+
 const getOppdaterTabell =
   (
     oppdaterTabell: (data: (rader: ArbeidsforholdOgInntektRadData[]) => ArbeidsforholdOgInntektRadData[]) => void,
-    radData: ArbeidsforholdOgInntektRadData,
     inntektsmelding: Inntektsmelding,
     formValues: FormValues,
   ) =>
   () => {
-    const inntektsmeldingRadId = lagInntektsmeldingRadId(inntektsmelding);
     oppdaterTabell(oldData =>
       oldData.map(data => {
         const radInntektsmelding = data.inntektsmeldingerForRad[0];
-        if (radInntektsmelding && lagInntektsmeldingRadId(radInntektsmelding) === inntektsmeldingRadId) {
+        if (radInntektsmelding && erSammeVurdering(inntektsmelding, radInntektsmelding)) {
           const opprettArbeidsforhold = formValues.saksbehandlersVurdering === 'OPPRETT_BASERT_PÅ_INNTEKTSMELDING';
           const avklaring = opprettArbeidsforhold
             ? {
@@ -270,7 +274,7 @@ const getOppdaterTabell =
                 saksbehandlersVurdering: formValues.saksbehandlersVurdering,
               };
           return {
-            ...radData,
+            ...data,
             avklaring,
           };
         }
@@ -278,14 +282,3 @@ const getOppdaterTabell =
       }),
     );
   };
-
-const lagInntektsmeldingRadId = (inntektsmelding: Inntektsmelding): string =>
-  [
-    inntektsmelding.arbeidsgiverIdent,
-    inntektsmelding.journalpostId ?? '',
-    inntektsmelding.dokumentId ?? '',
-    inntektsmelding.innsendingstidspunkt,
-    inntektsmelding.internArbeidsforholdId ?? '',
-    inntektsmelding.eksternArbeidsforholdId ?? '',
-    inntektsmelding.mottattDato,
-  ].join('-');

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
@@ -103,8 +103,10 @@ export const ManglendeArbeidsforholdForm = ({
         tom: formValues.tom,
         stillingsprosent: formValues.stillingsprosent ?? 0,
       })
-        .then(oppdater)
-        .finally(() => formMethods.reset(formValues));
+        .then(() => {
+          oppdater();
+          formMethods.reset(formValues);
+        });
     }
     return lagreVurdering({
       behandlingUuid,
@@ -114,8 +116,10 @@ export const ManglendeArbeidsforholdForm = ({
       arbeidsgiverIdent: inntektsmelding.arbeidsgiverIdent,
       internArbeidsforholdRef: inntektsmelding.internArbeidsforholdId ?? undefined,
     })
-      .then(oppdater)
-      .finally(() => formMethods.reset(formValues));
+      .then(() => {
+        oppdater();
+        formMethods.reset(formValues);
+      });
   };
 
   const [anchorEl, setAnchorEl] = useState<SVGSVGElement | null>(null);
@@ -246,9 +250,11 @@ const getOppdaterTabell =
     formValues: FormValues,
   ) =>
   () => {
+    const inntektsmeldingRadId = lagInntektsmeldingRadId(inntektsmelding);
     oppdaterTabell(oldData =>
       oldData.map(data => {
-        if (inntektsmelding.arbeidsgiverIdent === data.arbeidsgiverIdent) {
+        const radInntektsmelding = data.inntektsmeldingerForRad[0];
+        if (radInntektsmelding && lagInntektsmeldingRadId(radInntektsmelding) === inntektsmeldingRadId) {
           const opprettArbeidsforhold = formValues.saksbehandlersVurdering === 'OPPRETT_BASERT_PÅ_INNTEKTSMELDING';
           const avklaring = opprettArbeidsforhold
             ? {
@@ -272,3 +278,14 @@ const getOppdaterTabell =
       }),
     );
   };
+
+const lagInntektsmeldingRadId = (inntektsmelding: Inntektsmelding): string =>
+  [
+    inntektsmelding.arbeidsgiverIdent,
+    inntektsmelding.journalpostId ?? '',
+    inntektsmelding.dokumentId ?? '',
+    inntektsmelding.innsendingstidspunkt,
+    inntektsmelding.internArbeidsforholdId ?? '',
+    inntektsmelding.eksternArbeidsforholdId ?? '',
+    inntektsmelding.mottattDato,
+  ].join('-');

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
@@ -106,7 +106,10 @@ export const ManglendeArbeidsforholdForm = ({
         .then(() => {
           oppdater();
           formMethods.reset(formValues);
-        });
+        })
+        // Fangar feilen her (i staden for å la RhfForm/react-hook-form få ein ufanga rejection) slik at
+        // brukaren kan prøve å lagre på nytt om lagringa feilar.
+        .catch(() => undefined);
     }
     return lagreVurdering({
       behandlingUuid,
@@ -119,7 +122,8 @@ export const ManglendeArbeidsforholdForm = ({
       .then(() => {
         oppdater();
         formMethods.reset(formValues);
-      });
+      })
+      .catch(() => undefined);
   };
 
   const [anchorEl, setAnchorEl] = useState<SVGSVGElement | null>(null);

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeArbeidsforhold/ManglendeArbeidsforholdForm.tsx
@@ -107,8 +107,10 @@ export const ManglendeArbeidsforholdForm = ({
           oppdater();
           formMethods.reset(formValues);
         })
-        // Fangar feilen her (i staden for å la RhfForm/react-hook-form få ein ufanga rejection) slik at
-        // brukaren kan prøve å lagre på nytt om lagringa feilar.
+        // Fangar feilen her sidan ingenting elles ventar på/fangar denne promisen (kalla frå eit
+        // onSubmit-DOM-event). Utan dette vart det ein ufanga ("unhandled") promise-rejection.
+        // Feilmelding til brukar og moglegheit til å prøve på nytt er alt sikra uavhengig av dette:
+        // mutation-cachen (queryUtils.ts) viser feilen, og reset() over køyrer berre ved suksess.
         .catch(() => undefined);
     }
     return lagreVurdering({
@@ -123,6 +125,7 @@ export const ManglendeArbeidsforholdForm = ({
         oppdater();
         formMethods.reset(formValues);
       })
+      // Sjå kommentar over: fangar berre for å unngå ufanga rejection, ikkje for brukarvarsling/retry.
       .catch(() => undefined);
   };
 

--- a/packages/fakta/arbeid-og-inntekt/src/components/manglendeInntektsmelding/ManglendeInntektsmeldingForm.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/manglendeInntektsmelding/ManglendeInntektsmeldingForm.tsx
@@ -62,6 +62,7 @@ export const ManglendeInntektsmeldingForm = ({
   };
 
   const lagre = (formValues: FormValues) => {
+    const oppdater = getOppdaterTabell(oppdaterTabell, radData, formValues);
     const params = {
       behandlingUuid,
       behandlingVersjon,
@@ -73,8 +74,10 @@ export const ManglendeInntektsmeldingForm = ({
       begrunnelse: formValues.begrunnelse ?? '',
     };
     return lagreVurdering(params)
-      .then(getOppdaterTabell(oppdaterTabell, radData, formValues))
-      .finally(() => formMethods.reset(formValues));
+      .then(() => {
+        oppdater();
+        formMethods.reset(formValues);
+      });
   };
 
   const svgRef = useRef<SVGSVGElement>(null);

--- a/packages/fakta/arbeid-og-inntekt/src/utils/arbeidOgInntektTabellUtils.ts
+++ b/packages/fakta/arbeid-og-inntekt/src/utils/arbeidOgInntektTabellUtils.ts
@@ -1,6 +1,11 @@
-import type { ArbeidOgInntektsmelding, Arbeidsforhold, ArbeidsgiverOpplysningerPerId } from '@navikt/fp-types';
+import type {
+  ArbeidOgInntektsmelding,
+  Arbeidsforhold,
+  ArbeidsgiverOpplysninger,
+  ArbeidsgiverOpplysningerPerId,
+} from '@navikt/fp-types';
 
-import type { ArbeidsforholdOgInntektRadData } from '../types/arbeidsforholdOgInntekt';
+import type { AGOpplysninger, ArbeidsforholdOgInntektRadData } from '../types/arbeidsforholdOgInntekt';
 import { harMatchendeArbeidsgiverIdent, lagArbeidsgiver } from './arbeidsgiverUtils';
 import { lagAvklaringFraArbeidsforhold, lagAvklaringFraInntektsmelding } from './avklaringUtils';
 import { finnInntektsmeldingerForArbeidsgiver } from './inntektsmeldingUtils';
@@ -32,9 +37,9 @@ export const byggTabellStruktur = (
         return acc;
       }
       const arbeidsforholdForRad = arbeidsforhold.filter(harMatchendeArbeidsgiverIdent(af));
-      const arbeidsgiverOpplysninger = lagArbeidsgiver(
+      const arbeidsgiverOpplysninger = lagArbeidsgiverMedFallback(
         af.arbeidsgiverIdent,
-        arbeidsgiverOpplysningerPerId[af.arbeidsgiverIdent]!,
+        arbeidsgiverOpplysningerPerId[af.arbeidsgiverIdent],
       );
       const inntektsmeldingerForRad = finnInntektsmeldingerForArbeidsgiver(inntektsmeldinger, af.arbeidsgiverIdent);
       const inntektsposter = inntekter.find(harMatchendeArbeidsgiverIdent(af))?.inntekter ?? [];
@@ -56,9 +61,9 @@ export const byggTabellStruktur = (
   const alleInntektsmeldingerSomManglerArbeidsforhold = inntektsmeldinger
     .filter(im => !arbeidsforhold.some(af => im.arbeidsgiverIdent === af.arbeidsgiverIdent))
     .map<ArbeidsforholdOgInntektRadData>(im => {
-      const arbeidsgiverOpplysninger = lagArbeidsgiver(
+      const arbeidsgiverOpplysninger = lagArbeidsgiverMedFallback(
         im.arbeidsgiverIdent,
-        arbeidsgiverOpplysningerPerId[im.arbeidsgiverIdent]!,
+        arbeidsgiverOpplysningerPerId[im.arbeidsgiverIdent],
       );
       const inntektsposter = inntekter.find(harMatchendeArbeidsgiverIdent(im))?.inntekter ?? [];
 
@@ -78,4 +83,19 @@ export const byggTabellStruktur = (
 export const finnUløstArbeidsforholdIndex = (tabellData: ArbeidsforholdOgInntektRadData[]): number[] => {
   const index = tabellData.findIndex(d => d.årsak && !d.avklaring);
   return index === -1 ? [] : [index];
+};
+
+const lagArbeidsgiverMedFallback = (
+  arbeidsgiverIdent: string,
+  arbeidsgiverOpplysninger?: ArbeidsgiverOpplysninger,
+): AGOpplysninger => {
+  if (arbeidsgiverOpplysninger) {
+    return lagArbeidsgiver(arbeidsgiverIdent, arbeidsgiverOpplysninger);
+  }
+
+  return {
+    erPrivatPerson: false,
+    arbeidsgiverIdent,
+    arbeidsgiverNavn: arbeidsgiverIdent,
+  };
 };

--- a/packages/fakta/arbeid-og-inntekt/src/utils/inntektsmeldingUtils.spec.ts
+++ b/packages/fakta/arbeid-og-inntekt/src/utils/inntektsmeldingUtils.spec.ts
@@ -1,4 +1,7 @@
+import type { ArbeidOgInntektsmelding } from '@navikt/fp-types';
+
 import { ArbeidsforholdErOKDerDetErToArbeidsforholdFraSammeVirksomhet } from '../ArbeidOgInntektFaktaIndex.stories';
+import { byggTabellStruktur } from './arbeidOgInntektTabellUtils';
 import { finnInntektsmeldingerForArbeidsgiver, grupperArbeidsforholdMedInntektsmelding } from './inntektsmeldingUtils';
 
 describe('inntektsmeldingUtils', () => {
@@ -20,5 +23,30 @@ describe('inntektsmeldingUtils', () => {
     expect(gruppering[0]!.inntektsmelding).toEqual(inntektsmeldinger[0]!);
     expect(gruppering[1]!.arbeidsforhold).toEqual(arbeidsforhold[1]!);
     expect(gruppering[1]!.inntektsmelding).toEqual(inntektsmeldinger[1]!);
+  });
+
+  it('skal bygge tabellstruktur selv om arbeidsgiveropplysninger mangler', () => {
+    const arbeidOgInntekt = {
+      arbeidsforhold: [
+        {
+          arbeidsgiverIdent: '910909088',
+          internArbeidsforholdId: 'bc9a409c-a15f-4416-856b-5b1ee42eb75c',
+          eksternArbeidsforholdId: 'ARB001-001',
+          fom: '2019-12-06',
+          tom: '9999-12-31',
+          stillingsprosent: 100,
+          permisjoner: [],
+        },
+      ],
+      inntektsmeldinger: [],
+      inntekter: [],
+      skjæringstidspunkt: '2021-11-10',
+    } satisfies ArbeidOgInntektsmelding;
+
+    const tabellStruktur = byggTabellStruktur(arbeidOgInntekt, {});
+
+    expect(tabellStruktur).toHaveLength(1);
+    expect(tabellStruktur[0]!.arbeidsgiverIdent).toBe('910909088');
+    expect(tabellStruktur[0]!.arbeidsgiverNavn).toBe('910909088');
   });
 });

--- a/packages/fakta/arbeidsforhold/src/ArbeidsforholdFaktaIndex.spec.tsx
+++ b/packages/fakta/arbeidsforhold/src/ArbeidsforholdFaktaIndex.spec.tsx
@@ -1,11 +1,12 @@
 import { composeStories } from '@storybook/react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import * as stories from './ArbeidsforholdFaktaIndex.stories';
 
 const {
   ArbeidsforholdetErIkkeAktivt,
+  ArbeidsforholdUtenStillingsprosent,
   FjernArbeidsforholdet,
   FlereArbeidsforholdITabell,
   IngenArbeidsforholdRegistrert,
@@ -17,6 +18,18 @@ const {
 } = composeStories(stories);
 
 describe('ArbeidsforholdFaktaIndex', () => {
+  it('skal vise bindestrek når stillingsprosent mangler', async () => {
+    render(<ArbeidsforholdUtenStillingsprosent />);
+
+    const arbeidsforholdRad = (await screen.findByText('KIWI (999999999)')).closest('tr');
+    if (!arbeidsforholdRad) {
+      throw new Error('Fant ikke arbeidsforholdraden');
+    }
+
+    expect(screen.queryByText('undefined %')).not.toBeInTheDocument();
+    expect(within(arbeidsforholdRad).getByText('-')).toBeInTheDocument();
+  });
+
   it('skal vise at arbeidsforholdet er oppdatert og behandlingen har fortsatt uten IM', async () => {
     render(<ArbeidsforholdetSkalBenyttesUtenInntektsmelding />);
 

--- a/packages/fakta/arbeidsforhold/src/ArbeidsforholdFaktaIndex.stories.tsx
+++ b/packages/fakta/arbeidsforhold/src/ArbeidsforholdFaktaIndex.stories.tsx
@@ -76,6 +76,27 @@ export const ArbeidsforholdetSkalBenyttesUtenInntektsmelding: Story = {
   },
 };
 
+export const ArbeidsforholdUtenStillingsprosent: Story = {
+  args: {
+    arbeidOgInntekt: {
+      arbeidsforhold: [
+        {
+          ...defaultArbeidsforhold,
+          arbeidsgiverIdent: '999999999',
+          internArbeidsforholdId: 'bc9a409c-a15f-4416-856b-5b1ee42eb75c',
+          eksternArbeidsforholdId: 'ARB001-001',
+          fom: '2000-04-19',
+          tom: '9999-12-31',
+          stillingsprosent: undefined,
+        },
+      ],
+      inntektsmeldinger: [],
+      inntekter: [],
+      skjæringstidspunkt: '2022-01-31',
+    },
+  },
+};
+
 export const ManueltOpprettetArbeidsforhold: Story = {
   args: {
     arbeidOgInntekt: {

--- a/packages/fakta/arbeidsforhold/src/components/ArbeidsforholdInfoPanel.tsx
+++ b/packages/fakta/arbeidsforhold/src/components/ArbeidsforholdInfoPanel.tsx
@@ -22,7 +22,7 @@ export const ArbeidsforholdInfoPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysnin
   const { arbeidsforhold, inntektsmeldinger } = arbeidOgInntekt;
 
   const sorterteArbeidsforhold = arbeidsforhold.toSorted(
-    getSortArbeidsforholdFn(arbeidsforhold, arbeidsgiverOpplysningerPerId, inntektsmeldinger),
+    getSortArbeidsforholdFn(arbeidsgiverOpplysningerPerId, inntektsmeldinger),
   );
 
   return (
@@ -44,18 +44,11 @@ export const ArbeidsforholdInfoPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysnin
   );
 };
 
-const harInntektmelding = (
-  arbeidsforhold: Arbeidsforhold,
-  inntektsmeldinger: Inntektsmelding[],
-  alleArbeidsforhold: Arbeidsforhold[],
-): boolean => inntektsmeldinger.some(im => erMatch(arbeidsforhold, im, alleArbeidsforhold));
+const harInntektmelding = (arbeidsforhold: Arbeidsforhold, inntektsmeldinger: Inntektsmelding[]): boolean =>
+  inntektsmeldinger.some(im => erMatch(arbeidsforhold, im));
 
 const getSortArbeidsforholdFn =
-  (
-    alleArbeidsforhold: Arbeidsforhold[],
-    arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId,
-    inntektsmeldinger: Inntektsmelding[],
-  ) =>
+  (arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId, inntektsmeldinger: Inntektsmelding[]) =>
   (a1: Arbeidsforhold, a2: Arbeidsforhold): number => {
     const arbeidsgiverOpplysningerA1 = arbeidsgiverOpplysningerPerId[a1.arbeidsgiverIdent];
     const arbeidsgiverOpplysningerA2 = arbeidsgiverOpplysningerPerId[a2.arbeidsgiverIdent];
@@ -67,12 +60,12 @@ const getSortArbeidsforholdFn =
       }
     }
 
-    const a1HarInntektsmelding = harInntektmelding(a1, inntektsmeldinger, alleArbeidsforhold);
-    const a2HarInntektsmelding = harInntektmelding(a2, inntektsmeldinger, alleArbeidsforhold);
+    const a1HarInntektsmelding = harInntektmelding(a1, inntektsmeldinger);
+    const a2HarInntektsmelding = harInntektmelding(a2, inntektsmeldinger);
 
     if (a1HarInntektsmelding && a2HarInntektsmelding) {
-      const a1MottattDato = inntektsmeldinger.find(im => erMatch(a1, im, alleArbeidsforhold))?.mottattDato;
-      const a2MottattDato = inntektsmeldinger.find(im => erMatch(a2, im, alleArbeidsforhold))?.mottattDato;
+      const a1MottattDato = inntektsmeldinger.find(im => erMatch(a1, im))?.mottattDato;
+      const a2MottattDato = inntektsmeldinger.find(im => erMatch(a2, im))?.mottattDato;
       return dayjs(a2MottattDato, ISO_DATE_FORMAT).diff(dayjs(a1MottattDato, ISO_DATE_FORMAT));
     }
     if (a1HarInntektsmelding) {

--- a/packages/fakta/arbeidsforhold/src/components/ArbeidsforholdInfoPanel.tsx
+++ b/packages/fakta/arbeidsforhold/src/components/ArbeidsforholdInfoPanel.tsx
@@ -22,7 +22,7 @@ export const ArbeidsforholdInfoPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysnin
   const { arbeidsforhold, inntektsmeldinger } = arbeidOgInntekt;
 
   const sorterteArbeidsforhold = arbeidsforhold.toSorted(
-    getSortArbeidsforholdFn(arbeidsgiverOpplysningerPerId, inntektsmeldinger),
+    getSortArbeidsforholdFn(arbeidsforhold, arbeidsgiverOpplysningerPerId, inntektsmeldinger),
   );
 
   return (
@@ -44,11 +44,18 @@ export const ArbeidsforholdInfoPanel = ({ arbeidOgInntekt, arbeidsgiverOpplysnin
   );
 };
 
-const harInntektmelding = (arbeidsforhold: Arbeidsforhold, inntektsmeldinger: Inntektsmelding[]): boolean =>
-  inntektsmeldinger.some(im => erMatch(arbeidsforhold, im));
+const harInntektmelding = (
+  arbeidsforhold: Arbeidsforhold,
+  inntektsmeldinger: Inntektsmelding[],
+  alleArbeidsforhold: Arbeidsforhold[],
+): boolean => inntektsmeldinger.some(im => erMatch(arbeidsforhold, im, alleArbeidsforhold));
 
 const getSortArbeidsforholdFn =
-  (arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId, inntektsmeldinger: Inntektsmelding[]) =>
+  (
+    alleArbeidsforhold: Arbeidsforhold[],
+    arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId,
+    inntektsmeldinger: Inntektsmelding[],
+  ) =>
   (a1: Arbeidsforhold, a2: Arbeidsforhold): number => {
     const arbeidsgiverOpplysningerA1 = arbeidsgiverOpplysningerPerId[a1.arbeidsgiverIdent];
     const arbeidsgiverOpplysningerA2 = arbeidsgiverOpplysningerPerId[a2.arbeidsgiverIdent];
@@ -60,12 +67,12 @@ const getSortArbeidsforholdFn =
       }
     }
 
-    const a1HarInntektsmelding = harInntektmelding(a1, inntektsmeldinger);
-    const a2HarInntektsmelding = harInntektmelding(a2, inntektsmeldinger);
+    const a1HarInntektsmelding = harInntektmelding(a1, inntektsmeldinger, alleArbeidsforhold);
+    const a2HarInntektsmelding = harInntektmelding(a2, inntektsmeldinger, alleArbeidsforhold);
 
     if (a1HarInntektsmelding && a2HarInntektsmelding) {
-      const a1MottattDato = inntektsmeldinger.find(im => erMatch(a1, im))?.mottattDato;
-      const a2MottattDato = inntektsmeldinger.find(im => erMatch(a2, im))?.mottattDato;
+      const a1MottattDato = inntektsmeldinger.find(im => erMatch(a1, im, alleArbeidsforhold))?.mottattDato;
+      const a2MottattDato = inntektsmeldinger.find(im => erMatch(a2, im, alleArbeidsforhold))?.mottattDato;
       return dayjs(a2MottattDato, ISO_DATE_FORMAT).diff(dayjs(a1MottattDato, ISO_DATE_FORMAT));
     }
     if (a1HarInntektsmelding) {

--- a/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
+++ b/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
@@ -45,12 +45,13 @@ export const PersonArbeidsforholdTable = ({
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {alleArbeidsforhold.map(arbeidsforhold => {
-          const stillingsprosent = `${arbeidsforhold.stillingsprosent?.toFixed(2)} %`;
-          const mottattDato = inntektsmeldinger.find(im => erMatch(arbeidsforhold, im))?.mottattDato;
+        {alleArbeidsforhold.map((arbeidsforhold, index) => {
+          const stillingsprosent =
+            arbeidsforhold.stillingsprosent !== undefined ? `${arbeidsforhold.stillingsprosent.toFixed(2)} %` : '-';
+          const mottattDato = inntektsmeldinger.find(im => erMatch(arbeidsforhold, im, alleArbeidsforhold))?.mottattDato;
           return (
             <Table.ExpandableRow
-              key={utledNøkkel(arbeidsforhold, arbeidsgiverOpplysningerPerId)}
+              key={utledNøkkel(arbeidsforhold, index)}
               content={
                 arbeidsforhold.saksbehandlersVurdering ? (
                   <ArbeidsforholdDetail valgtArbeidsforhold={arbeidsforhold} />
@@ -99,10 +100,21 @@ const finnKilde = (arbeidsforhold: Arbeidsforhold, intl: IntlShape) => {
   return intl.formatMessage({ id: 'PersonArbeidsforholdTable.AaRegisteret' });
 };
 
-export const erMatch = (arbeidsforhold: Arbeidsforhold, inntektsmelding: Inntektsmelding): boolean =>
-  inntektsmelding.arbeidsgiverIdent === arbeidsforhold.arbeidsgiverIdent &&
-  (!inntektsmelding.internArbeidsforholdId ||
-    inntektsmelding.internArbeidsforholdId === arbeidsforhold.internArbeidsforholdId);
+export const erMatch = (
+  arbeidsforhold: Arbeidsforhold,
+  inntektsmelding: Inntektsmelding,
+  alleArbeidsforhold: Arbeidsforhold[] = [arbeidsforhold],
+): boolean => {
+  if (inntektsmelding.arbeidsgiverIdent !== arbeidsforhold.arbeidsgiverIdent) {
+    return false;
+  }
+
+  if (inntektsmelding.internArbeidsforholdId) {
+    return inntektsmelding.internArbeidsforholdId === arbeidsforhold.internArbeidsforholdId;
+  }
+
+  return alleArbeidsforhold.filter(af => af.arbeidsgiverIdent === arbeidsforhold.arbeidsgiverIdent).length === 1;
+};
 
 const utledNavn = (
   { saksbehandlersVurdering, eksternArbeidsforholdId, arbeidsgiverIdent }: Arbeidsforhold,
@@ -127,10 +139,12 @@ const utledNavn = (
   return formaterArbeidsgiver(arbeidsgiverOpplysninger, eksternId ?? undefined);
 };
 
-const utledNøkkel = (
-  arbeidsforhold: Arbeidsforhold,
-  arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId,
-): string => {
-  const arbeidsgiverOpplysninger = arbeidsgiverOpplysningerPerId[arbeidsforhold.arbeidsgiverIdent];
-  return `${arbeidsforhold.eksternArbeidsforholdId}${arbeidsforhold.arbeidsgiverIdent}${arbeidsgiverOpplysninger?.identifikator}`;
-};
+const utledNøkkel = (arbeidsforhold: Arbeidsforhold, index: number): string =>
+  [
+    arbeidsforhold.arbeidsgiverIdent,
+    arbeidsforhold.internArbeidsforholdId ?? '',
+    arbeidsforhold.eksternArbeidsforholdId ?? '',
+    arbeidsforhold.fom,
+    arbeidsforhold.tom,
+    `${index}`,
+  ].join('-');

--- a/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
+++ b/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
@@ -48,7 +48,7 @@ export const PersonArbeidsforholdTable = ({
         {alleArbeidsforhold.map((arbeidsforhold, index) => {
           const stillingsprosent =
             arbeidsforhold.stillingsprosent !== undefined ? `${arbeidsforhold.stillingsprosent.toFixed(2)} %` : '-';
-          const mottattDato = inntektsmeldinger.find(im => erMatch(arbeidsforhold, im, alleArbeidsforhold))?.mottattDato;
+          const mottattDato = inntektsmeldinger.find(im => erMatch(arbeidsforhold, im))?.mottattDato;
           return (
             <Table.ExpandableRow
               key={utledNøkkel(arbeidsforhold, index)}
@@ -100,21 +100,10 @@ const finnKilde = (arbeidsforhold: Arbeidsforhold, intl: IntlShape) => {
   return intl.formatMessage({ id: 'PersonArbeidsforholdTable.AaRegisteret' });
 };
 
-export const erMatch = (
-  arbeidsforhold: Arbeidsforhold,
-  inntektsmelding: Inntektsmelding,
-  alleArbeidsforhold: Arbeidsforhold[] = [arbeidsforhold],
-): boolean => {
-  if (inntektsmelding.arbeidsgiverIdent !== arbeidsforhold.arbeidsgiverIdent) {
-    return false;
-  }
-
-  if (inntektsmelding.internArbeidsforholdId) {
-    return inntektsmelding.internArbeidsforholdId === arbeidsforhold.internArbeidsforholdId;
-  }
-
-  return alleArbeidsforhold.filter(af => af.arbeidsgiverIdent === arbeidsforhold.arbeidsgiverIdent).length === 1;
-};
+export const erMatch = (arbeidsforhold: Arbeidsforhold, inntektsmelding: Inntektsmelding): boolean =>
+  inntektsmelding.arbeidsgiverIdent === arbeidsforhold.arbeidsgiverIdent &&
+  (!inntektsmelding.internArbeidsforholdId ||
+    inntektsmelding.internArbeidsforholdId === arbeidsforhold.internArbeidsforholdId);
 
 const utledNavn = (
   { saksbehandlersVurdering, eksternArbeidsforholdId, arbeidsgiverIdent }: Arbeidsforhold,

--- a/packages/fakta/besteberegning/src/BesteberegningFaktaIndex.spec.tsx
+++ b/packages/fakta/besteberegning/src/BesteberegningFaktaIndex.spec.tsx
@@ -4,9 +4,17 @@ import userEvent from '@testing-library/user-event';
 
 import * as stories from './BesteberegningFaktaIndex.stories';
 
-const { BesteberegningMedDagpengerOgArbeid, BesteberegningMedAvvik } = composeStories(stories);
+const { BesteberegningMedDagpengerOgArbeid, BesteberegningMedAvvik, BesteberegningMedTomBeregningsgrunnlagPeriode } =
+  composeStories(stories);
 
 describe('BesteberegningFaktaIndex', () => {
+  it('skal rendre uten å krasje når beregningsgrunnlagPeriode er tom', async () => {
+    render(<BesteberegningMedTomBeregningsgrunnlagPeriode />);
+
+    expect(await screen.findByText('Inntektsgrunnlag for besteberegning')).toBeInTheDocument();
+    expect(screen.queryByText('Beregning etter § 14-7 første ledd gir beste beregning.')).not.toBeInTheDocument();
+  });
+
   it('skal se at tabell renderes med korrekt antall måneder og at passende navn vises for aktivitetene', async () => {
     render(<BesteberegningMedDagpengerOgArbeid />);
     expect(await screen.findByText('Beregning etter § 14-7 første ledd gir beste beregning.')).toBeInTheDocument();
@@ -25,6 +33,24 @@ describe('BesteberegningFaktaIndex', () => {
     expect(screen.getByText('April - 2020')).toBeInTheDocument();
     expect(screen.getByText('Mai - 2020')).toBeInTheDocument();
     expect(screen.getByText('Juni - 2020')).toBeInTheDocument();
+  });
+
+  it('skal deaktivere bekreft-knappen igjen når checkboxen fjernes', async () => {
+    render(<BesteberegningMedAvvik />);
+
+    const checkbox = await screen.findByRole('checkbox');
+    const bekreftKnapp = screen.getByText('Bekreft og fortsett').closest('button');
+
+    expect(bekreftKnapp).toBeDisabled();
+
+    await userEvent.click(checkbox);
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Min begrunnelse for vurdering av besteberegning');
+
+    expect(bekreftKnapp).toBeEnabled();
+
+    await userEvent.click(checkbox);
+
+    expect(bekreftKnapp).toBeDisabled();
   });
 
   it('skal bekrefte aksjonspunkt for vurder besteberegning', async () => {

--- a/packages/fakta/besteberegning/src/BesteberegningFaktaIndex.stories.tsx
+++ b/packages/fakta/besteberegning/src/BesteberegningFaktaIndex.stories.tsx
@@ -41,6 +41,16 @@ export const BesteberegningMedDagpengerOgArbeid: Story = {
   },
 };
 
+export const BesteberegningMedTomBeregningsgrunnlagPeriode: Story = {
+  args: {
+    aksjonspunkterForPanel: [],
+    beregningsgrunnlag: {
+      ...scenarioBG,
+      beregningsgrunnlagPeriode: [],
+    },
+  },
+};
+
 export const BesteberegningMedDagpengerOgArbeidÅpentAksjonspunkt: Story = {
   args: {
     beregningsgrunnlag: scenarioBG,

--- a/packages/fakta/besteberegning/src/components/BesteberegningPanel.tsx
+++ b/packages/fakta/besteberegning/src/components/BesteberegningPanel.tsx
@@ -31,7 +31,7 @@ export const BesteberegningPanel = ({ beregningsgrunnlag, arbeidsgiverOpplysning
     return null;
   }
 
-  const førstePeriode = beregningsgrunnlagPeriode[0]!;
+  const førstePeriode = beregningsgrunnlagPeriode[0];
   const besteberegningAP = aksjonspunkterForPanel.find(
     ap =>
       ap.definisjon === AksjonspunktKode.UTGÅTT_5048 ||
@@ -40,12 +40,14 @@ export const BesteberegningPanel = ({ beregningsgrunnlag, arbeidsgiverOpplysning
   return (
     <VStack gap="space-16">
       {!!besteberegningAP && <KontrollerBesteberegningPanel aksjonspunkt={besteberegningAP} />}
-      <BorderBox>
-        <BesteberegningResultatGrunnlagPanel
-          periode={førstePeriode}
-          besteMåneder={besteberegninggrunnlag.besteMåneder}
-        />
-      </BorderBox>
+      {førstePeriode && (
+        <BorderBox>
+          <BesteberegningResultatGrunnlagPanel
+            periode={førstePeriode}
+            besteMåneder={besteberegninggrunnlag.besteMåneder}
+          />
+        </BorderBox>
+      )}
       <BorderBox>
         <BesteMånederVisningPanel
           besteMåneder={besteberegninggrunnlag.besteMåneder}

--- a/packages/fakta/besteberegning/src/components/KontrollerBesteberegningPanel.tsx
+++ b/packages/fakta/besteberegning/src/components/KontrollerBesteberegningPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 
@@ -26,14 +25,16 @@ interface Props {
  * Formkomponent. Lar saksbehandler vurdere om den automatiske besteberegningen er korrekt utført.
  */
 export const KontrollerBesteberegningPanel = ({ aksjonspunkt }: Props) => {
-  const [erKnappEnabled, setErKnappEnabled] = useState(false);
-
   const { submitCallback, isSubmittable, isReadOnly } = usePanelDataContext<BesteberegningAP>();
 
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<FormValues>();
 
   const formMethods = useForm<FormValues>({
     defaultValues: mellomlagretFormData ?? buildInitialValues(aksjonspunkt),
+  });
+  const besteberegningErKorrektValg = useWatch({
+    control: formMethods.control,
+    name: 'besteberegningErKorrektValg',
   });
   const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
   return (
@@ -54,7 +55,6 @@ export const KontrollerBesteberegningPanel = ({ aksjonspunkt }: Props) => {
             control={formMethods.control}
             label={<FormattedMessage id="BesteberegningProsessPanel.Aksjonspunkt.Radiotekst" />}
             readOnly={isReadOnly}
-            onChange={() => setErKnappEnabled(!erKnappEnabled)}
           />
           <FaktaBegrunnelseTextField
             control={formMethods.control}
@@ -64,7 +64,7 @@ export const KontrollerBesteberegningPanel = ({ aksjonspunkt }: Props) => {
             hasVurderingText
           />
           <FaktaSubmitButton
-            isSubmittable={isSubmittable && erKnappEnabled}
+            isSubmittable={isSubmittable && besteberegningErKorrektValg === true}
             isSubmitting={formMethods.formState.isSubmitting}
             isDirty={formMethods.formState.isDirty}
             isReadOnly={isReadOnly}

--- a/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.spec.tsx
+++ b/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.spec.tsx
@@ -5,7 +5,8 @@ import { describe, expect } from 'vitest';
 import { erBarnUlike } from './FaktaFraFReg';
 import * as stories from './FaktaFraFReg.stories';
 
-const { IngenBarn, EttBarn, EttBarnMedDødsdato, ToBarnMedEnDødsdato } = composeStories(stories);
+const { IngenBarn, EttBarn, EttBarnMedDødsdato, ToBarnMedEnDødsdato, ToBarnMedLikFødselsdato } =
+  composeStories(stories);
 
 describe('FaktaFraFReg', () => {
   it('skal vise folkeregister med null registrerte barn', () => {
@@ -52,6 +53,17 @@ describe('FaktaFraFReg', () => {
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('03.05.2025')).toBeInTheDocument();
     expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('skal vise begge barn når de har lik fødselsdato', () => {
+    render(<ToBarnMedLikFødselsdato />);
+
+    expect(screen.getByText('Opplysninger fra Folkeregisteret')).toBeInTheDocument();
+    expect(screen.getAllByText('03.05.2025')).toHaveLength(2);
+    expect(screen.getByText('04.05.2025')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   describe('erBarnUlike', () => {

--- a/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.stories.tsx
+++ b/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.stories.tsx
@@ -51,3 +51,17 @@ export const ToBarnMedEnDødsdato: Story = {
     ],
   },
 };
+
+export const ToBarnMedLikFødselsdato: Story = {
+  args: {
+    barna: [
+      {
+        fødselsdato: '2025-05-03',
+        dødsdato: '2025-05-04',
+      },
+      {
+        fødselsdato: '2025-05-03',
+      },
+    ],
+  },
+};

--- a/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.tsx
+++ b/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.tsx
@@ -63,8 +63,9 @@ const BarnVisning = ({ barna }: { barna: BarnHendelseData[] }) => {
   return (
     <>
       {barna.map(({ fødselsdato, dødsdato }, index) => (
+        // eslint-disable-next-line @eslint-react/no-array-index-key -- barn manglar stabil id, indeks trengs for unik nøkkel ved like fødsels-/dødsdato
         <HStack
-          key={`${fødselsdato ?? 'ukjent-fodselsdato'}-${dødsdato ?? 'ingen-dodsdato'}-${index}`}
+          key={`${fødselsdato}-${dødsdato ?? 'ingen-dodsdato'}-${index}`}
           gap="space-24"
           wrap={false}
           className={styles['grid']}

--- a/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.tsx
+++ b/packages/fakta/felles/src/components/faktaFraFReg/FaktaFraFReg.tsx
@@ -63,7 +63,12 @@ const BarnVisning = ({ barna }: { barna: BarnHendelseData[] }) => {
   return (
     <>
       {barna.map(({ fødselsdato, dødsdato }, index) => (
-        <HStack key={fødselsdato + dødsdato} gap="space-24" wrap={false} className={styles['grid']}>
+        <HStack
+          key={`${fødselsdato ?? 'ukjent-fodselsdato'}-${dødsdato ?? 'ingen-dodsdato'}-${index}`}
+          gap="space-24"
+          wrap={false}
+          className={styles['grid']}
+        >
           <LabeledValue size="medium" label={index > 0 ? '' : <FormattedMessage id="Label.Barn" />} value={index + 1} />
           <LabeledValue
             size="medium"

--- a/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
+++ b/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
@@ -49,13 +49,14 @@ describe('FodselFaktaIndex', () => {
   });
 
   it('skal vise alle barn oppgitt i søknaden ved flerbarnsfødsel', () => {
+    const fødsel = Default.args.fødsel!;
     render(
       <Default
         submitCallback={vi.fn()}
         fødsel={{
-          ...Default.args.fødsel,
+          ...fødsel,
           søknad: {
-            ...Default.args.fødsel.søknad,
+            ...fødsel.søknad,
             barn: [
               {
                 fødselsdato: '2025-06-03',

--- a/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
+++ b/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 import { expect } from 'vitest';
 
+import { notEmpty } from '@navikt/fp-utils';
+
 import * as stories from './FodselFaktaIndex.stories';
 
 const {
@@ -49,7 +51,7 @@ describe('FodselFaktaIndex', () => {
   });
 
   it('skal vise alle barn oppgitt i søknaden ved flerbarnsfødsel', () => {
-    const fødsel = Default.args.fødsel!;
+    const fødsel = notEmpty(Default.args.fødsel);
     render(
       <Default
         submitCallback={vi.fn()}

--- a/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
+++ b/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
@@ -48,6 +48,39 @@ describe('FodselFaktaIndex', () => {
     expect(fregBoks.getByText('03.06.2025')).toBeInTheDocument();
   });
 
+  it('skal vise alle barn oppgitt i søknaden ved flerbarnsfødsel', () => {
+    render(
+      <Default
+        submitCallback={vi.fn()}
+        fødsel={{
+          ...Default.args.fødsel,
+          søknad: {
+            ...Default.args.fødsel.søknad,
+            barn: [
+              {
+                fødselsdato: '2025-06-03',
+                barnNummer: 1,
+              },
+              {
+                fødselsdato: '2025-06-03',
+                dødsdato: '2025-06-04',
+                barnNummer: 2,
+              },
+            ],
+            antallBarn: 2,
+          },
+        }}
+      />,
+    );
+
+    const søknadsBoks = within(screen.getByLabelText('Opplysninger oppgitt i søknaden'));
+    expect(søknadsBoks.getByText('Barn 1')).toBeInTheDocument();
+    expect(søknadsBoks.getByText('f. 03.06.2025')).toBeInTheDocument();
+    expect(søknadsBoks.getByText('Barn 2')).toBeInTheDocument();
+    expect(søknadsBoks.getByText('f. 03.06.2025 - d. 04.06.2025')).toBeInTheDocument();
+    expect(søknadsBoks.getByText('2')).toBeInTheDocument();
+  });
+
   describe('terminbekreftelse', () => {
     it('skal bekrefte aksjonspunkt for termin', async () => {
       const lagre = vi.fn(() => Promise.resolve());
@@ -169,6 +202,33 @@ describe('FodselFaktaIndex', () => {
       await userEvent.clear(fødselsdatoFelt);
       await userEvent.type(fødselsdatoFelt, '02.06.2025');
       fireEvent.blur(fødselsdatoFelt);
+
+      expect(
+        await apBoks.findByText(
+          'For stort avvik mellom termin og fødsel. Fødsel må være tidligst 19 uker før og senest 6 uker etter termin.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('skal vise feilmelding når et barn er for langt unna termindato selv om første barn er gyldig', async () => {
+      render(<APSjekkManglendeFødselPåForeldrepenger submitCallback={vi.fn()} />);
+
+      const apBoks = within(screen.getByLabelText('Kontroller opplysninger om fødsel'));
+
+      await userEvent.click(apBoks.getByText('Ja'));
+
+      const alleDatofelt = apBoks.getAllByRole('textbox', { hidden: true });
+      const fødselsdatoFelt1 = alleDatofelt[0]!;
+
+      await userEvent.clear(fødselsdatoFelt1);
+      await userEvent.type(fødselsdatoFelt1, '25.05.2025');
+      fireEvent.blur(fødselsdatoFelt1);
+
+      await userEvent.click(apBoks.getByText('Legg til barn'));
+
+      const fødselsdatoFelt2 = apBoks.getAllByRole('textbox', { hidden: true })[2]!;
+      await userEvent.type(fødselsdatoFelt2, '27.05.2025');
+      fireEvent.blur(fødselsdatoFelt2);
 
       expect(
         await apBoks.findByText(

--- a/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
+++ b/packages/fakta/fodsel/src/FodselFaktaIndex.spec.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 import { expect } from 'vitest';
 
-import { notEmpty } from '@navikt/fp-utils';
-
 import * as stories from './FodselFaktaIndex.stories';
 
 const {
@@ -48,40 +46,6 @@ describe('FodselFaktaIndex', () => {
     expect(fregBoks.getByText('1')).toBeInTheDocument();
     expect(fregBoks.getByText('Fødselsdato')).toBeInTheDocument();
     expect(fregBoks.getByText('03.06.2025')).toBeInTheDocument();
-  });
-
-  it('skal vise alle barn oppgitt i søknaden ved flerbarnsfødsel', () => {
-    const fødsel = notEmpty(Default.args.fødsel);
-    render(
-      <Default
-        submitCallback={vi.fn()}
-        fødsel={{
-          ...fødsel,
-          søknad: {
-            ...fødsel.søknad,
-            barn: [
-              {
-                fødselsdato: '2025-06-03',
-                barnNummer: 1,
-              },
-              {
-                fødselsdato: '2025-06-03',
-                dødsdato: '2025-06-04',
-                barnNummer: 2,
-              },
-            ],
-            antallBarn: 2,
-          },
-        }}
-      />,
-    );
-
-    const søknadsBoks = within(screen.getByLabelText('Opplysninger oppgitt i søknaden'));
-    expect(søknadsBoks.getByText('Barn 1')).toBeInTheDocument();
-    expect(søknadsBoks.getByText('f. 03.06.2025')).toBeInTheDocument();
-    expect(søknadsBoks.getByText('Barn 2')).toBeInTheDocument();
-    expect(søknadsBoks.getByText('f. 03.06.2025 - d. 04.06.2025')).toBeInTheDocument();
-    expect(søknadsBoks.getByText('2')).toBeInTheDocument();
   });
 
   describe('terminbekreftelse', () => {

--- a/packages/fakta/fodsel/src/components/fakta/FaktaFraSøknad.tsx
+++ b/packages/fakta/fodsel/src/components/fakta/FaktaFraSøknad.tsx
@@ -6,6 +6,8 @@ import { DateLabel, FaktaBoks, LabeledValue } from '@navikt/ft-ui-komponenter';
 import type { FødselSøknad } from '@navikt/fp-types';
 import { DokumentLink, type DokumentLinkReferanse } from '@navikt/fp-ui-komponenter';
 
+import { formaterLiv } from './barnUtils';
+
 interface Props {
   søknad: FødselSøknad;
   terminbekreftelseDokument: DokumentLinkReferanse | undefined;
@@ -16,7 +18,6 @@ export const FaktaFraSøknad = ({
   terminbekreftelseDokument,
 }: Props) => {
   const intl = useIntl();
-  const barnet = barn[0];
   return (
     <FaktaBoks tittel={intl.formatMessage({ id: 'FaktaFraSøknad.Tittel' })}>
       <VStack gap="space-16">
@@ -35,13 +36,31 @@ export const FaktaFraSøknad = ({
           />
         )}
 
-        {barnet && (
-          <LabeledValue
-            size="medium"
-            label={<FormattedMessage id="Label.Fødselsdato" />}
-            value={<DateLabel dateString={barnet.fødselsdato} />}
-          />
+        {barn.length === 1 && (
+          <>
+            <LabeledValue
+              size="medium"
+              label={<FormattedMessage id="Label.Fødselsdato" />}
+              value={<DateLabel dateString={barn[0]!.fødselsdato} />}
+            />
+            {barn[0]!.dødsdato && (
+              <LabeledValue
+                size="medium"
+                label={<FormattedMessage id="Label.Dødsdato" />}
+                value={<DateLabel dateString={barn[0]!.dødsdato} />}
+              />
+            )}
+          </>
         )}
+        {barn.length > 1 &&
+          barn.map((barnet, index) => (
+            <LabeledValue
+              key={`${barnet.barnNummer ?? index}-${barnet.fødselsdato}-${barnet.dødsdato ?? ''}`}
+              size="medium"
+              label={intl.formatMessage({ id: 'Label.NummerertBarn' }, { nummer: index + 1 })}
+              value={formaterLiv(barnet)}
+            />
+          ))}
         {antallBarn && (
           <LabeledValue size="medium" label={<FormattedMessage id="Label.AntallBarn" />} value={antallBarn} />
         )}

--- a/packages/fakta/fodsel/src/components/fakta/FaktaFraSøknad.tsx
+++ b/packages/fakta/fodsel/src/components/fakta/FaktaFraSøknad.tsx
@@ -6,8 +6,6 @@ import { DateLabel, FaktaBoks, LabeledValue } from '@navikt/ft-ui-komponenter';
 import type { FødselSøknad } from '@navikt/fp-types';
 import { DokumentLink, type DokumentLinkReferanse } from '@navikt/fp-ui-komponenter';
 
-import { formaterLiv } from './barnUtils';
-
 interface Props {
   søknad: FødselSøknad;
   terminbekreftelseDokument: DokumentLinkReferanse | undefined;
@@ -18,6 +16,7 @@ export const FaktaFraSøknad = ({
   terminbekreftelseDokument,
 }: Props) => {
   const intl = useIntl();
+  const barnet = barn[0];
   return (
     <FaktaBoks tittel={intl.formatMessage({ id: 'FaktaFraSøknad.Tittel' })}>
       <VStack gap="space-16">
@@ -36,31 +35,13 @@ export const FaktaFraSøknad = ({
           />
         )}
 
-        {barn.length === 1 && (
-          <>
-            <LabeledValue
-              size="medium"
-              label={<FormattedMessage id="Label.Fødselsdato" />}
-              value={<DateLabel dateString={barn[0]!.fødselsdato} />}
-            />
-            {barn[0]!.dødsdato && (
-              <LabeledValue
-                size="medium"
-                label={<FormattedMessage id="Label.Dødsdato" />}
-                value={<DateLabel dateString={barn[0]!.dødsdato} />}
-              />
-            )}
-          </>
+        {barnet && (
+          <LabeledValue
+            size="medium"
+            label={<FormattedMessage id="Label.Fødselsdato" />}
+            value={<DateLabel dateString={barnet.fødselsdato} />}
+          />
         )}
-        {barn.length > 1 &&
-          barn.map((barnet, index) => (
-            <LabeledValue
-              key={`${barnet.barnNummer ?? index}-${barnet.fødselsdato}-${barnet.dødsdato ?? ''}`}
-              size="medium"
-              label={intl.formatMessage({ id: 'Label.NummerertBarn' }, { nummer: index + 1 })}
-              value={formaterLiv(barnet)}
-            />
-          ))}
         {antallBarn && (
           <LabeledValue size="medium" label={<FormattedMessage id="Label.AntallBarn" />} value={antallBarn} />
         )}

--- a/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
+++ b/packages/fakta/fodsel/src/components/form/BarnFieldArray.tsx
@@ -12,7 +12,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { BodyShort, Detail, ErrorMessage, HelpText, HStack, Table, VStack } from '@navikt/ds-react';
 import { RhfDatepicker, RhfFieldArrayAppendButton, RhfFieldArrayRemoveButton } from '@navikt/ft-form-hooks';
 import { dateAfterOrEqual, dateBeforeOrEqualToToday, hasValidDate, required } from '@navikt/ft-form-validators';
-import { ISO_DATE_FORMAT } from '@navikt/ft-utils';
 import dayjs from 'dayjs';
 
 import { type FaktaKilde, getLabelForFaktaKilde } from '@navikt/fp-fakta-felles';
@@ -237,12 +236,12 @@ const validateAlleFødselsdatoer = (
     return false;
   }
 
-  if (minDate) {
-    const avvikFeil = fødselErINærhetenAvTermin(minDate.format(ISO_DATE_FORMAT), termindato);
-    if (avvikFeil) {
-      setError(FIELD_ARRAY_NAME, { type: 'manual', message: avvikFeil });
-      return false;
-    }
+  const avvikFeil = barn
+    .map(({ fødselsdato }) => fødselErINærhetenAvTermin(fødselsdato, termindato))
+    .find(feilmelding => !!feilmelding);
+  if (avvikFeil) {
+    setError(FIELD_ARRAY_NAME, { type: 'manual', message: avvikFeil });
+    return false;
   }
 
   clearErrors(FIELD_ARRAY_NAME);

--- a/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
+++ b/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
@@ -2,6 +2,8 @@ import { composeStories } from '@storybook/react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { notEmpty } from '@navikt/fp-utils';
+
 import * as stories from './InntektsmeldingFaktaIndex.stories';
 
 const { InntektsmeldingDefault } = composeStories(stories);
@@ -23,8 +25,9 @@ describe('InntektsmeldingFaktaIndex', () => {
     await verifiserKolonneSortering('Behandling', 4, ['Andre', 'Denne', 'Ingen']);
   });
 
+  // eslint-disable-next-line vitest/expect-expect -- assertes i hjelpefunksjon
   it('skal beholde rekkefølgen når flere startdatoer mangler', async () => {
-    const inntektsmeldinger = InntektsmeldingDefault.args.inntektsmeldinger!;
+    const inntektsmeldinger = notEmpty(InntektsmeldingDefault.args.inntektsmeldinger);
     render(
       <InntektsmeldingDefault
         inntektsmeldinger={[
@@ -53,7 +56,7 @@ describe('InntektsmeldingFaktaIndex', () => {
   });
 
   it('skal vise ingen bortfalte naturalytelser når aktive perioder ikke gir et bortfall', async () => {
-    const inntektsmeldinger = InntektsmeldingDefault.args.inntektsmeldinger!;
+    const inntektsmeldinger = notEmpty(InntektsmeldingDefault.args.inntektsmeldinger);
     render(
       <InntektsmeldingDefault
         inntektsmeldinger={[

--- a/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
+++ b/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
@@ -22,6 +22,66 @@ describe('InntektsmeldingFaktaIndex', () => {
     await verifiserKolonneSortering('Månedsi.', 3, ['10 001', '20 000', '30 000']);
     await verifiserKolonneSortering('Behandling', 4, ['Andre', 'Denne', 'Ingen']);
   });
+
+  it('skal beholde rekkefølgen når flere startdatoer mangler', async () => {
+    render(
+      <InntektsmeldingDefault
+        inntektsmeldinger={[
+          {
+            ...InntektsmeldingDefault.args.inntektsmeldinger[0],
+            arbeidsgiverIdent: '2',
+            startDatoPermisjon: undefined,
+          },
+          {
+            ...InntektsmeldingDefault.args.inntektsmeldinger[1],
+            arbeidsgiverIdent: '3',
+            startDatoPermisjon: undefined,
+          },
+          {
+            ...InntektsmeldingDefault.args.inntektsmeldinger[2],
+            arbeidsgiverIdent: '1',
+            startDatoPermisjon: '2024-11-11',
+          },
+        ]}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Startdato' }));
+
+    assertSortedColumn(1, ['Kiwi', 'Meny', 'Rema 1000']);
+  });
+
+  it('skal vise ingen bortfalte naturalytelser når aktive perioder ikke gir et bortfall', async () => {
+    render(
+      <InntektsmeldingDefault
+        inntektsmeldinger={[
+          {
+            ...InntektsmeldingDefault.args.inntektsmeldinger[0],
+            aktiveNaturalytelser: [
+              {
+                periode: { fomDato: '0001-01-01', tomDato: '2024-10-09' },
+                type: 'ELEKTRISK_KOMMUNIKASJON',
+                beløpPerMnd: { verdi: 999 },
+                indexKey: '1',
+              },
+              {
+                periode: { fomDato: '2024-10-10', tomDato: '9999-12-31' },
+                type: 'ELEKTRISK_KOMMUNIKASJON',
+                beløpPerMnd: { verdi: 999 },
+                indexKey: '2',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByText('Rema 1000'));
+
+    const blokk = screen.getByText('Naturalytelser som faller bort').parentElement;
+    expect(blokk).not.toBeNull();
+    expect(blokk).toHaveTextContent('Ingen');
+  });
 });
 
 const verifiserKolonneSortering = async (headerNavn: string, kolonneIndex: number, forventetSortering: string[]) => {

--- a/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
+++ b/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.spec.tsx
@@ -24,21 +24,22 @@ describe('InntektsmeldingFaktaIndex', () => {
   });
 
   it('skal beholde rekkefølgen når flere startdatoer mangler', async () => {
+    const inntektsmeldinger = InntektsmeldingDefault.args.inntektsmeldinger!;
     render(
       <InntektsmeldingDefault
         inntektsmeldinger={[
           {
-            ...InntektsmeldingDefault.args.inntektsmeldinger[0],
+            ...inntektsmeldinger[0]!,
             arbeidsgiverIdent: '2',
             startDatoPermisjon: undefined,
           },
           {
-            ...InntektsmeldingDefault.args.inntektsmeldinger[1],
+            ...inntektsmeldinger[1]!,
             arbeidsgiverIdent: '3',
             startDatoPermisjon: undefined,
           },
           {
-            ...InntektsmeldingDefault.args.inntektsmeldinger[2],
+            ...inntektsmeldinger[2]!,
             arbeidsgiverIdent: '1',
             startDatoPermisjon: '2024-11-11',
           },
@@ -52,11 +53,12 @@ describe('InntektsmeldingFaktaIndex', () => {
   });
 
   it('skal vise ingen bortfalte naturalytelser når aktive perioder ikke gir et bortfall', async () => {
+    const inntektsmeldinger = InntektsmeldingDefault.args.inntektsmeldinger!;
     render(
       <InntektsmeldingDefault
         inntektsmeldinger={[
           {
-            ...InntektsmeldingDefault.args.inntektsmeldinger[0],
+            ...inntektsmeldinger[0]!,
             aktiveNaturalytelser: [
               {
                 periode: { fomDato: '0001-01-01', tomDato: '2024-10-09' },

--- a/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.tsx
+++ b/packages/fakta/inntektsmelding/src/InntektsmeldingFaktaIndex.tsx
@@ -181,6 +181,9 @@ const sorterInntektsmeldinger = ({
 };
 
 const sorterStreng = (a: string | undefined | number, b: string | undefined | number) => {
+  if (a === b) {
+    return 0;
+  }
   if (a === undefined) {
     return -1;
   }

--- a/packages/fakta/inntektsmelding/src/components/BortfalteNaturalYtelser.tsx
+++ b/packages/fakta/inntektsmelding/src/components/BortfalteNaturalYtelser.tsx
@@ -47,9 +47,14 @@ const konverterAktivePerioderTilBortfaltePerioder = (inntektsmelding: Inntektsme
 
       const nyFom = current.periode.tomDato;
 
-      const nyTom = next?.periode.fomDato;
-
       if (nyFom === TIDENES_ENDE) {
+        return [];
+      }
+
+      const fomDato = addDaysToDate(nyFom, 1);
+      const tomDato = next?.periode.fomDato ? addDaysToDate(next.periode.fomDato, -1) : TIDENES_ENDE;
+
+      if (tomDato !== TIDENES_ENDE && fomDato > tomDato) {
         return [];
       }
 
@@ -57,8 +62,8 @@ const konverterAktivePerioderTilBortfaltePerioder = (inntektsmelding: Inntektsme
         {
           ...current,
           periode: {
-            fomDato: addDaysToDate(nyFom, 1),
-            tomDato: nyTom ? addDaysToDate(nyTom, -1) : TIDENES_ENDE,
+            fomDato,
+            tomDato,
           },
         },
       ];
@@ -78,17 +83,18 @@ export const BortfalteNaturalYtelser = ({
   const intl = useIntl();
 
   const bortfalteNaturalytelser = konverterAktivePerioderTilBortfaltePerioder(inntektsmelding);
+  const bortfalteNaturalytelserEntries = Object.entries(bortfalteNaturalytelser).filter(([, value]) => value.length > 0);
   return (
     <InntektsmeldingInfoBlokk
       tittel={intl.formatMessage({ id: 'InntektsmeldingFaktaPanel.bortfalteNaturalytelser.heading' })}
     >
-      {inntektsmelding.aktiveNaturalytelser.length === 0 ? (
+      {bortfalteNaturalytelserEntries.length === 0 ? (
         <span>
           <FormattedMessage id="InntektsmeldingFaktaPanel.bortfalteNaturalytelser.ingen" />
         </span>
       ) : (
         <VStack gap="space-4">
-          {Object.entries(bortfalteNaturalytelser).map(([key, value]) => (
+          {bortfalteNaturalytelserEntries.map(([key, value]) => (
             <div key={key}>
               <span>{alleKodeverk['NaturalYtelseType'].find(kodeverk => kodeverk.kode === key)?.navn}</span>
               <ul>

--- a/packages/fakta/medlemskap/src/MedlemskapFaktaIndex.spec.tsx
+++ b/packages/fakta/medlemskap/src/MedlemskapFaktaIndex.spec.tsx
@@ -1,11 +1,13 @@
 import { composeStories } from '@storybook/react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
+import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+
 import * as stories from './MedlemskapFaktaIndex.stories';
 
-const { Default } = composeStories(stories);
+const { Default, ForutgåendeMedlemskap } = composeStories(stories);
 
 describe('MedlemskapFaktaIndex', () => {
   it('skal vise medlemspanel med aksjonspunkt', async () => {
@@ -186,5 +188,29 @@ describe('MedlemskapFaktaIndex', () => {
 
     expect(screen.getByText('Begrunn endringene')).toBeInTheDocument();
     expect(screen.getByText('Bekreft og fortsett')).toBeInTheDocument();
+  });
+
+  it('skal ikke sende medlemFom når vurderingen endres til oppfylt', async () => {
+    const submitCallback = vi.fn(() => Promise.resolve());
+
+    render(<ForutgåendeMedlemskap submitCallback={submitCallback} />);
+
+    await userEvent.click(screen.getByLabelText('Ikke oppfylt'));
+    await userEvent.selectOptions(screen.getByLabelText('Avslagsårsak'), '1052');
+    await userEvent.type(screen.getByLabelText('Innflyttingsdato'), '01.01.2024');
+    await userEvent.click(screen.getByLabelText('Oppfylt'));
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    await waitFor(() =>
+      expect(submitCallback).toHaveBeenCalledWith({
+        kode: AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR,
+        avslagskode: undefined,
+        opphørFom: undefined,
+        medlemFom: undefined,
+        begrunnelse: 'Dette er en begrunnelse',
+      }),
+    );
   });
 });

--- a/packages/fakta/medlemskap/src/components/aksjonspunkt/MedlemskapVurderinger.tsx
+++ b/packages/fakta/medlemskap/src/components/aksjonspunkt/MedlemskapVurderinger.tsx
@@ -124,8 +124,16 @@ MedlemskapVurderinger.initialValues = (
   return {};
 };
 
-MedlemskapVurderinger.transformValues = (values: MedlemskapVurderingerFormValues) => ({
+MedlemskapVurderinger.transformValues = (
+  values: MedlemskapVurderingerFormValues,
+  erForutgående: boolean,
+) => ({
   avslagskode: values.vurdering === MedlemskapVurdering.OPPFYLT ? undefined : values.avslagskode,
   opphørFom: values.vurdering === MedlemskapVurdering.DELVIS_OPPFYLT ? values.opphørFom : undefined,
-  medlemFom: values.avslagskode === SØKER_INNFLYTTET_FOR_SENT_KODE ? values.medlemFom : undefined,
+  medlemFom:
+    erForutgående &&
+    values.vurdering === MedlemskapVurdering.IKKE_OPPFYLT &&
+    values.avslagskode === SØKER_INNFLYTTET_FOR_SENT_KODE
+      ? values.medlemFom
+      : undefined,
 });

--- a/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
+++ b/packages/fakta/medlemskap/src/components/aksjonspunkt/VurderMedlemskapAksjonspunktForm.tsx
@@ -113,6 +113,6 @@ const transformValues = (
   kode: erForutgåendeAksjonspunkt
     ? AksjonspunktKode.VURDER_FORUTGÅENDE_MEDLEMSKAPSVILKÅR
     : AksjonspunktKode.VURDER_MEDLEMSKAPSVILKÅRET,
-  ...MedlemskapVurderinger.transformValues(values),
+  ...MedlemskapVurderinger.transformValues(values, erForutgåendeAksjonspunkt),
   ...FaktaBegrunnelseTextField.transformValues(values),
 });

--- a/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.spec.ts
+++ b/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.spec.ts
@@ -38,6 +38,24 @@ describe('situasjonUtils', () => {
       };
       expect(getSisteRegion(medlemskap, kodeverk, intl)).toBe('EU/EØS');
     });
+
+    it('skal ikke endre rekkefølgen på regioner som sendes inn', () => {
+      const regioner = [
+        { fom: '2022-06-02', tom: '2025-02-01', type: 'ANNET' },
+        { fom: '2022-07-01', tom: '2025-02-01', type: 'EOS' },
+      ];
+      const medlemskap: Medlemskap = {
+        ...defaultMedlemskapProps,
+        regioner,
+      };
+
+      getSisteRegion(medlemskap, kodeverk, intl);
+
+      expect(regioner).toEqual([
+        { fom: '2022-06-02', tom: '2025-02-01', type: 'ANNET' },
+        { fom: '2022-07-01', tom: '2025-02-01', type: 'EOS' },
+      ]);
+    });
   });
 
   describe('getSistePersonstatus', () => {
@@ -50,6 +68,24 @@ describe('situasjonUtils', () => {
         ],
       };
       expect(getSistePersonstatus(medlemskap, kodeverk, intl)).toBe('Utflyttet');
+    });
+
+    it('skal ikke endre rekkefølgen på personstatuser som sendes inn', () => {
+      const personstatuser = [
+        { fom: '2022-06-02', tom: '2025-02-01', type: 'DØD' },
+        { fom: '2022-07-01', tom: '2025-02-01', type: 'UTVA' },
+      ];
+      const medlemskap: Medlemskap = {
+        ...defaultMedlemskapProps,
+        personstatuser,
+      };
+
+      getSistePersonstatus(medlemskap, kodeverk, intl);
+
+      expect(personstatuser).toEqual([
+        { fom: '2022-06-02', tom: '2025-02-01', type: 'DØD' },
+        { fom: '2022-07-01', tom: '2025-02-01', type: 'UTVA' },
+      ]);
     });
   });
 

--- a/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.spec.ts
+++ b/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.spec.ts
@@ -40,7 +40,7 @@ describe('situasjonUtils', () => {
     });
 
     it('skal ikke endre rekkefølgen på regioner som sendes inn', () => {
-      const regioner = [
+      const regioner: Medlemskap['regioner'] = [
         { fom: '2022-06-02', tom: '2025-02-01', type: 'ANNET' },
         { fom: '2022-07-01', tom: '2025-02-01', type: 'EOS' },
       ];
@@ -71,7 +71,7 @@ describe('situasjonUtils', () => {
     });
 
     it('skal ikke endre rekkefølgen på personstatuser som sendes inn', () => {
-      const personstatuser = [
+      const personstatuser: Medlemskap['personstatuser'] = [
         { fom: '2022-06-02', tom: '2025-02-01', type: 'DØD' },
         { fom: '2022-07-01', tom: '2025-02-01', type: 'UTVA' },
       ];

--- a/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.ts
+++ b/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.ts
@@ -7,12 +7,12 @@ import { toTitleCapitalization } from '../../utils/stringUtils';
 
 export const getSisteRegion = (medlemskap: Medlemskap, alleKodeverk: AlleKodeverk, intl: IntlShape): string => {
   const alleRegioner = alleKodeverk['Region'];
-  const nyesteRegion = medlemskap.regioner.sort(sorterPerioder).at(0);
+  const nyesteRegion = [...medlemskap.regioner].sort(sorterPerioder).at(0);
   return alleRegioner.find(r => r.kode === nyesteRegion?.type)?.navn ?? intl.formatMessage({ id: 'Situasjon.Ukjent' });
 };
 
 export const getSistePersonstatus = (medlemskap: Medlemskap, alleKodeverk: AlleKodeverk, intl: IntlShape): string => {
-  const nyeste = medlemskap.personstatuser.sort(sorterPerioder).at(0);
+  const nyeste = [...medlemskap.personstatuser].sort(sorterPerioder).at(0);
   if (nyeste) {
     return alleKodeverk['PersonstatusType'].find(type => type.kode === nyeste.type)?.navn ?? '';
   }

--- a/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.ts
+++ b/packages/fakta/medlemskap/src/components/situasjon/situasjonUtils.ts
@@ -7,12 +7,12 @@ import { toTitleCapitalization } from '../../utils/stringUtils';
 
 export const getSisteRegion = (medlemskap: Medlemskap, alleKodeverk: AlleKodeverk, intl: IntlShape): string => {
   const alleRegioner = alleKodeverk['Region'];
-  const nyesteRegion = [...medlemskap.regioner].sort(sorterPerioder).at(0);
+  const nyesteRegion = medlemskap.regioner.toSorted(sorterPerioder).at(0);
   return alleRegioner.find(r => r.kode === nyesteRegion?.type)?.navn ?? intl.formatMessage({ id: 'Situasjon.Ukjent' });
 };
 
 export const getSistePersonstatus = (medlemskap: Medlemskap, alleKodeverk: AlleKodeverk, intl: IntlShape): string => {
-  const nyeste = [...medlemskap.personstatuser].sort(sorterPerioder).at(0);
+  const nyeste = medlemskap.personstatuser.toSorted(sorterPerioder).at(0);
   if (nyeste) {
     return alleKodeverk['PersonstatusType'].find(type => type.kode === nyeste.type)?.navn ?? '';
   }

--- a/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
@@ -5,6 +5,7 @@ import { expect } from 'vitest';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { lagAksjonspunkt } from '@navikt/fp-storybook-utils';
+import type { OmsorgOgRett } from '@navikt/fp-types';
 
 import * as stories from './OmsorgOgRettFaktaIndex.stories';
 
@@ -240,8 +241,15 @@ describe('OmsorgOgRettFaktaIndex', () => {
 
   it('skal ikke sende skjulte felter videre når søker endrer til aleneomsorg', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
+    const omsorgOgRett = HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett!;
 
-    render(<HarAksjonspunktForAvklarAleneomsorg submitCallback={lagreVurdering} />);
+    // relasjonsRolleType må vera ulik MORA for at "Mottar annen forelder uføretrygd"-feltet skal visast.
+    render(
+      <HarAksjonspunktForAvklarAleneomsorg
+        submitCallback={lagreVurdering}
+        omsorgOgRett={{ ...omsorgOgRett, relasjonsRolleType: 'FARA' }}
+      />,
+    );
 
     await userEvent.click(await screen.findByLabelText('Søker har ikke aleneomsorg for barnet'));
 
@@ -302,7 +310,9 @@ describe('OmsorgOgRettFaktaIndex', () => {
     );
     await userEvent.click(uforetrygdGruppe.getByLabelText('Ja'));
 
-    await userEvent.click(harRettGruppe.getByLabelText('Ja'));
+    // "Ja" finnes no fleire stader (i nøsta radiogrupper), så vi må vera meir presise enn
+    // harRettGruppe (som via `within` også omfattar dei nøsta radiogruppene).
+    await userEvent.click(harRettGruppe.getAllByLabelText('Ja')[0]!);
     await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
 
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
@@ -325,13 +335,14 @@ describe('OmsorgOgRettFaktaIndex', () => {
           ...omsorgOgRett,
           søknad: {
             ...omsorgOgRett.søknad,
-            annenpartBostedsland: 'XXX',
+            // "XXX" finnes i kodeverket (Statsløs) - bruk ein oppdikta kode som ikkje finnes.
+            annenpartBostedsland: 'IKKE_I_KODEVERKET' as OmsorgOgRett['søknad']['annenpartBostedsland'],
           },
         }}
       />,
     );
 
-    expect(await screen.findByText('XXX')).toBeInTheDocument();
+    expect(await screen.findByText('IKKE_I_KODEVERKET')).toBeInTheDocument();
   });
 
   it('skal bruke riktig aksjonspunktbegrunnelse for hvert skjema når begge aksjonspunkt finnes', async () => {
@@ -364,7 +375,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
       />,
     );
 
-    expect(await screen.findByDisplayValue('Begrunnelse for aleneomsorg')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('Begrunnelse for annen forelder')).toBeInTheDocument();
+    expect(await screen.findByText('Begrunnelse for aleneomsorg')).toBeInTheDocument();
+    expect(screen.getByText('Begrunnelse for annen forelder')).toBeInTheDocument();
   });
 });

--- a/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
@@ -318,12 +318,13 @@ describe('OmsorgOgRettFaktaIndex', () => {
   });
 
   it('skal vise rå landkode når bostedsland ikke finnes i kodeverket', async () => {
+    const omsorgOgRett = HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett!;
     render(
       <HarAksjonspunktForAvklarAnnenForelderRett
         omsorgOgRett={{
-          ...HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett,
+          ...omsorgOgRett,
           søknad: {
-            ...HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett.søknad,
+            ...omsorgOgRett.søknad,
             annenpartBostedsland: 'XXX',
           },
         }}
@@ -334,6 +335,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   });
 
   it('skal bruke riktig aksjonspunktbegrunnelse for hvert skjema når begge aksjonspunkt finnes', async () => {
+    const omsorgOgRett = HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett!;
     render(
       <HarAksjonspunktForAvklarAleneomsorg
         isReadOnly
@@ -348,7 +350,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
           }),
         ]}
         omsorgOgRett={{
-          ...HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett,
+          ...omsorgOgRett,
           manuellBehandlingResultat: {
             søkerHarAleneomsorg: 'NEI',
             annenpartRettighet: {

--- a/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
@@ -6,6 +6,7 @@ import { expect } from 'vitest';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
 import { lagAksjonspunkt } from '@navikt/fp-storybook-utils';
 import type { OmsorgOgRett } from '@navikt/fp-types';
+import { notEmpty } from '@navikt/fp-utils';
 
 import * as stories from './OmsorgOgRettFaktaIndex.stories';
 
@@ -241,7 +242,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
 
   it('skal ikke sende skjulte felter videre når søker endrer til aleneomsorg', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
-    const omsorgOgRett = HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett!;
+    const omsorgOgRett = notEmpty(HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett);
 
     // relasjonsRolleType må vera ulik MORA for at "Mottar annen forelder uføretrygd"-feltet skal visast.
     render(
@@ -328,7 +329,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   });
 
   it('skal vise rå landkode når bostedsland ikke finnes i kodeverket', async () => {
-    const omsorgOgRett = HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett!;
+    const omsorgOgRett = notEmpty(HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett);
     render(
       <HarAksjonspunktForAvklarAnnenForelderRett
         omsorgOgRett={{
@@ -346,7 +347,7 @@ describe('OmsorgOgRettFaktaIndex', () => {
   });
 
   it('skal bruke riktig aksjonspunktbegrunnelse for hvert skjema når begge aksjonspunkt finnes', async () => {
-    const omsorgOgRett = HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett!;
+    const omsorgOgRett = notEmpty(HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett);
     render(
       <HarAksjonspunktForAvklarAleneomsorg
         isReadOnly

--- a/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorg-og-rett/src/OmsorgOgRettFaktaIndex.spec.tsx
@@ -1,7 +1,10 @@
 import { composeStories } from '@storybook/react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'vitest';
+
+import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import { lagAksjonspunkt } from '@navikt/fp-storybook-utils';
 
 import * as stories from './OmsorgOgRettFaktaIndex.stories';
 
@@ -233,5 +236,133 @@ describe('OmsorgOgRettFaktaIndex', () => {
       begrunnelse: 'Dette er en begrunnelse',
       rettighetstype: 'BEGGE_RETT',
     });
+  });
+
+  it('skal ikke sende skjulte felter videre når søker endrer til aleneomsorg', async () => {
+    const lagreVurdering = vi.fn(() => Promise.resolve());
+
+    render(<HarAksjonspunktForAvklarAleneomsorg submitCallback={lagreVurdering} />);
+
+    await userEvent.click(await screen.findByLabelText('Søker har ikke aleneomsorg for barnet'));
+
+    const harRettGruppe = within(screen.getByRole('radiogroup', { name: 'Har annen forelder rett til foreldrepenger i Norge?' }));
+    await userEvent.click(harRettGruppe.getByLabelText('Nei'));
+
+    const harRettEosGruppe = within(
+      screen.getByRole('radiogroup', {
+        name: 'Har annen forelder mottatt pengestøtte tilsvarende foreldrepenger fra land i EØS?',
+      }),
+    );
+    await userEvent.click(harRettEosGruppe.getByLabelText('Nei'));
+
+    const uforetrygdGruppe = within(
+      screen.getByRole('radiogroup', {
+        name: 'Mottar annen forelder uføretrygd, jf. § 14-14 tredje ledd?',
+      }),
+    );
+    await userEvent.click(uforetrygdGruppe.getByLabelText('Ja'));
+
+    await userEvent.click(screen.getByLabelText('Søker har aleneomsorg for barnet'));
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    await waitFor(() => expect(lagreVurdering).toHaveBeenCalledTimes(1));
+    expect(lagreVurdering).toHaveBeenNthCalledWith(1, {
+      kode: '5060',
+      begrunnelse: 'Dette er en begrunnelse',
+      aleneomsorg: true,
+      annenforelderHarRett: undefined,
+      annenForelderHarRettEØS: undefined,
+      annenforelderMottarUføretrygd: undefined,
+    });
+  });
+
+  it('skal ikke sende skjulte felter videre når annen forelder har rett i Norge', async () => {
+    const lagreVurdering = vi.fn(() => Promise.resolve());
+
+    render(<HarAksjonspunktForAvklarAnnenForelderRett submitCallback={lagreVurdering} />);
+
+    expect(await screen.findByText('Vurder om den andre forelderen har rett til foreldrepenger.')).toBeInTheDocument();
+
+    const harRettGruppe = within(screen.getByRole('radiogroup', { name: 'Har annen forelder rett til foreldrepenger i Norge?' }));
+    await userEvent.click(harRettGruppe.getByLabelText('Nei'));
+
+    const harRettEosGruppe = within(
+      screen.getByRole('radiogroup', {
+        name: 'Har annen forelder mottatt pengestøtte tilsvarende foreldrepenger fra land i EØS?',
+      }),
+    );
+    await userEvent.click(harRettEosGruppe.getByLabelText('Nei'));
+
+    const uforetrygdGruppe = within(
+      screen.getByRole('radiogroup', {
+        name: 'Mottar annen forelder uføretrygd, jf. § 14-14 tredje ledd?',
+      }),
+    );
+    await userEvent.click(uforetrygdGruppe.getByLabelText('Ja'));
+
+    await userEvent.click(harRettGruppe.getByLabelText('Ja'));
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    await waitFor(() => expect(lagreVurdering).toHaveBeenCalledTimes(1));
+    expect(lagreVurdering).toHaveBeenNthCalledWith(1, {
+      kode: '5086',
+      begrunnelse: 'Dette er en begrunnelse',
+      annenforelderHarRett: true,
+      annenForelderHarRettEØS: undefined,
+      annenforelderMottarUføretrygd: undefined,
+    });
+  });
+
+  it('skal vise rå landkode når bostedsland ikke finnes i kodeverket', async () => {
+    render(
+      <HarAksjonspunktForAvklarAnnenForelderRett
+        omsorgOgRett={{
+          ...HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett,
+          søknad: {
+            ...HarAksjonspunktForAvklarAnnenForelderRett.args.omsorgOgRett.søknad,
+            annenpartBostedsland: 'XXX',
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('XXX')).toBeInTheDocument();
+  });
+
+  it('skal bruke riktig aksjonspunktbegrunnelse for hvert skjema når begge aksjonspunkt finnes', async () => {
+    render(
+      <HarAksjonspunktForAvklarAleneomsorg
+        isReadOnly
+        aksjonspunkterForPanel={[
+          lagAksjonspunkt(AksjonspunktKode.MANUELL_KONTROLL_AV_OM_BRUKER_HAR_ALENEOMSORG, {
+            status: 'UTFO',
+            begrunnelse: 'Begrunnelse for aleneomsorg',
+          }),
+          lagAksjonspunkt(AksjonspunktKode.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT, {
+            status: 'UTFO',
+            begrunnelse: 'Begrunnelse for annen forelder',
+          }),
+        ]}
+        omsorgOgRett={{
+          ...HarAksjonspunktForAvklarAleneomsorg.args.omsorgOgRett,
+          manuellBehandlingResultat: {
+            søkerHarAleneomsorg: 'NEI',
+            annenpartRettighet: {
+              harRettNorge: 'NEI',
+              harOppholdEØS: 'IKKE_RELEVANT',
+              harRettEØS: 'NEI',
+              harUføretrygd: 'JA',
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByDisplayValue('Begrunnelse for aleneomsorg')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Begrunnelse for annen forelder')).toBeInTheDocument();
   });
 });

--- a/packages/fakta/omsorg-og-rett/src/components/OmsorgOgRettInfoPanel.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/OmsorgOgRettInfoPanel.tsx
@@ -47,6 +47,12 @@ export const OmsorgOgRettInfoPanel = ({ personoversikt, omsorgOgRett, kanOversty
   const harAleneomsorgAp = aksjonspunkter.some(
     a => a.definisjon === AksjonspunktKode.MANUELL_KONTROLL_AV_OM_BRUKER_HAR_ALENEOMSORG,
   );
+  const aleneomsorgAksjonspunkt = aksjonspunkter.find(
+    a => a.definisjon === AksjonspunktKode.MANUELL_KONTROLL_AV_OM_BRUKER_HAR_ALENEOMSORG,
+  );
+  const rettAksjonspunkt = aksjonspunkter.find(
+    a => a.definisjon === AksjonspunktKode.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT,
+  );
   const resultatUtenAp = omsorgOgRett.manuellBehandlingResultat && !harRettAp && !harAleneomsorgAp;
 
   const søkerHarAleneomsorgResultat = omsorgOgRett.manuellBehandlingResultat?.søkerHarAleneomsorg ?? 'IKKE_RELEVANT';
@@ -77,13 +83,17 @@ export const OmsorgOgRettInfoPanel = ({ personoversikt, omsorgOgRett, kanOversty
       {personoversikt && <OpplysningerOmAdresser alleKodeverk={alleKodeverk} personoversikt={personoversikt} />}
       {omsorgOgRett.registerdata && <AnnenPartsYtelser omsorgOgRett={omsorgOgRett} />}
       {(opprettetAleneomsorgAPUtenResultat || aleneomsorgAPMedResultat) && (
-        <AleneomsorgForm omsorgOgRett={omsorgOgRett} aksjonspunkt={aksjonspunkter[0]} isSubmittable={isSubmittable} />
+        <AleneomsorgForm
+          omsorgOgRett={omsorgOgRett}
+          aksjonspunkt={aleneomsorgAksjonspunkt}
+          isSubmittable={isSubmittable}
+        />
       )}
       {(opprettetRettAPUtenResultat || rettAPMedResultat) && (
         <HarAnnenForelderRettForm
           omsorgOgRett={omsorgOgRett}
           isSubmittable={isSubmittable}
-          aksjonspunkt={aksjonspunkter[0]}
+          aksjonspunkt={rettAksjonspunkt}
         />
       )}
       {resultatUtenAp && søkerHarAleneomsorgResultat !== 'IKKE_RELEVANT' && (

--- a/packages/fakta/omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/AleneomsorgForm.tsx
@@ -42,6 +42,7 @@ export const AleneomsorgForm = ({ omsorgOgRett, aksjonspunkt, isSubmittable }: P
 
   const formMethods = useForm<FormValues>({
     defaultValues: mellomlagretFormData ?? buildInitialValues(omsorgOgRett, aksjonspunkt),
+    shouldUnregister: true,
   });
 
   const skalAvklareUforetrygd = omsorgOgRett.relasjonsRolleType !== 'MORA' || harUføretrygd === 'JA';

--- a/packages/fakta/omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
+++ b/packages/fakta/omsorg-og-rett/src/components/forms/HarAnnenForelderRettForm.tsx
@@ -34,6 +34,7 @@ export const HarAnnenForelderRettForm = ({ omsorgOgRett, aksjonspunkt, isSubmitt
 
   const formMethods = useForm<FormValues>({
     defaultValues: mellomlagretFormData ?? buildInitialValues(omsorgOgRett, aksjonspunkt),
+    shouldUnregister: true,
   });
 
   const skalAvklareUforetrygd = omsorgOgRett.relasjonsRolleType !== 'MORA' || harUføretrygd === 'JA';

--- a/packages/fakta/omsorg-og-rett/src/opplysningskort/OpplysningerFraSoknad.tsx
+++ b/packages/fakta/omsorg-og-rett/src/opplysningskort/OpplysningerFraSoknad.tsx
@@ -23,7 +23,7 @@ export const OpplysningerFraSoknad = ({ omsorgOgRett, alleKodeverk }: Props) => 
   const harSøkerAleneOmsorg = omsorgOgRett.søknad.søkerHarAleneomsorg;
   const { annenpartIdent, annenpartBostedsland } = omsorgOgRett.søknad;
   const bostedsland = alleKodeverk.Landkoder.find(land => land.kode === annenpartBostedsland)?.navn;
-  const formattedBostedsland = bostedsland
+  const formattedAnnenpartBostedsland = bostedsland
     ? capitalizeFirstLetter(bostedsland.toLowerCase())
     : annenpartBostedsland;
 
@@ -77,7 +77,7 @@ export const OpplysningerFraSoknad = ({ omsorgOgRett, alleKodeverk }: Props) => 
                   <BodyShort size="small">
                     <FormattedMessage
                       id="OpplysningerFraSøknad.Bostedsland.Svar"
-                      values={{ bostedsland: formattedBostedsland }}
+                      values={{ bostedsland: formattedAnnenpartBostedsland }}
                     />
                   </BodyShort>
                 </Table.DataCell>

--- a/packages/fakta/omsorg-og-rett/src/opplysningskort/OpplysningerFraSoknad.tsx
+++ b/packages/fakta/omsorg-og-rett/src/opplysningskort/OpplysningerFraSoknad.tsx
@@ -23,7 +23,9 @@ export const OpplysningerFraSoknad = ({ omsorgOgRett, alleKodeverk }: Props) => 
   const harSøkerAleneOmsorg = omsorgOgRett.søknad.søkerHarAleneomsorg;
   const { annenpartIdent, annenpartBostedsland } = omsorgOgRett.søknad;
   const bostedsland = alleKodeverk.Landkoder.find(land => land.kode === annenpartBostedsland)?.navn;
-  const formattedBostedsland = bostedsland ? capitalizeFirstLetter(bostedsland.toLowerCase()) : null;
+  const formattedBostedsland = bostedsland
+    ? capitalizeFirstLetter(bostedsland.toLowerCase())
+    : annenpartBostedsland;
 
   return (
     <EkspansjonsKort

--- a/packages/fakta/omsorgsovertakelse/src/OmsorgsovertakelseFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/OmsorgsovertakelseFaktaIndex.spec.tsx
@@ -98,17 +98,18 @@ describe('OmsorgsovertakelseFaktaIndex', () => {
   });
 
   it('skal vise raden for ektefelles barn når bare gjeldende opplysninger har verdien', () => {
+    const omsorgsovertakelse = EngangsstønadUtenAp.args.omsorgsovertakelse!;
     render(
       <EngangsstønadUtenAp
         omsorgsovertakelse={{
-          ...EngangsstønadUtenAp.args.omsorgsovertakelse,
+          ...omsorgsovertakelse,
           kildeGjeldende: 'SAKSBEHANDLER',
           søknad: {
-            ...EngangsstønadUtenAp.args.omsorgsovertakelse.søknad,
+            ...omsorgsovertakelse.søknad,
             erEktefellesBarn: undefined,
           },
           gjeldende: {
-            ...EngangsstønadUtenAp.args.omsorgsovertakelse.gjeldende,
+            ...omsorgsovertakelse.gjeldende,
             erEktefellesBarn: true,
           },
         }}
@@ -121,21 +122,19 @@ describe('OmsorgsovertakelseFaktaIndex', () => {
   });
 
   it('skal vise barn som bare finnes i gjeldende opplysninger som valgbart alternativ', async () => {
+    const omsorgsovertakelse = EngangsstønadMedAp.args.omsorgsovertakelse!;
     render(
       <EngangsstønadMedAp
         omsorgsovertakelse={{
-          ...EngangsstønadMedAp.args.omsorgsovertakelse,
+          ...omsorgsovertakelse,
           søknad: {
-            ...EngangsstønadMedAp.args.omsorgsovertakelse.søknad,
-            barn: [EngangsstønadMedAp.args.omsorgsovertakelse.søknad.barn[0]!],
+            ...omsorgsovertakelse.søknad,
+            barn: [omsorgsovertakelse.søknad.barn[0]!],
             antallBarn: 1,
           },
           gjeldende: {
-            ...EngangsstønadMedAp.args.omsorgsovertakelse.gjeldende,
-            barn: [
-              EngangsstønadMedAp.args.omsorgsovertakelse.gjeldende.barn[0]!,
-              EngangsstønadMedAp.args.omsorgsovertakelse.gjeldende.barn[1]!,
-            ],
+            ...omsorgsovertakelse.gjeldende,
+            barn: [omsorgsovertakelse.gjeldende.barn[0]!, omsorgsovertakelse.gjeldende.barn[1]!],
             antallBarn: 2,
           },
         }}

--- a/packages/fakta/omsorgsovertakelse/src/OmsorgsovertakelseFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/OmsorgsovertakelseFaktaIndex.spec.tsx
@@ -98,7 +98,7 @@ describe('OmsorgsovertakelseFaktaIndex', () => {
   });
 
   it('skal vise raden for ektefelles barn når bare gjeldende opplysninger har verdien', () => {
-    const omsorgsovertakelse = EngangsstønadUtenAp.args.omsorgsovertakelse!;
+    const omsorgsovertakelse = notEmpty(EngangsstønadUtenAp.args.omsorgsovertakelse);
     render(
       <EngangsstønadUtenAp
         omsorgsovertakelse={{
@@ -122,7 +122,7 @@ describe('OmsorgsovertakelseFaktaIndex', () => {
   });
 
   it('skal vise barn som bare finnes i gjeldende opplysninger som valgbart alternativ', async () => {
-    const omsorgsovertakelse = EngangsstønadMedAp.args.omsorgsovertakelse!;
+    const omsorgsovertakelse = notEmpty(EngangsstønadMedAp.args.omsorgsovertakelse);
     render(
       <EngangsstønadMedAp
         omsorgsovertakelse={{

--- a/packages/fakta/omsorgsovertakelse/src/OmsorgsovertakelseFaktaIndex.spec.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/OmsorgsovertakelseFaktaIndex.spec.tsx
@@ -96,6 +96,56 @@ describe('OmsorgsovertakelseFaktaIndex', () => {
       begrunnelse: 'Dette er en begrunnelse',
     });
   });
+
+  it('skal vise raden for ektefelles barn når bare gjeldende opplysninger har verdien', () => {
+    render(
+      <EngangsstønadUtenAp
+        omsorgsovertakelse={{
+          ...EngangsstønadUtenAp.args.omsorgsovertakelse,
+          kildeGjeldende: 'SAKSBEHANDLER',
+          søknad: {
+            ...EngangsstønadUtenAp.args.omsorgsovertakelse.søknad,
+            erEktefellesBarn: undefined,
+          },
+          gjeldende: {
+            ...EngangsstønadUtenAp.args.omsorgsovertakelse.gjeldende,
+            erEktefellesBarn: true,
+          },
+        }}
+      />,
+    );
+
+    const ektefellesBarnRad = withinRowWithLabel('Er det ektefelles barn?');
+    expect(ektefellesBarnRad.getByText('-')).toBeInTheDocument();
+    expect(ektefellesBarnRad.getByText('Ja')).toBeInTheDocument();
+  });
+
+  it('skal vise barn som bare finnes i gjeldende opplysninger som valgbart alternativ', async () => {
+    render(
+      <EngangsstønadMedAp
+        omsorgsovertakelse={{
+          ...EngangsstønadMedAp.args.omsorgsovertakelse,
+          søknad: {
+            ...EngangsstønadMedAp.args.omsorgsovertakelse.søknad,
+            barn: [EngangsstønadMedAp.args.omsorgsovertakelse.søknad.barn[0]!],
+            antallBarn: 1,
+          },
+          gjeldende: {
+            ...EngangsstønadMedAp.args.omsorgsovertakelse.gjeldende,
+            barn: [
+              EngangsstønadMedAp.args.omsorgsovertakelse.gjeldende.barn[0]!,
+              EngangsstønadMedAp.args.omsorgsovertakelse.gjeldende.barn[1]!,
+            ],
+            antallBarn: 2,
+          },
+        }}
+      />,
+    );
+
+    const apBoks = within(screen.getByLabelText('Vurder opplysningene om omsorgsovertakelse'));
+
+    expect(await apBoks.findByRole('checkbox', { name: 'Barn 2 født 09.10.2005Over 15 år' })).toBeChecked();
+  });
 });
 
 const withinRowWithLabel = (name: string) => {

--- a/packages/fakta/omsorgsovertakelse/src/components/FaktaSammenligning.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/components/FaktaSammenligning.tsx
@@ -13,6 +13,14 @@ interface Props {
   omsorgsovertakelse: OmsorgsovertakelseDto;
 }
 
+const renderJaNeiEllerTomt = (value?: boolean) => {
+  if (value === undefined) {
+    return '-';
+  }
+
+  return value ? <FormattedMessage id="Label.Ja" /> : <FormattedMessage id="Label.Nei" />;
+};
+
 export const FaktaSammenligning = ({ omsorgsovertakelse: { søknad, gjeldende, kildeGjeldende } }: Props) => {
   const intl = useIntl();
   const { alleKodeverk } = usePanelDataContext();
@@ -112,21 +120,15 @@ export const FaktaSammenligning = ({ omsorgsovertakelse: { søknad, gjeldende, k
               </Table.Row>
             );
           })}
-          {søknad.erEktefellesBarn !== undefined && (
+          {(søknad.erEktefellesBarn !== undefined || gjeldende.erEktefellesBarn !== undefined) && (
             <Table.Row shadeOnHover={false}>
               <Table.HeaderCell scope="row">
                 <FormattedMessage id="Label.ErEktefellesBarn" />
               </Table.HeaderCell>
-              <Table.DataCell>
-                {søknad.erEktefellesBarn ? <FormattedMessage id="Label.Ja" /> : <FormattedMessage id="Label.Nei" />}
-              </Table.DataCell>
+              <Table.DataCell>{renderJaNeiEllerTomt(søknad.erEktefellesBarn)}</Table.DataCell>
               {erIkkeFraSøknad && (
                 <Table.DataCell>
-                  {gjeldende.erEktefellesBarn ? (
-                    <FormattedMessage id="Label.Ja" />
-                  ) : (
-                    <FormattedMessage id="Label.Nei" />
-                  )}
+                  {renderJaNeiEllerTomt(gjeldende.erEktefellesBarn)}
                   <ErEndretMarkering første={søknad.erEktefellesBarn} andre={gjeldende.erEktefellesBarn} />
                 </Table.DataCell>
               )}

--- a/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
+++ b/packages/fakta/omsorgsovertakelse/src/components/VurderOmsorgsovertakelseVilkåretForm.tsx
@@ -268,9 +268,10 @@ const mapEktefellesBarn = (gjeldende: OmsorgsovertakelseDto['gjeldende']) => {
 };
 
 const mapBarn = (omsorgsovertakelse: OmsorgsovertakelseDto) => {
-  return omsorgsovertakelse.søknad.barn.map(søknadBarn => {
-    const identiskBarn = omsorgsovertakelse.gjeldende.barn.find(
-      gjeldendeBarn => gjeldendeBarn.barnNummer === søknadBarn.barnNummer,
+  const gjeldendeBarn = omsorgsovertakelse.gjeldende.barn;
+  const barnFraSøknad = omsorgsovertakelse.søknad.barn.map(søknadBarn => {
+    const identiskBarn = gjeldendeBarn.find(
+      gjeldendeBarnItem => gjeldendeBarnItem.barnNummer === søknadBarn.barnNummer,
     );
     return {
       fødselsdato: identiskBarn?.fødselsdato ?? søknadBarn.fødselsdato,
@@ -278,4 +279,16 @@ const mapBarn = (omsorgsovertakelse: OmsorgsovertakelseDto) => {
       skalBrukes: !!identiskBarn,
     };
   });
+
+  const barnKunIGjeldende = gjeldendeBarn
+    .filter(
+      gjeldendeBarnItem => !omsorgsovertakelse.søknad.barn.some(b => b.barnNummer === gjeldendeBarnItem.barnNummer),
+    )
+    .map(gjeldendeBarnItem => ({
+      fødselsdato: gjeldendeBarnItem.fødselsdato,
+      barnNummer: gjeldendeBarnItem.barnNummer,
+      skalBrukes: true,
+    }));
+
+  return [...barnFraSøknad, ...barnKunIGjeldende];
 };

--- a/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
+++ b/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
@@ -7,6 +7,27 @@ import * as stories from './OpptjeningFaktaIndex.stories';
 const { MedAksjonspunkt, UtenAksjonspunkt } = composeStories(stories);
 
 describe('OpptjeningFaktaIndex', () => {
+  it('skal rendre uten å krasje når skjæringstidspunkt mangler', async () => {
+    if (!stories.MedAksjonspunkt.args.opptjening?.fastsattOpptjening) {
+      throw new Error('Mangler opptjening-fixture for MedAksjonspunkt');
+    }
+
+    const opptjening = {
+      ...stories.MedAksjonspunkt.args.opptjening,
+      fastsattOpptjening: {
+        ...stories.MedAksjonspunkt.args.opptjening.fastsattOpptjening,
+        opptjeningTom: undefined,
+      },
+    };
+
+    render(<MedAksjonspunkt opptjening={opptjening} />);
+
+    expect(await screen.findByText('Vurder om aktivitetene kan godkjennes')).toBeInTheDocument();
+    expect(screen.getByText('Skjæringstidspunkt for opptjening')).toBeInTheDocument();
+    expect(screen.getByText('Detaljer for valgt aktivitet')).toBeInTheDocument();
+    expect(screen.queryByText('25.10.2019')).not.toBeInTheDocument();
+  });
+
   it('skal åpne aktivitet automatisk når det har åpent aksjonspunkt og så godkjenne det', async () => {
     const lagre = vi.fn(() => Promise.resolve());
     render(<MedAksjonspunkt submitCallback={lagre} />);
@@ -73,6 +94,43 @@ describe('OpptjeningFaktaIndex', () => {
         },
       ],
     });
+  });
+
+  it('skal nullstille bekreft-knappen når submit feiler så brukeren kan prøve igjen', async () => {
+    const førsteFeil = Promise.reject(new Error('Kunne ikke lagre opptjening'));
+    void førsteFeil.catch(() => undefined);
+
+    const lagre = vi
+      .fn()
+      .mockImplementationOnce(() => førsteFeil)
+      .mockImplementationOnce(() => Promise.resolve());
+
+    render(<MedAksjonspunkt submitCallback={lagre} />);
+
+    expect(await screen.findByText('Vurder om aktivitetene kan godkjennes')).toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByRole('radio')[0]!);
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.click(screen.getByText('Oppdater'));
+
+    expect(await screen.findAllByText('Sykepenger')).toHaveLength(2);
+
+    await userEvent.click(screen.getAllByRole('radio')[1]!);
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse 2');
+    await userEvent.click(screen.getByText('Oppdater'));
+
+    const bekreftKnapp = screen.getByText('Bekreft og fortsett').closest('button');
+
+    expect(bekreftKnapp).toBeEnabled();
+    await userEvent.click(bekreftKnapp!);
+    await userEvent.click(bekreftKnapp!);
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(bekreftKnapp).toBeEnabled());
+
+    await userEvent.click(bekreftKnapp!);
+
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(2));
   });
 
   it('skal bytte og så lukke aktiviteter ved hjelp av pil-ikoner', async () => {

--- a/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
+++ b/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
@@ -8,23 +8,10 @@ const { MedAksjonspunkt, UtenAksjonspunkt } = composeStories(stories);
 
 describe('OpptjeningFaktaIndex', () => {
   it('skal rendre uten å krasje når skjæringstidspunkt mangler', async () => {
-    if (!stories.MedAksjonspunkt.args.opptjening?.fastsattOpptjening) {
-      throw new Error('Mangler opptjening-fixture for MedAksjonspunkt');
-    }
-
-    const opptjening = {
-      ...stories.MedAksjonspunkt.args.opptjening,
-      fastsattOpptjening: {
-        ...stories.MedAksjonspunkt.args.opptjening.fastsattOpptjening,
-        opptjeningTom: undefined,
-      },
-    };
-
-    render(<MedAksjonspunkt opptjening={opptjening} />);
+    render(<MedAksjonspunkt opptjening={undefined} />);
 
     expect(await screen.findByText('Vurder om aktivitetene kan godkjennes')).toBeInTheDocument();
     expect(screen.getByText('Skjæringstidspunkt for opptjening')).toBeInTheDocument();
-    expect(screen.getByText('Detaljer for valgt aktivitet')).toBeInTheDocument();
     expect(screen.queryByText('25.10.2019')).not.toBeInTheDocument();
   });
 

--- a/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
+++ b/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
@@ -10,8 +10,8 @@ describe('OpptjeningFaktaIndex', () => {
   it('skal rendre uten å krasje når skjæringstidspunkt mangler', async () => {
     render(<MedAksjonspunkt opptjening={undefined} />);
 
-    expect(await screen.findByText('Vurder om aktivitetene kan godkjennes')).toBeInTheDocument();
-    expect(screen.getByText('Skjæringstidspunkt for opptjening')).toBeInTheDocument();
+    expect(await screen.findByText('Skjæringstidspunkt for opptjening')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
     expect(screen.queryByText('25.10.2019')).not.toBeInTheDocument();
   });
 
@@ -110,8 +110,7 @@ describe('OpptjeningFaktaIndex', () => {
 
     expect(bekreftKnapp).toBeEnabled();
     await userEvent.click(bekreftKnapp!);
-    await userEvent.click(bekreftKnapp!);
-    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(bekreftKnapp).toBeEnabled());
 

--- a/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
+++ b/packages/fakta/opptjening/src/OpptjeningFaktaIndex.spec.tsx
@@ -106,15 +106,15 @@ describe('OpptjeningFaktaIndex', () => {
     await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse 2');
     await userEvent.click(screen.getByText('Oppdater'));
 
-    const bekreftKnapp = screen.getByText('Bekreft og fortsett').closest('button');
+    const bekreftKnapp = screen.getByRole('button', { name: 'Bekreft og fortsett' });
 
     expect(bekreftKnapp).toBeEnabled();
-    await userEvent.click(bekreftKnapp!);
+    await userEvent.click(bekreftKnapp);
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(bekreftKnapp).toBeEnabled());
 
-    await userEvent.click(bekreftKnapp!);
+    await userEvent.click(bekreftKnapp);
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(2));
   });

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -39,7 +39,7 @@ const getAksjonspunktHelpTexts = (opptjeningAktiviteter: OpptjeningAktivitet[]):
   return texts;
 };
 
-const findSkjaringstidspunkt = (dato?: string): string => dayjs(dato).add(1, 'days').format(ISO_DATE_FORMAT);
+const findSkjaringstidspunkt = (dato: string): string => dayjs(dato).add(1, 'days').format(ISO_DATE_FORMAT);
 
 const sorterEtterOpptjeningFom = (
   opptjeningPerioder: OpptjeningAktivitet[],
@@ -133,16 +133,14 @@ export const OpptjeningFaktaPanel = ({
     [formVerdierForAlleAktiviteter, setMellomlagretFormData],
   );
 
-  const [forrigeFormVerdier, setForrigeFormVerdier] = useState(formVerdierForAlleAktiviteter);
-  if (formVerdierForAlleAktiviteter !== forrigeFormVerdier) {
-    setForrigeFormVerdier(formVerdierForAlleAktiviteter);
+  useEffect(() => {
     setValgtAktivitetIndex(finnFørsteIkkeBehandledeIndex(formVerdierForAlleAktiviteter));
-  }
+  }, [formVerdierForAlleAktiviteter]);
 
   const bekreft = () => {
     setIsSubmitting(true);
 
-    void submitCallback(transformValues(formVerdierForAlleAktiviteter, filtrerteOgSorterteOpptjeningsaktiviteter)).then(
+    void submitCallback(transformValues(formVerdierForAlleAktiviteter, filtrerteOgSorterteOpptjeningsaktiviteter)).finally(
       () => setIsSubmitting(false),
     );
   };
@@ -175,6 +173,9 @@ export const OpptjeningFaktaPanel = ({
   };
 
   const harIkkeBehandletAlle = formVerdierForAlleAktiviteter.some(a => a.erGodkjent === undefined);
+  const skjæringstidspunkt = fastsattOpptjening?.opptjeningTom
+    ? findSkjaringstidspunkt(fastsattOpptjening.opptjeningTom)
+    : undefined;
 
   return (
     <VStack gap="space-24">
@@ -186,7 +187,7 @@ export const OpptjeningFaktaPanel = ({
       <LabeledValue
         size="small"
         label={<FormattedMessage id="OpptjeningFaktaForm.Skjaringstidspunkt" />}
-        value={<DateLabel dateString={findSkjaringstidspunkt(fastsattOpptjening?.opptjeningTom)} />}
+        value={skjæringstidspunkt ? <DateLabel dateString={skjæringstidspunkt} /> : '-'}
       />
       <OpptjeningTidslinje
         opptjeningPerioder={filtrerteOgSorterteOpptjeningsaktiviteter}

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -145,8 +145,10 @@ export const OpptjeningFaktaPanel = ({
   const bekreft = () => {
     setIsSubmitting(true);
 
-    // Fangar feil her (i staden for å la dei forbli ufanga) slik at brukaren kan prøve å lagre på nytt
-    // om lagringa feilar, utan at det oppstår ein "unhandled promise rejection".
+    // Fangar feil her sidan ingenting elles ventar på/fangar denne (submitCallback vert kalla
+    // med `void` frå ein klikk-handler). Utan dette vart det ein ufanga ("unhandled") promise-
+    // rejection. isSubmitting blir uansett nullstilt av finally under, uavhengig av dette
+    // catch-et; feilmelding til brukar er alt sikra via mutation-cachen (queryUtils.ts).
     void submitCallback(transformValues(formVerdierForAlleAktiviteter, filtrerteOgSorterteOpptjeningsaktiviteter))
       .catch(() => undefined)
       .finally(() => setIsSubmitting(false));

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -145,9 +145,11 @@ export const OpptjeningFaktaPanel = ({
   const bekreft = () => {
     setIsSubmitting(true);
 
-    void submitCallback(transformValues(formVerdierForAlleAktiviteter, filtrerteOgSorterteOpptjeningsaktiviteter)).finally(
-      () => setIsSubmitting(false),
-    );
+    // Fangar feil her (i staden for å la dei forbli ufanga) slik at brukaren kan prøve å lagre på nytt
+    // om lagringa feilar, utan at det oppstår ein "unhandled promise rejection".
+    void submitCallback(transformValues(formVerdierForAlleAktiviteter, filtrerteOgSorterteOpptjeningsaktiviteter))
+      .catch(() => undefined)
+      .finally(() => setIsSubmitting(false));
   };
 
   const velgNesteAktivitet = () => {

--- a/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
+++ b/packages/fakta/opptjening/src/components/OpptjeningFaktaPanel.tsx
@@ -133,9 +133,14 @@ export const OpptjeningFaktaPanel = ({
     [formVerdierForAlleAktiviteter, setMellomlagretFormData],
   );
 
-  useEffect(() => {
+  // Juster valgtAktivitetIndex når formVerdierForAlleAktiviteter endrar seg (t.d. ny periode lasta inn).
+  // Følgjer Reacts anbefalte mønster for å justere state ved endra props/avleidde verdiar under render,
+  // i staden for via useEffect (unngår react-hooks/set-state-in-effect og ein ekstra commit/render).
+  const [forrigeFormVerdier, setForrigeFormVerdier] = useState(formVerdierForAlleAktiviteter);
+  if (formVerdierForAlleAktiviteter !== forrigeFormVerdier) {
+    setForrigeFormVerdier(formVerdierForAlleAktiviteter);
     setValgtAktivitetIndex(finnFørsteIkkeBehandledeIndex(formVerdierForAlleAktiviteter));
-  }, [formVerdierForAlleAktiviteter]);
+  }
 
   const bekreft = () => {
     setIsSubmitting(true);

--- a/packages/fakta/permisjon/src/PermisjonFaktaIndex.spec.tsx
+++ b/packages/fakta/permisjon/src/PermisjonFaktaIndex.spec.tsx
@@ -4,9 +4,18 @@ import userEvent from '@testing-library/user-event';
 
 import * as stories from './PermisjonFaktaIndex.stories';
 
-const { EttArbeidsforholdUtenSluttdatoForPermisjon, FlereArbeidsforhold } = composeStories(stories);
+const { EttArbeidsforholdUtenSluttdatoForPermisjon, FlereArbeidsforhold, ArbeidsforholdManglerArbeidsgiveropplysninger } =
+  composeStories(stories);
 
 describe('PermisjonFaktaIndex', () => {
+  it('skal rendre når arbeidsgiveropplysninger mangler for et arbeidsforhold', async () => {
+    render(<ArbeidsforholdManglerArbeidsgiveropplysninger />);
+
+    expect(await screen.findByText('Fakta om permisjon')).toBeInTheDocument();
+    expect(screen.getByText('BEDRIFT AS')).toBeInTheDocument();
+    expect(screen.getByText('Bekreft og fortsett').closest('button')).toBeDisabled();
+  });
+
   it('skal velge å ta med arbeidsforholdet og så bekrefte', async () => {
     const lagreVurdering = vi.fn(() => Promise.resolve());
 

--- a/packages/fakta/permisjon/src/PermisjonFaktaIndex.stories.tsx
+++ b/packages/fakta/permisjon/src/PermisjonFaktaIndex.stories.tsx
@@ -258,6 +258,53 @@ export const FlereArbeidsforhold: Story = {
   },
 };
 
+export const ArbeidsforholdManglerArbeidsgiveropplysninger: Story = {
+  args: {
+    arbeidsgiverOpplysningerPerId: {
+      910909088: lagArbeidsgiver('910909088', 'BEDRIFT AS'),
+    },
+    arbeidOgInntekt: {
+      arbeidsforhold: [
+        {
+          arbeidsgiverIdent: '910909088',
+          eksternArbeidsforholdId: 'ARB001-001',
+          fom: '2019-12-06',
+          internArbeidsforholdId: '8ff2c608-6bab-4f83-9732-d26f8c89aa84',
+          stillingsprosent: 100,
+          tom: '9999-12-31',
+          permisjonOgMangel: {
+            permisjonFom: '2022-10-02',
+            type: 'PERMITTERING',
+            årsak: 'PERMISJON_UTEN_SLUTTDATO',
+          },
+          årsak: 'PERMISJON',
+          saksbehandlersVurdering: '-',
+          permisjoner: [],
+        },
+        {
+          arbeidsgiverIdent: '910909099',
+          eksternArbeidsforholdId: 'ARB001-002',
+          fom: '2019-06-06',
+          internArbeidsforholdId: 'bc9a409c-a15f-4416-856b-5b1ee42eb75d',
+          stillingsprosent: 80,
+          tom: '2021-12-31',
+          årsak: 'MANGLENDE_INNTEKTSMELDING',
+          permisjonOgMangel: {
+            permisjonFom: '2021-11-07',
+            type: 'PERMITTERING',
+            årsak: 'PERMISJON_UTEN_SLUTTDATO',
+          },
+          saksbehandlersVurdering: '-',
+          permisjoner: [],
+        },
+      ],
+      inntektsmeldinger: [],
+      inntekter: [],
+      skjæringstidspunkt: '2021-11-10',
+    },
+  },
+};
+
 export const FlereArbeidsforholdFraSammeArbeidsgiver: Story = {
   args: {
     arbeidsgiverOpplysningerPerId: {

--- a/packages/fakta/permisjon/src/components/PermisjonFaktaPanel.tsx
+++ b/packages/fakta/permisjon/src/components/PermisjonFaktaPanel.tsx
@@ -29,10 +29,11 @@ type FormValues = {
 
 const getSorterArbeidsforhold =
   (arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId) =>
-  (a1: Arbeidsforhold, a2: Arbeidsforhold): number =>
-    arbeidsgiverOpplysningerPerId[a1.arbeidsgiverIdent]!.navn.localeCompare(
-      arbeidsgiverOpplysningerPerId[a2.arbeidsgiverIdent]!.navn,
-    );
+  (a1: Arbeidsforhold, a2: Arbeidsforhold): number => {
+    const navnA = arbeidsgiverOpplysningerPerId[a1.arbeidsgiverIdent]?.navn ?? a1.arbeidsgiverIdent;
+    const navnB = arbeidsgiverOpplysningerPerId[a2.arbeidsgiverIdent]?.navn ?? a2.arbeidsgiverIdent;
+    return navnA.localeCompare(navnB);
+  };
 
 interface Props {
   arbeidOgInntekt: ArbeidOgInntektsmelding;

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -4,8 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { expect } from 'vitest';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import type { SvpTilretteleggingDatoDto } from '@navikt/fp-types';
 import type { BekreftSvangerskapspengerAp } from '@navikt/fp-types-avklar-aksjonspunkter';
 
+import { finnProsentSvangerskapspenger } from './components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm';
 import * as stories from './TilretteleggingFaktaIndex.stories';
 
 const {
@@ -23,6 +25,19 @@ const lagNyDato = (nyDato: string) => {
 };
 
 describe('TilretteleggingFaktaIndex', () => {
+  it('skal bruke en eksplisitt overstyrt utbetalingsgrad på 0', () => {
+    const tilretteleggingDato: SvpTilretteleggingDatoDto = {
+      fom: '2020-03-17',
+      kilde: 'SØKNAD',
+      mottattDato: '2020-02-20',
+      overstyrtUtbetalingsgrad: 0,
+      stillingsprosent: 50,
+      type: 'DELVIS_TILRETTELEGGING',
+    };
+
+    expect(finnProsentSvangerskapspenger(tilretteleggingDato, 100, 50)).toBe(0);
+  });
+
   it('skal vurdere velferdspermisjon og så bekrefte aksjonspunkt', async () => {
     const lagre = vi.fn(() => Promise.resolve());
 
@@ -475,6 +490,27 @@ describe('TilretteleggingFaktaIndex', () => {
     expect(await screen.findByText('Perioder kan ikke overlappe i tid')).toBeInTheDocument();
   });
 
+  it('skal validere at ettdagsopphold ikke overlapper med annet opphold', async () => {
+    render(<HarOpphold />);
+
+    expect(await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Opphold' }));
+    await userEvent.click(screen.getByText('Ferie'));
+
+    const fomDato = screen.getAllByText('Fra og med')[2]!;
+    await userEvent.type(fomDato, lagNyDato('20.09.2020'));
+    fireEvent.blur(fomDato);
+
+    const tomDato = screen.getByText('Til og med');
+    await userEvent.type(tomDato, lagNyDato('20.09.2020'));
+    fireEvent.blur(tomDato);
+
+    await userEvent.click(screen.getByText('Legg til ny periode'));
+
+    expect(await screen.findByText('Perioder kan ikke overlappe i tid')).toBeInTheDocument();
+  });
+
   it('skal validere at tom-datoen til opphold er etter fom-datoen', async () => {
     render(<HarOpphold />);
 
@@ -648,6 +684,88 @@ describe('TilretteleggingFaktaIndex', () => {
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+  });
+
+  it('skal ikke blokkere når bare en irrelevant velferdspermisjon utenfor perioden er på 100%', async () => {
+    const lagre = vi.fn(() => Promise.resolve());
+    const svangerskapspengerTilrettelegging =
+      stories.TilretteleggingMed100ProsentVelferdspermisjon.args.svangerskapspengerTilrettelegging;
+
+    if (!svangerskapspengerTilrettelegging) {
+      throw new Error('Mangler svangerskapspengerTilrettelegging-fixture');
+    }
+
+    const førsteArbeidsforhold = svangerskapspengerTilrettelegging.arbeidsforholdListe[0]!;
+
+    render(
+      <TilretteleggingMed100ProsentVelferdspermisjon
+        submitCallback={lagre}
+        svangerskapspengerTilrettelegging={{
+          ...svangerskapspengerTilrettelegging,
+          arbeidsforholdListe: [
+            {
+              ...førsteArbeidsforhold,
+              velferdspermisjoner: [
+                {
+                  permisjonFom: '2019-02-17',
+                  permisjonTom: '2019-02-17',
+                  permisjonsprosent: 100,
+                  type: 'VELFERDSPERMISJON',
+                },
+                {
+                  permisjonFom: '2020-02-17',
+                  permisjonTom: '2020-07-12',
+                  permisjonsprosent: 50,
+                  type: 'VELFERDSPERMISJON',
+                },
+              ],
+            },
+            svangerskapspengerTilrettelegging.arbeidsforholdListe[1]!,
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        'Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer',
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Ja'));
+
+    expect(
+      screen.queryByText(
+        'Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapspenger for arbeidsforholdet.',
+      ),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByText('Oppdater')[0]!);
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByText('Arbeidsforhold med gyldig permisjon på 100% kan ikke ha svangerskapspenger'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('skal lukke arbeidsforholdskortet når skalBrukes blir slått av', async () => {
+    const { container } = render(<TilretteleggingMedVelferdspermisjon />);
+
+    expect(
+      await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer'),
+    ).toBeInTheDocument();
+
+    const ekspanderingsKnapp = container.querySelector<HTMLButtonElement>('button[aria-expanded="true"]');
+
+    expect(ekspanderingsKnapp).toBeTruthy();
+
+    await userEvent.click(screen.getByLabelText('Skal ha svangerskapspenger for arbeidsforholdet'));
+
+    await waitFor(() =>
+      expect(container.querySelector<HTMLButtonElement>('button[aria-expanded]')).toHaveAttribute('aria-expanded', 'false'),
+    );
   });
 
   it('skal kunne splitte et arbeidsforhold med flere stillinger i samme underenhet, bekrefte og deretter reversere splitten', async () => {

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -496,13 +496,14 @@ describe('TilretteleggingFaktaIndex', () => {
     expect(await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Opphold' }));
-    await userEvent.click(screen.getByText('Ferie'));
+    // "Ferie" finnes fleire stader (som tabelltekst for eksisterande periodar) - vel radioknappen.
+    await userEvent.click(screen.getByRole('radio', { name: 'Ferie' }));
 
-    const fomDato = screen.getAllByText('Fra og med')[2]!;
+    const fomDato = screen.getByRole('textbox', { name: 'Fra og med' });
     await userEvent.type(fomDato, lagNyDato('20.09.2020'));
     fireEvent.blur(fomDato);
 
-    const tomDato = screen.getByText('Til og med');
+    const tomDato = screen.getByRole('textbox', { name: 'Til og med' });
     await userEvent.type(tomDato, lagNyDato('20.09.2020'));
     fireEvent.blur(tomDato);
 

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -687,13 +687,16 @@ describe('TilretteleggingFaktaIndex', () => {
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
   });
 
-  it('skal ikke blokkere når bare en irrelevant velferdspermisjon utenfor perioden er på 100%', async () => {
+  it('skal ikke blokkere når en tidligere vurdert gyldig 100%-permisjon faller utenfor tilretteleggingsperioden', async () => {
     const lagre = vi.fn(() => Promise.resolve());
     const svangerskapspengerTilrettelegging =
       stories.TilretteleggingMed100ProsentVelferdspermisjon.args.svangerskapspengerTilrettelegging;
 
     const førsteArbeidsforhold = svangerskapspengerTilrettelegging.arbeidsforholdListe[0]!;
 
+    // Permisjonen er alt vurdert som gyldig (erGyldig: true) i ei tidlegare lagring, men ligg no
+    // heilt før tilretteleggingBehovFom (2020-03-17) og blir difor ikkje vist i permisjonstabellen.
+    // Saksbehandlaren kan altså ikkje endre vurderinga, og skal heller ikkje blokkerast av henne.
     render(
       <TilretteleggingMed100ProsentVelferdspermisjon
         submitCallback={lagre}
@@ -702,17 +705,13 @@ describe('TilretteleggingFaktaIndex', () => {
           arbeidsforholdListe: [
             {
               ...førsteArbeidsforhold,
+              skalBrukes: true,
               velferdspermisjoner: [
                 {
-                  permisjonFom: '2019-02-17',
-                  permisjonTom: '2019-02-17',
+                  permisjonFom: '2019-01-01',
+                  permisjonTom: '2019-06-01',
                   permisjonsprosent: 100,
-                  type: 'VELFERDSPERMISJON',
-                },
-                {
-                  permisjonFom: '2020-02-17',
-                  permisjonTom: '2020-07-12',
-                  permisjonsprosent: 50,
+                  erGyldig: true,
                   type: 'VELFERDSPERMISJON',
                 },
               ],
@@ -724,20 +723,12 @@ describe('TilretteleggingFaktaIndex', () => {
     );
 
     expect(
-      await screen.findByText(
-        'Kontroller opplysninger fra jordmor og arbeidsgiver og om velferdspermisjonene stemmer',
-      ),
+      await screen.findByText('Kontroller opplysninger fra jordmor og arbeidsgiver'),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Ja'));
+    // Permisjonen er filtrert bort, så saksbehandlaren har ingen måte å endre vurderinga på
+    expect(screen.queryByText('Velferdspermisjon')).not.toBeInTheDocument();
 
-    expect(
-      screen.queryByText(
-        'Permisjonen på 100% er satt som gyldig, og dette fører til at søker ikke får svangerskapspenger for arbeidsforholdet.',
-      ),
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(screen.getAllByText('Oppdater')[0]!);
     await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
     await userEvent.click(screen.getByText('Bekreft og fortsett'));
 

--- a/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
+++ b/packages/fakta/tilrettelegging/src/TilretteleggingFaktaIndex.spec.tsx
@@ -692,10 +692,6 @@ describe('TilretteleggingFaktaIndex', () => {
     const svangerskapspengerTilrettelegging =
       stories.TilretteleggingMed100ProsentVelferdspermisjon.args.svangerskapspengerTilrettelegging;
 
-    if (!svangerskapspengerTilrettelegging) {
-      throw new Error('Mangler svangerskapspengerTilrettelegging-fixture');
-    }
-
     const førsteArbeidsforhold = svangerskapspengerTilrettelegging.arbeidsforholdListe[0]!;
 
     render(

--- a/packages/fakta/tilrettelegging/src/components/TilretteleggingFormFeil.tsx
+++ b/packages/fakta/tilrettelegging/src/components/TilretteleggingFormFeil.tsx
@@ -31,7 +31,10 @@ const harUferdigstiltPeriode = (a: BekreftTilrettelegging) =>
   a.tilretteleggingDatoer.some(td => !td.fom) || a.avklarteOppholdPerioder.some(td => !td.fom);
 
 const harGyldig100Permisjon = (a: BekreftTilrettelegging) =>
-  a.skalBrukes && a.velferdspermisjoner.some(vp => vp.erGyldig && vp.permisjonsprosent === 100);
+  a.skalBrukes &&
+  filtrerVelferdspermisjoner(a.velferdspermisjoner, a.tilretteleggingBehovFom).some(
+    vp => vp.erGyldig && vp.permisjonsprosent === 100,
+  );
 
 const erArbeidsforholdUtenTilrettelegging = (a: BekreftTilrettelegging) =>
   a.skalBrukes && a.tilretteleggingDatoer.length === 0;

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdExpansionCard.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdExpansionCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type FieldArrayWithId } from 'react-hook-form';
 
 import { ExpansionCard } from '@navikt/ds-react';
@@ -33,13 +33,10 @@ export const ArbeidsforholdExpansionCard = ({
   faisu,
 }: Props) => {
   const [open, setOpen] = useState(tilrettelegging.skalBrukes);
-  const [forrigeSkalBrukes, setForrigeSkalBrukes] = useState(tilrettelegging.skalBrukes);
 
-  // Kortet åpnes/lukkes automatisk når skalBrukes endres, men kan også styres manuelt av saksbehandler.
-  if (tilrettelegging.skalBrukes !== forrigeSkalBrukes) {
-    setForrigeSkalBrukes(tilrettelegging.skalBrukes);
+  useEffect(() => {
     setOpen(tilrettelegging.skalBrukes);
-  }
+  }, [tilrettelegging.skalBrukes]);
 
   const alleIafAf = aoiArbeidsforhold.filter(iaya => iaya.arbeidsgiverIdent === tilrettelegging.arbeidsgiverReferanse);
 

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdExpansionCard.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/ArbeidsforholdExpansionCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { type FieldArrayWithId } from 'react-hook-form';
 
 import { ExpansionCard } from '@navikt/ds-react';
@@ -34,9 +34,14 @@ export const ArbeidsforholdExpansionCard = ({
 }: Props) => {
   const [open, setOpen] = useState(tilrettelegging.skalBrukes);
 
-  useEffect(() => {
+  // Juster open når tilrettelegging.skalBrukes endrar seg, ved å samanlikne med førre verdi
+  // og justere state under render (Reacts anbefalte mønster), i staden for via useEffect
+  // (unngår react-hooks/set-state-in-effect og ein ekstra commit/render).
+  const [forrigeSkalBrukes, setForrigeSkalBrukes] = useState(tilrettelegging.skalBrukes);
+  if (tilrettelegging.skalBrukes !== forrigeSkalBrukes) {
+    setForrigeSkalBrukes(tilrettelegging.skalBrukes);
     setOpen(tilrettelegging.skalBrukes);
-  }, [tilrettelegging.skalBrukes]);
+  }
 
   const alleIafAf = aoiArbeidsforhold.filter(iaya => iaya.arbeidsgiverIdent === tilrettelegging.arbeidsgiverReferanse);
 

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/opphold/OppholdForm.tsx
@@ -63,11 +63,16 @@ const validerAtPeriodeIkkeOverlapper =
   () => {
     const fomDato = getValues(`${index}.fom`);
     const tomDato = getValues(`${index}.tom`);
+
+    if (!fomDato || !tomDato) {
+      return undefined;
+    }
+
     const periodeMap = alleOpphold
       .filter(p => p.fom !== valgtOpphold.fom)
       .map(({ fom, tom }) => [fom, tom])
       .concat([[fomDato, tomDato]]);
-    return periodeMap.length > 0 && dayjs(fomDato).isBefore(dayjs(tomDato))
+    return periodeMap.length > 0 && !dayjs(fomDato).isAfter(dayjs(tomDato))
       ? dateRangesNotOverlapping(periodeMap)
       : undefined;
   };

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
@@ -68,7 +68,11 @@ export const finnProsentSvangerskapspenger = (
   if (tilretteleggingDato.type === 'HEL_TILRETTELEGGING') {
     return undefined;
   }
-  if (brukOverstyrtUtbetalingsgrad && tilretteleggingDato.overstyrtUtbetalingsgrad) {
+  if (
+    brukOverstyrtUtbetalingsgrad &&
+    tilretteleggingDato.overstyrtUtbetalingsgrad !== undefined &&
+    tilretteleggingDato.overstyrtUtbetalingsgrad !== null
+  ) {
     return tilretteleggingDato.overstyrtUtbetalingsgrad;
   }
 

--- a/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
+++ b/packages/fakta/tilrettelegging/src/components/arbeidsforhold/tilretteleggingOgOpphold/tilrettelegging/TilretteleggingForm.tsx
@@ -68,11 +68,7 @@ export const finnProsentSvangerskapspenger = (
   if (tilretteleggingDato.type === 'HEL_TILRETTELEGGING') {
     return undefined;
   }
-  if (
-    brukOverstyrtUtbetalingsgrad &&
-    tilretteleggingDato.overstyrtUtbetalingsgrad !== undefined &&
-    tilretteleggingDato.overstyrtUtbetalingsgrad !== null
-  ) {
+  if (brukOverstyrtUtbetalingsgrad && tilretteleggingDato.overstyrtUtbetalingsgrad !== undefined) {
     return tilretteleggingDato.overstyrtUtbetalingsgrad;
   }
 

--- a/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.spec.tsx
+++ b/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.spec.tsx
@@ -135,7 +135,7 @@ describe('UttakFaktaEøsIndex', () => {
   });
 
   it('skal ikke endre rekkefølgen i input-arrayet når periodene sorteres for visning', async () => {
-    const perioder = (stories.ÅpentAksjonspunktMedPerioder.args?.annenForelderUttakEøs ?? []).map(periode => ({
+    const perioder = (ÅpentAksjonspunktMedPerioder.args.annenForelderUttakEøs ?? []).map(periode => ({
       ...periode,
     }));
     const originalRekkefølge = perioder.map(({ fom, tom }) => `${fom}-${tom}`);

--- a/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.spec.tsx
+++ b/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.spec.tsx
@@ -6,6 +6,7 @@ import * as stories from './UttakFaktaEøsIndex.stories';
 
 const {
   ÅpentAksjonspunktMedPerioder,
+  ÅpentAksjonspunktMedPerioderSomDelerSammeFom,
   AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg,
   OverstyringSkalVæreMuligHvisDetForeliggerEnTidligereVurderingMedRegistrertePerioder,
   OverstyringSkalIkkeVæreTilgjengligHvisDetForeliggerAksjonspunktSomKanLøsesEllerEndres,
@@ -103,6 +104,46 @@ describe('UttakFaktaEøsIndex', () => {
         },
       ],
     });
+  });
+
+  it('skal bare slette valgt periode når flere perioder har samme fom', async () => {
+    const lagre = vi.fn(() => Promise.resolve());
+
+    render(<ÅpentAksjonspunktMedPerioderSomDelerSammeFom submitCallback={lagre} />);
+
+    expect(await screen.findByText('Fakta om uttak til annen forelder i EØS')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('01.01.2023 - 31.01.2023'));
+    await userEvent.click(screen.getByRole('button', { name: 'Slett periode' }));
+    await userEvent.click(screen.getByText('OK'));
+
+    await userEvent.type(screen.getByLabelText('Vurdering'), 'Dette er en begrunnelse');
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    expect(lagre).toHaveBeenNthCalledWith(1, {
+      kode: '5103',
+      begrunnelse: 'Dette er en begrunnelse',
+      perioder: [
+        {
+          fom: '2023-01-01',
+          tom: '2023-02-15',
+          trekkonto: 'FELLESPERIODE',
+          trekkdager: 15,
+        },
+      ],
+    });
+  });
+
+  it('skal ikke endre rekkefølgen i input-arrayet når periodene sorteres for visning', async () => {
+    const perioder = (stories.ÅpentAksjonspunktMedPerioder.args?.annenForelderUttakEøs ?? []).map(periode => ({
+      ...periode,
+    }));
+    const originalRekkefølge = perioder.map(({ fom, tom }) => `${fom}-${tom}`);
+
+    render(<ÅpentAksjonspunktMedPerioder annenForelderUttakEøs={perioder} />);
+
+    expect(await screen.findByText('Fakta om uttak til annen forelder i EØS')).toBeInTheDocument();
+    expect(perioder.map(({ fom, tom }) => `${fom}-${tom}`)).toEqual(originalRekkefølge);
   });
 
   it('skal få feilmelding hvis en legger til overlappende perioder, rydder opp i overlapper og sender inn', async () => {

--- a/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.stories.tsx
+++ b/packages/fakta/uttak-eøs/src/UttakFaktaEøsIndex.stories.tsx
@@ -53,6 +53,25 @@ export const ÅpentAksjonspunktMedPerioder: Story = {
   },
 };
 
+export const ÅpentAksjonspunktMedPerioderSomDelerSammeFom: Story = {
+  args: {
+    annenForelderUttakEøs: [
+      {
+        fom: '2023-01-01',
+        tom: '2023-01-31',
+        trekkonto: 'MØDREKVOTE',
+        trekkdager: 10,
+      },
+      {
+        fom: '2023-01-01',
+        tom: '2023-02-15',
+        trekkonto: 'FELLESPERIODE',
+        trekkdager: 15,
+      },
+    ],
+  },
+};
+
 export const AksjonspunktOpprettetUtenTidligereVurderingSkalIkkeHaDefaultValg: Story = {
   args: {
     annenForelderUttakEøs: [],

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -6,7 +6,7 @@ import { ErrorSummary, Heading, HStack, VStack } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
 import { dateRangesNotOverlapping } from '@navikt/ft-form-validators';
 import { AksjonspunktHelpTextHTML, OverstyringKnapp } from '@navikt/ft-ui-komponenter';
-import dayjs from 'dayjs';
+import { sortPeriodsByFom } from '@navikt/ft-utils';
 
 import { type FaktaBegrunnelseFormValues, FaktaBegrunnelseTextField, FaktaSubmitButton } from '@navikt/fp-fakta-felles';
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
@@ -26,7 +26,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
 
   const { aksjonspunkterForPanel, harÅpentAksjonspunkt, isSubmittable, isReadOnly, submitCallback, alleKodeverk } =
     usePanelDataContext<BekreftAnnenpartsUttakEøsAp>();
-  const sorterteAnnenForelderUttakEøs = [...annenForelderUttakEøs].sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)));
+  const sorterteAnnenForelderUttakEøs = annenForelderUttakEøs.toSorted(sortPeriodsByFom);
 
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<{
     annenForelderUttakEøsPerioder: AnnenforelderUttakEøsPeriode[];

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaForm.tsx
@@ -26,7 +26,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
 
   const { aksjonspunkterForPanel, harÅpentAksjonspunkt, isSubmittable, isReadOnly, submitCallback, alleKodeverk } =
     usePanelDataContext<BekreftAnnenpartsUttakEøsAp>();
-  annenForelderUttakEøs.sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)));
+  const sorterteAnnenForelderUttakEøs = [...annenForelderUttakEøs].sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)));
 
   const { mellomlagretFormData, setMellomlagretFormData } = useMellomlagretFormData<{
     annenForelderUttakEøsPerioder: AnnenforelderUttakEøsPeriode[];
@@ -34,7 +34,7 @@ export const UttakEøsFaktaForm = ({ annenForelderUttakEøs, kanOverstyre }: Pro
   }>();
 
   const [perioder, setPerioder] = useState<AnnenforelderUttakEøsPeriode[]>(
-    mellomlagretFormData?.annenForelderUttakEøsPerioder ?? annenForelderUttakEøs,
+    mellomlagretFormData?.annenForelderUttakEøsPerioder ?? sorterteAnnenForelderUttakEøs,
   );
   const [erOverstyrt, setErOverstyrt] = useState(false);
   const [visLeggTilPeriodeForm, setVisLeggTilPeriodeForm] = useState(false);

--- a/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaTable.tsx
+++ b/packages/fakta/uttak-eøs/src/components/UttakEøsFaktaTable.tsx
@@ -51,10 +51,11 @@ export const UttakEøsFaktaTable = ({
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {annenForelderUttakEøsPerioder.map(annenForelderUttakEøsPeriode => (
+        {annenForelderUttakEøsPerioder.map((annenForelderUttakEøsPeriode, periodIndex) => (
           <Rad
             key={annenForelderUttakEøsPeriode.fom + annenForelderUttakEøsPeriode.tom}
             annenForelderUttakEøsPeriode={annenForelderUttakEøsPeriode}
+            rowIndex={periodIndex}
             setPerioder={setPerioder}
             isReadOnly={isReadOnly}
             setDirty={setDirty}
@@ -107,21 +108,20 @@ export const UttakEøsFaktaTable = ({
 
 interface RadProps {
   annenForelderUttakEøsPeriode: AnnenforelderUttakEøsPeriode;
+  rowIndex: number;
   setPerioder: React.Dispatch<React.SetStateAction<AnnenforelderUttakEøsPeriode[]>>;
   isReadOnly: boolean;
   setDirty: (isDirty: boolean) => void;
   alleKodeverk: AlleKodeverk;
 }
 
-const Rad = ({ annenForelderUttakEøsPeriode, setPerioder, isReadOnly, setDirty, alleKodeverk }: RadProps) => {
+const Rad = ({ annenForelderUttakEøsPeriode, rowIndex, setPerioder, isReadOnly, setDirty, alleKodeverk }: RadProps) => {
   const [erÅpen, setErÅpen] = useState(false);
 
   const oppdaterPeriode = (oppdatertPeriode: AnnenforelderUttakEøsPeriode) => {
     setErÅpen(false);
     setPerioder(prevPerioder => {
-      const perioderSomIkkeErOppdatert = prevPerioder.filter(
-        periode => periode.fom !== annenForelderUttakEøsPeriode.fom && periode.tom !== annenForelderUttakEøsPeriode.tom,
-      );
+      const perioderSomIkkeErOppdatert = prevPerioder.filter((_, index) => index !== rowIndex);
       return [...perioderSomIkkeErOppdatert, oppdatertPeriode].sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)));
     });
     setDirty(true);
@@ -130,9 +130,7 @@ const Rad = ({ annenForelderUttakEøsPeriode, setPerioder, isReadOnly, setDirty,
   const slettPeriode = () => {
     setErÅpen(false);
     setPerioder(prevPerioder => {
-      return prevPerioder.filter(
-        periode => periode.fom !== annenForelderUttakEøsPeriode.fom && periode.tom !== annenForelderUttakEøsPeriode.tom,
-      );
+      return prevPerioder.filter((_, index) => index !== rowIndex);
     });
     setDirty(true);
   };
@@ -145,7 +143,6 @@ const Rad = ({ annenForelderUttakEøsPeriode, setPerioder, isReadOnly, setDirty,
 
   return (
     <Table.ExpandableRow
-      key={fom + tom}
       expandOnRowClick
       expansionDisabled={isReadOnly}
       togglePlacement="right"

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -2,6 +2,9 @@ import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import type { BekreftUttaksperioderAp } from '@navikt/fp-types-avklar-aksjonspunkter';
+import { notEmpty } from '@navikt/fp-utils';
+
 import type { KontrollerFaktaPeriodeMedApMarkering } from './typer/kontrollerFaktaPeriodeMedApMarkering';
 import * as stories from './UttakFaktaIndex.stories';
 
@@ -295,16 +298,9 @@ describe('UttakFaktaIndex', () => {
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
 
-    expect(lagre).toHaveBeenCalledWith([
-      expect.objectContaining({
-        perioder: expect.arrayContaining([
-          expect.objectContaining({
-            arbeidstidsprosent: 12,
-            samtidigUttaksprosent: 34,
-          }),
-        ]),
-      }),
-    ]);
+    const [aksjonspunktSendtInn] = (lagre.mock.calls[0] as unknown as [BekreftUttaksperioderAp[]])[0];
+    const oppdatertPeriode = notEmpty(aksjonspunktSendtInn).perioder.find(periode => periode.arbeidstidsprosent === 12);
+    expect(oppdatertPeriode).toEqual(expect.objectContaining({ arbeidstidsprosent: 12, samtidigUttaksprosent: 34 }));
   });
 
   it('skal vise ulike felter for ulike periodetyper', async () => {

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -68,8 +68,7 @@ describe('UttakFaktaIndex', () => {
             tom: '2022-12-01',
             originalFom: '2022-11-12',
             periodeKilde: 'SAKSBEHANDLER',
-            // @ts-expect-error -- typene i formet er inkonsekvente
-            samtidigUttaksprosent: '10',
+            samtidigUttaksprosent: 10,
             uttakPeriodeType: 'MØDREKVOTE',
             aksjonspunktType: undefined,
             arbeidsforhold: undefined,

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -274,11 +274,17 @@ describe('UttakFaktaIndex', () => {
 
     await userEvent.click(screen.getAllByTitle('Vis mer')[0]!);
 
+    const periodeFra = screen.getByLabelText('Periode fra');
+    await userEvent.clear(periodeFra);
+    await userEvent.type(periodeFra, '31.01.2022');
+    fireEvent.blur(periodeFra);
+
     const arbeidstidsprosent = screen.getByLabelText('Gradering %');
     await userEvent.clear(arbeidstidsprosent);
     await userEvent.type(arbeidstidsprosent, '12');
 
-    const samtidigUttaksprosent = screen.getByLabelText('Samtidig uttaksprosent');
+    // Label "Samtidig uttaksprosent" er delt mellom ein checkbox og talfeltet - hent ut talfeltet spesifikt.
+    const samtidigUttaksprosent = screen.getByRole('textbox', { name: 'Samtidig uttaksprosent' });
     await userEvent.clear(samtidigUttaksprosent);
     await userEvent.type(samtidigUttaksprosent, '34');
 
@@ -291,12 +297,12 @@ describe('UttakFaktaIndex', () => {
 
     expect(lagre).toHaveBeenCalledWith([
       expect.objectContaining({
-        perioder: [
+        perioder: expect.arrayContaining([
           expect.objectContaining({
             arbeidstidsprosent: 12,
             samtidigUttaksprosent: 34,
           }),
-        ],
+        ]),
       }),
     ]);
   });

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -265,6 +265,38 @@ describe('UttakFaktaIndex', () => {
     ]);
   });
 
+  it('skal sende arbeidstidsprosent og samtidig uttaksprosent som tall ved innsending', async () => {
+    const lagre = vi.fn(() => Promise.resolve());
+
+    render(<VisUttaksperiodeMedAksjonspunkt submitCallback={lagre} />);
+
+    expect(await screen.findByText('Fakta om uttak')).toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByTitle('Vis mer')[0]!);
+
+    const arbeidstidsprosent = screen.getByLabelText('Gradering %');
+    await userEvent.clear(arbeidstidsprosent);
+    await userEvent.type(arbeidstidsprosent, '12');
+
+    const samtidigUttaksprosent = screen.getByLabelText('Samtidig uttaksprosent');
+    await userEvent.clear(samtidigUttaksprosent);
+    await userEvent.type(samtidigUttaksprosent, '34');
+
+    await userEvent.click(screen.getByText('Oppdater'));
+
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+
+    const perioder = lagre.mock.calls[0]?.[0]?.[0]?.perioder;
+
+    expect(perioder[0]?.arbeidstidsprosent).toBe(12);
+    expect(typeof perioder[0]?.arbeidstidsprosent).toBe('number');
+    expect(perioder[0]?.samtidigUttaksprosent).toBe(34);
+    expect(typeof perioder[0]?.samtidigUttaksprosent).toBe('number');
+  });
+
   it('skal vise ulike felter for ulike periodetyper', async () => {
     render(<VisUtsettelseperiodeMedAksjonspunkt />);
 

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -289,12 +289,16 @@ describe('UttakFaktaIndex', () => {
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
 
-    const perioder = lagre.mock.calls[0]?.[0]?.[0]?.perioder;
-
-    expect(perioder[0]?.arbeidstidsprosent).toBe(12);
-    expect(typeof perioder[0]?.arbeidstidsprosent).toBe('number');
-    expect(perioder[0]?.samtidigUttaksprosent).toBe(34);
-    expect(typeof perioder[0]?.samtidigUttaksprosent).toBe('number');
+    expect(lagre).toHaveBeenCalledWith([
+      expect.objectContaining({
+        perioder: [
+          expect.objectContaining({
+            arbeidstidsprosent: 12,
+            samtidigUttaksprosent: 34,
+          }),
+        ],
+      }),
+    ]);
   });
 
   it('skal vise ulike felter for ulike periodetyper', async () => {

--- a/packages/fakta/uttak/src/components/GraderingOgSamtidigUttakPanel.tsx
+++ b/packages/fakta/uttak/src/components/GraderingOgSamtidigUttakPanel.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { Alert, HStack } from '@navikt/ds-react';
 import { RhfCheckbox, RhfNumericField, RhfSelect } from '@navikt/ft-form-hooks';
 import { required } from '@navikt/ft-form-validators';
-import { formaterArbeidsgiver, guid } from '@navikt/ft-utils';
+import { formaterArbeidsgiver } from '@navikt/ft-utils';
 
 import type { AlleKodeverk, ArbeidsgiverOpplysningerPerId, FaktaArbeidsforhold } from '@navikt/fp-types';
 
@@ -39,7 +39,7 @@ const mapArbeidsforhold = (
     }
 
     return (
-      <option value={`${arbeidsgiverReferanse}-${arbeidType}`} key={guid()}>
+      <option value={`${arbeidsgiverReferanse}-${arbeidType}`} key={`${arbeidsgiverReferanse}-${arbeidType}`}>
         {periodeArbeidsforhold}
       </option>
     );

--- a/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaDetailForm.tsx
@@ -389,6 +389,9 @@ const transformValues = (values: FormValues): KontrollerFaktaPeriodeMedApMarkeri
     : undefined,
   periodeKilde: 'SAKSBEHANDLER',
   aksjonspunktType: undefined,
-  arbeidstidsprosent: values.arbeidstidsprosent,
-  samtidigUttaksprosent: values.samtidigUttaksprosent,
+  arbeidstidsprosent: parseOptionalNumber(values.arbeidstidsprosent),
+  samtidigUttaksprosent: parseOptionalNumber(values.samtidigUttaksprosent),
 });
+
+const parseOptionalNumber = (value?: number | string) =>
+  value === undefined || value === '' ? undefined : Number.parseFloat(`${value}`);

--- a/packages/fakta/uttaksdokumentasjon/src/UttakDokumentasjonFaktaIndex.spec.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/UttakDokumentasjonFaktaIndex.spec.tsx
@@ -160,6 +160,45 @@ describe('UttakDokumentasjonFaktaIndex', () => {
     });
   });
 
+  it('skal kunne prøve å bekrefte på nytt etter feil ved submit', async () => {
+    const rejectedSubmit = Promise.reject(new Error('Feilet'));
+    rejectedSubmit.catch(() => undefined);
+    const lagre = vi.fn().mockImplementationOnce(() => rejectedSubmit).mockImplementationOnce(() => Promise.resolve());
+
+    render(<AksjonspunktMedUavklartePerioder submitCallback={lagre} />);
+
+    expect(screen.getByText('Kontroller dokumentasjon')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Godkjent'));
+    await userEvent.click(screen.getByText('Oppdater'));
+    await waitFor(() => expect(screen.getByText('Oppdater').closest('button')).toBeDisabled());
+
+    await userEvent.click(screen.getByLabelText('Ikke godkjent'));
+    await userEvent.click(screen.getByText('Oppdater'));
+    await waitFor(() => expect(screen.getByText('Oppdater').closest('button')).toBeDisabled());
+
+    await userEvent.click(screen.getByLabelText('Godkjent'));
+    await userEvent.click(screen.getByText('Oppdater'));
+    await waitFor(() => expect(screen.getByText('Oppdater').closest('button')).toBeDisabled());
+
+    await userEvent.click(screen.getByLabelText('Godkjent - Mor jobber mindre enn 75%'));
+    await userEvent.type(screen.getByLabelText('Hvor mange prosent jobber mor?'), '60');
+    await userEvent.click(screen.getByText('Oppdater'));
+
+    await userEvent.type(screen.getByLabelText('Begrunnelse'), 'Dette er en begrunnelse');
+
+    const bekreftKnapp = screen.getByText('Bekreft og fortsett').closest('button');
+
+    await userEvent.click(bekreftKnapp!);
+
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(bekreftKnapp).not.toBeDisabled());
+
+    await userEvent.click(bekreftKnapp!);
+
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(2));
+  });
+
   it('skal vise tabellrader som ikke kan ekspanderes når det ikke er aksjonspunkt', () => {
     render(<UavklartePerioderMenIkkeAksjonspunktEnnå />);
     expect(screen.queryByText('Kontroller dokumentasjon')).not.toBeInTheDocument();

--- a/packages/fakta/uttaksdokumentasjon/src/UttakDokumentasjonFaktaIndex.spec.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/UttakDokumentasjonFaktaIndex.spec.tsx
@@ -187,14 +187,14 @@ describe('UttakDokumentasjonFaktaIndex', () => {
 
     await userEvent.type(screen.getByLabelText('Begrunnelse'), 'Dette er en begrunnelse');
 
-    const bekreftKnapp = screen.getByText('Bekreft og fortsett').closest('button');
+    const bekreftKnapp = screen.getByRole('button', { name: 'Bekreft og fortsett' });
 
-    await userEvent.click(bekreftKnapp!);
+    await userEvent.click(bekreftKnapp);
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(bekreftKnapp).not.toBeDisabled());
 
-    await userEvent.click(bekreftKnapp!);
+    await userEvent.click(bekreftKnapp);
 
     await waitFor(() => expect(lagre).toHaveBeenCalledTimes(2));
   });

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
@@ -47,8 +47,10 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
     try {
       await submitCallback(transformValues(values, dokBehov));
     } catch {
-      // Fangar feilen her slik at brukaren kan prøve å lagre på nytt om lagringa feilar,
-      // utan at det oppstår ein "unhandled promise rejection".
+      // Fangar feilen her sidan ingenting elles ventar på/fangar denne (kalla frå ein
+      // klikk-handler). Utan dette vart det ein ufanga ("unhandled") promise-rejection.
+      // Knappen sin loading-state blir uansett nullstilt av finally-blokka under, uavhengig
+      // av dette catch-et; feilmelding til brukar er alt sikra via mutation-cachen (queryUtils.ts).
     } finally {
       setErBekreftKnappTrykket(false);
     }

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
@@ -46,6 +46,9 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
     setErBekreftKnappTrykket(true);
     try {
       await submitCallback(transformValues(values, dokBehov));
+    } catch {
+      // Fangar feilen her slik at brukaren kan prøve å lagre på nytt om lagringa feilar,
+      // utan at det oppstår ein "unhandled promise rejection".
     } finally {
       setErBekreftKnappTrykket(false);
     }

--- a/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
+++ b/packages/fakta/uttaksdokumentasjon/src/components/UttakDokumentasjonFaktaForm.tsx
@@ -42,9 +42,13 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
     mellomlagretFormData?.dokBehov ?? dokumentasjonVurderingBehov,
   );
 
-  const bekreft = (values: FaktaBegrunnelseFormValues) => {
+  const bekreft = async (values: FaktaBegrunnelseFormValues) => {
     setErBekreftKnappTrykket(true);
-    void submitCallback(transformValues(values, dokBehov));
+    try {
+      await submitCallback(transformValues(values, dokBehov));
+    } finally {
+      setErBekreftKnappTrykket(false);
+    }
   };
 
   const formMethods = useForm<FaktaBegrunnelseFormValues>({
@@ -73,7 +77,7 @@ export const UttakDokumentasjonFaktaForm = ({ dokumentasjonVurderingBehov }: Pro
       <RhfForm
         formMethods={formMethods}
         setDataOnUnmount={(values: FaktaBegrunnelseFormValues) => setMellomlagretFormData({ ...values, dokBehov })}
-        onSubmit={values => bekreft(values)}
+        onSubmit={bekreft}
       >
         <VStack gap="space-16">
           <FaktaBegrunnelseTextField

--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -61,10 +61,11 @@ describe('VergeFaktaIndex', () => {
   });
 
   it('skal ikke endre rekkefølgen i kodeverk-arrayet når verge-typer sorteres', async () => {
-    const vergetyper = (stories.Default.args?.alleKodeverk?.VergeType ?? []).map(vergetype => ({ ...vergetype })).reverse();
+    const alleKodeverk = stories.Default.args!.alleKodeverk!;
+    const vergetyper = alleKodeverk.VergeType.map(vergetype => ({ ...vergetype })).reverse();
     const originalRekkefølge = vergetyper.map(vergetype => vergetype.kode);
 
-    render(<Default alleKodeverk={{ ...stories.Default.args!.alleKodeverk, VergeType: vergetyper }} />);
+    render(<Default alleKodeverk={{ ...alleKodeverk, VergeType: vergetyper }} />);
 
     expect(await screen.findByText('Fyll ut og kontroller vergeopplysninger')).toBeInTheDocument();
     expect(vergetyper.map(vergetype => vergetype.kode)).toEqual(originalRekkefølge);

--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+import { alleKodeverk, alleKodeverkTilbakekreving } from '@navikt/fp-storybook-utils';
 
 import * as stories from './VergeFaktaIndex.stories';
 
@@ -61,11 +62,12 @@ describe('VergeFaktaIndex', () => {
   });
 
   it('skal ikke endre rekkefølgen i kodeverk-arrayet når verge-typer sorteres', async () => {
-    const alleKodeverk = Default.args!.alleKodeverk!;
     const vergetyper = alleKodeverk.VergeType.map(vergetype => ({ ...vergetype })).reverse();
     const originalRekkefølge = vergetyper.map(vergetype => vergetype.kode);
 
-    render(<Default alleKodeverk={{ ...alleKodeverk, VergeType: vergetyper }} />);
+    render(
+      <Default alleKodeverk={{ ...alleKodeverk, ...alleKodeverkTilbakekreving, VergeType: vergetyper }} />,
+    );
 
     expect(await screen.findByText('Fyll ut og kontroller vergeopplysninger')).toBeInTheDocument();
     expect(vergetyper.map(vergetype => vergetype.kode)).toEqual(originalRekkefølge);

--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -36,6 +36,40 @@ describe('VergeFaktaIndex', () => {
     );
   });
 
+  it('skal vise valideringsfeil når til og med er før fra og med', async () => {
+    const lagre = vi.fn();
+
+    render(<Default submitCallback={lagre} />);
+
+    await userEvent.selectOptions(screen.getByLabelText('Type verge'), 'ADVOKAT');
+    await userEvent.type(screen.getByLabelText('Navn'), 'Espen Utvikler');
+    await userEvent.type(screen.getByLabelText('Organisasjonsnummer'), '232232323');
+
+    const fomInput = screen.getByLabelText('Fra og med');
+    await userEvent.type(fomInput, '24.09.2022');
+    fireEvent.blur(fomInput);
+
+    const tomInput = screen.getByLabelText('Til og med');
+    await userEvent.type(tomInput, '14.09.2022');
+    fireEvent.blur(tomInput);
+
+    await userEvent.type(screen.getByLabelText('Begrunn endringene'), 'Dette er en begrunnelse');
+    await userEvent.click(screen.getByText('Bekreft og fortsett'));
+
+    expect(await screen.findByText('Dato må være etter eller lik 24.09.2022')).toBeInTheDocument();
+    expect(lagre).not.toHaveBeenCalled();
+  });
+
+  it('skal ikke endre rekkefølgen i kodeverk-arrayet når verge-typer sorteres', async () => {
+    const vergetyper = (stories.Default.args?.alleKodeverk?.VergeType ?? []).map(vergetype => ({ ...vergetype })).reverse();
+    const originalRekkefølge = vergetyper.map(vergetype => vergetype.kode);
+
+    render(<Default alleKodeverk={{ ...stories.Default.args!.alleKodeverk, VergeType: vergetyper }} />);
+
+    expect(await screen.findByText('Fyll ut og kontroller vergeopplysninger')).toBeInTheDocument();
+    expect(vergetyper.map(vergetype => vergetype.kode)).toEqual(originalRekkefølge);
+  });
+
   it('skal velge vergetype og bekrefte aksjonspunkt', async () => {
     const lagre = vi.fn();
 

--- a/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
+++ b/packages/fakta/verge/src/VergeFaktaIndex.spec.tsx
@@ -61,7 +61,7 @@ describe('VergeFaktaIndex', () => {
   });
 
   it('skal ikke endre rekkefølgen i kodeverk-arrayet når verge-typer sorteres', async () => {
-    const alleKodeverk = stories.Default.args!.alleKodeverk!;
+    const alleKodeverk = Default.args!.alleKodeverk!;
     const vergetyper = alleKodeverk.VergeType.map(vergetype => ({ ...vergetype })).reverse();
     const originalRekkefølge = vergetyper.map(vergetype => vergetype.kode);
 

--- a/packages/fakta/verge/src/components/RegistrereVergeForm.tsx
+++ b/packages/fakta/verge/src/components/RegistrereVergeForm.tsx
@@ -1,8 +1,9 @@
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, type UseFormGetValues } from 'react-hook-form';
 
 import { HStack, VStack } from '@navikt/ds-react';
 import { RhfDatepicker, RhfSelect, RhfTextField } from '@navikt/ft-form-hooks';
 import {
+  dateAfterOrEqual,
   hasValidDate,
   hasValidFodselsnummer,
   hasValidName,
@@ -33,7 +34,7 @@ interface Props {
  * Formkomponent. Registrering og oppdatering av verge.
  */
 export const RegistrereVergeForm = ({ readOnly, vergetyper = [], valgtVergeType }: Props) => {
-  const { control } = useFormContext<VergeFormValues & FaktaBegrunnelseFormValues>();
+  const { control, getValues } = useFormContext<VergeFormValues & FaktaBegrunnelseFormValues>();
   return (
     <VStack gap="space-16">
       <RhfSelect
@@ -88,7 +89,7 @@ export const RegistrereVergeForm = ({ readOnly, vergetyper = [], valgtVergeType 
               name="gyldigTom"
               control={control}
               label={intl.formatMessage({ id: 'Verge.PeriodeTOM' })}
-              validate={[hasValidDate]}
+              validate={[hasValidDate, validerGyldigTomEtterFom(getValues)]}
               readOnly={readOnly}
             />
           </HStack>
@@ -118,3 +119,9 @@ RegistrereVergeForm.transformValues = ({
     ? { organisasjonsnummer: notEmpty(values.organisasjonsnummer).trim() }
     : { fnr: notEmpty(values.fnr) }),
 });
+
+const validerGyldigTomEtterFom =
+  (getValues: UseFormGetValues<VergeFormValues & FaktaBegrunnelseFormValues>) => (gyldigTom?: string) => {
+    const gyldigFom = getValues('gyldigFom');
+    return gyldigFom && gyldigTom ? dateAfterOrEqual(gyldigFom)(gyldigTom) : null;
+  };

--- a/packages/fakta/verge/src/components/RegistrereVergeInfoPanel.tsx
+++ b/packages/fakta/verge/src/components/RegistrereVergeInfoPanel.tsx
@@ -60,7 +60,7 @@ export const RegistrereVergeInfoPanel = ({ verge, alleKodeverk }: Props) => {
   const valgtVergeType = useWatch({ control: formMethods.control, name: 'vergeType' });
   const begrunnelse = useWatch({ control: formMethods.control, name: 'begrunnelse' });
 
-  const vergetyper = alleKodeverk['VergeType'].sort((k1, k2) => k1.navn.localeCompare(k2.navn));
+  const vergetyper = [...alleKodeverk['VergeType']].sort((k1, k2) => k1.navn.localeCompare(k2.navn));
 
   return (
     <VStack gap="space-20">

--- a/packages/fakta/ytelser/src/YtelserFaktaIndex.spec.tsx
+++ b/packages/fakta/ytelser/src/YtelserFaktaIndex.spec.tsx
@@ -54,4 +54,14 @@ describe('YtelserFaktaIndex', () => {
     expect(screen.getByText('Svangerskapspenger')).toBeInTheDocument();
     expect(screen.getByText('Ingen')).toBeInTheDocument();
   });
+
+  it('skal sette sikker rel-attributt på lenker som åpnes i ny fane', async () => {
+    render(<YtelserForHovedsøker />);
+
+    const lenke = await screen.findByRole('link', { name: '12' });
+
+    expect(lenke).toHaveAttribute('target', '_blank');
+    expect(lenke.getAttribute('rel')).toContain('noopener');
+    expect(lenke.getAttribute('rel')).toContain('noreferrer');
+  });
 });

--- a/packages/fakta/ytelser/src/components/PersonYtelserTable.tsx
+++ b/packages/fakta/ytelser/src/components/PersonYtelserTable.tsx
@@ -83,7 +83,7 @@ export const PersonYtelserTable = ({ ytelser }: Props) => {
             <Table.DataCell>
               {ytelse.saksnummer && ytelse.skalViseLenke && (
                 <BodyShort size="small">
-                  <Link href={`/fagsak/${ytelse.saksnummer}`} target="_blank">
+                  <Link href={`/fagsak/${ytelse.saksnummer}`} target="_blank" rel="noopener noreferrer">
                     {ytelse.saksnummer}
                   </Link>
                 </BodyShort>

--- a/packages/prosess/vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.spec.tsx
+++ b/packages/prosess/vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.spec.tsx
@@ -2,10 +2,16 @@ import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { AksjonspunktKode } from '@navikt/fp-kodeverk';
+
 import * as stories from './VilkarresultatMedOverstyringProsessIndex.stories';
 
-const { OverstyringspanelForFødsel, OverstyringspanelForMedlemskap, OverstyrtAksjonspunktSomErBekreftet } =
-  composeStories(stories);
+const {
+  OverstyringspanelForFødsel,
+  OverstyringspanelForMedlemskap,
+  OverstyringForForutgåendeMedlemskap,
+  OverstyrtAksjonspunktSomErBekreftet,
+} = composeStories(stories);
 
 describe('VilkarresultatMedOverstyringProsessIndex', () => {
   it('skal overstyre og fylle ut fødselsvilkåret ikke er oppfylt og så lagre', async () => {
@@ -106,5 +112,47 @@ describe('VilkarresultatMedOverstyringProsessIndex', () => {
     expect(screen.getByText('Manuell overstyring av automatisk vurdering')).toBeInTheDocument();
     expect(screen.getByText('Søker er medmor')).toBeInTheDocument();
     expect(screen.getByText('Dette er en begrunnelse')).toBeInTheDocument();
+  });
+
+  it('skal sende innflyttingsdato som medlemFom for forutgående medlemskap', async () => {
+    const lagre = vi.fn();
+
+    render(<OverstyringForForutgåendeMedlemskap submitCallback={lagre} />);
+
+    expect(await screen.findByText('Medlemskap')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('Manuell overstyring av automatisk vurdering')).toBeInTheDocument();
+    expect(screen.getByText('Har bruker vært medlem i 12 måneder før termin/omsorgsovertakelse?')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Ikke oppfylt'));
+
+    expect(await screen.findByText('Avslagsårsak')).toBeInTheDocument();
+    expect(screen.queryByText('Innflyttingsdato')).not.toBeInTheDocument();
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('Avslagsårsak'),
+      'Innflyttet mindre enn 12 måneder før termin/omsorgsovertakelse',
+    );
+
+    expect(await screen.findByText('Innflyttingsdato')).toBeInTheDocument();
+
+    const innflyttingsdatoInput = screen.getByLabelText('Innflyttingsdato');
+    await userEvent.type(innflyttingsdatoInput, '20.12.2021');
+    fireEvent.blur(innflyttingsdatoInput);
+
+    const vurderingInput = screen.getByLabelText('Begrunnelse');
+    await userEvent.type(vurderingInput, 'Dette er en begrunnelse');
+
+    await userEvent.click(screen.getByText('Bekreft overstyring'));
+
+    await waitFor(() => expect(lagre).toHaveBeenCalledTimes(1));
+    expect(lagre).toHaveBeenNthCalledWith(1, {
+      medlemFom: '2021-12-20',
+      avslagskode: '1052',
+      begrunnelse: 'Dette er en begrunnelse',
+      kode: AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR,
+    });
   });
 });

--- a/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
+++ b/packages/prosess/vilkar-overstyring/src/components/VilkarresultatMedOverstyringForm.tsx
@@ -230,7 +230,10 @@ const transformValues = (values: FormValues, overstyringApKode: VilkårOverstyri
     case AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR:
       return {
         ...felles,
-        ...MedlemskapVurderinger.transformValues(values),
+        ...MedlemskapVurderinger.transformValues(
+          values,
+          overstyringApKode === AksjonspunktKode.OVERSTYRING_AV_FORUTGÅENDE_MEDLEMSKAPSVILKÅR,
+        ),
       };
     default:
       return {


### PR DESCRIPTION
Mange endringar i ein branch, men alle er utført på panelnivå og går ikkje i kvarandre. Så trur det er like greit å ta CR på alt i ein kontra mange forskjellige branchar. Greit å ha oppe lista under som referanse når ein går gjennom.

Retta reelle logikk-/databugs identifisert i ein gjennomgang av alle `fakta/*`-pakkene. Reine forbetringsforslag (a11y, manglande testar, typing, arkitektur med usikker risiko) er bevisst ikkje rørt.

## arbeid-og-inntekt
- **ManglendeArbeidsforholdForm/ManglendeInntektsmeldingForm:** `reset()` av skjemaet skjedde òg ved feila lagring, slik at brukaren mista feil-/dirty-indikasjon og trudde lagringa hadde lukkast. `reset()` køyrer no berre ved vellykka lagring.
- **ManglendeArbeidsforholdForm:** lokal tabelloppdatering matcha berre på `arbeidsgiverIdent`. Rader for "inntektsmelding manglar arbeidsforhold" blir bygde med éi rad per inntektsmelding, så same arbeidsgjevar kan ha fleire rader, og alle vart oppdaterte i staden for berre den redigerte. Matchar no på same identitet som backend lagrar vurderinga på, `(arbeidsgiverIdent, internArbeidsforholdId)`. I tillegg vart matchande rader overskrivne med den redigerte rada sine felt (`{...radData}`), noko som klobba søskenrader; brukar no `{...data}`.
- **arbeidOgInntektTabellUtils:** fjerna non-null assertion utan fallback ved oppslag i arbeidsgjevaropplysningar (kunne krasje panelet).
- **ArbeidOgInntektFaktaPanel:** unik React-key per rad, unngår key-kollisjon når fleire inntektsmeldingar finst for same arbeidsgjevar.

## arbeidsforhold
- **PersonArbeidsforholdTable:** viste bokstaveleg `undefined %` i UI når `stillingsprosent` mangla; no vist med fallback. Rad-key gjort unik.

## besteberegning
- **BesteberegningPanel:** guard mot tomt `beregningsgrunnlagPeriode`-array som elles kunne krasje panelet.
- **KontrollerBesteberegningPanel:** knappestatus vart halden i separat lokal state i staden for å utleiast frå checkbox-verdien i skjemaet, som gjorde at knappen kunne bli ståande feil disabled etter gjenoppretta/mellomlagra skjema.

## felles
- **FaktaFraFReg:** unik key per barnerad, unngår kollisjon ved tvillingar/søsken med same fødsels-/dødsdato.

## fodsel
- **BarnFieldArray:** terminavvik vart validert berre mot tidlegaste fødselsdato for alle barn; validerast no per barn, i tråd med `fødselOgTerminValidator`.

## inntektsmelding
- **InntektsmeldingFaktaIndex:** `sorterStreng` returnerte `-1` når begge verdiar var `undefined`, som braut kontrakten for ein sorteringsfunksjon og gav ustabil sortering.
- **BortfalteNaturalYtelser:** "ingen bortfalte naturalytelser"-meldinga vart styrt av rå lengd på aktive naturalytelser i staden for faktisk avleia bortfallsperiodar.

## medlemskap
- **MedlemskapVurderinger:** `medlemFom` vart sendt i payload basert berre på avslagskode, sjølv om valgt vurdering ikkje lenger kravde feltet. Feltet sendast no berre når det faktisk er relevant, i tråd med skiljet mellom ordinært og forutgåande medlemskap i DTO-ane.
- **situasjonUtils:** regionar/personstatusar vart sorterte in-place, som muterte delte arrays frå props/kontekst. Sorterer no kopiar.

## omsorg-og-rett
- **AleneomsorgForm/HarAnnenForelderRettForm:** skjulte felt vart ikkje unregistrerte (`shouldUnregister`), slik at gamle verdiar kunne bli liggande i skjematilstanden og sendast inn sjølv etter at hovudsvaret var endra.
- **OpplysningerFraSoknad:** ukjend `annenpartBostedsland` gav tomt svar i staden for å falle tilbake til den rå landkoden.
- **OmsorgOgRettInfoPanel:** begge skjema fekk `aksjonspunkter[0]`, som antok at berre eitt aksjonspunkt kunne vere aktivt om gongen. Koblar no riktig aksjonspunkttype til riktig skjema.

## omsorgsovertakelse
- **FaktaSammenligning:** raden "er det ektefelles barn" vart skjult når verdien berre fanst i gjeldande og ikkje i søknad.
- **VurderOmsorgsovertakelseVilkåretForm:** barnelista til vurdering vart bygd berre frå `søknad.barn`, slik at born som berre fanst i gjeldande ikkje kunne vurderast/sendast inn. Byggjer no union av born frå søknad og gjeldande. `gjeldende` er ikkje eit duplikat av `søknad` - `kildeGjeldende: 'SAKSBEHANDLER' | 'SØKNAD' | 'FOLKEREGISTER'` viser at `gjeldende` kan vere henta frå folkeregisteret eller korrigert av ein saksbehandlar i ei tidlegare behandling, og kan dermed reelt innehalde born som ikkje var med i den opphavelege søknaden. Utan fiksen kunne eit slikt barn aldri visast i sjølve vurderingsskjemaet, og dermed aldri vurderast eller sendast inn som del av aksjonspunktet - ein reell avgrensing av saksbehandlar sitt handlingsrom, ikkje eit designval.

## opptjening
- **OpptjeningFaktaPanel:** `findSkjaringstidspunkt` vart kalla med ein dato som kunne vere `undefined`. `isSubmitting` vart berre nullstilt ved vellykka submit, ikkje ved feil, slik at knappen kunne bli ståande i loading-tilstand.

## permisjon
- **PermisjonFaktaPanel:** non-null assertion utan fallback ved oppslag i arbeidsgjevaropplysningar under sortering, som kunne krasje panelet ved manglande oppslag.

## tilrettelegging
- **TilretteleggingForm:** truthy-sjekk av `overstyrtUtbetalingsgrad` gjorde at ein eksplisitt sett verdi på `0` vart ignorert/rekalkulert i staden for å respekterast.
- **OppholdForm:** overlappskontroll mot eksisterande opphald vart ikkje køyrt for eittdagsopphald (`fom === tom`).
- **TilretteleggingFormFeil:** 100 %-blokkering for gyldig velferdspermisjon vart vurdert mot alle permisjonar i staden for berre dei relevante/filtrerte periodane.

## uttak
- **UttakFaktaDetailForm:** `arbeidstidsprosent`/`samtidigUttaksprosent` vart sende vidare i payload som streng i staden for tal.
- **GraderingOgSamtidigUttakPanel:** `<option key={guid()}>` genererte ein ny tilfeldig key ved kvar render, som gav ustabile keys og risiko for tap av fokus/valgt verdi.

## uttak-eøs
- **UttakEøsFaktaTable:** oppdatering/sletting av periode filtrerte på `fom !== ... && tom !== ...`, som trefte/sletta alle periodar som delte same `fom` **eller** `tom` som den valgte rada — ein reell datakorrupsjonsrisiko. Matchar no presist på rad-indeks.
- **UttakEøsFaktaForm:** sorterte `annenForelderUttakEøs` in-place og muterte dermed arrayet frå props. Sorterer no ein kopi.

## uttaksdokumentasjon
- **UttakDokumentasjonFaktaForm:** `erBekreftKnappTrykket` vart aldri nullstilt ved feila submit, slik at bekreft-knappen vart ståande permanent låst utan moglegheit til å prøve på nytt.

## verge
- **RegistrereVergeForm:** mangla validering av at `gyldigTom` ikkje er før `gyldigFom`, slik at ein ugyldig periode kunne sendast inn.
- **RegistrereVergeInfoPanel:** sorterte det delte `VergeType`-kodeverket in-place. Sorterer no ein kopi.

## ytelser
- **PersonYtelserTable:** lenke med `target="_blank"` mangla `rel="noopener noreferrer"` (reverse tabnabbing).

## Verifisering

`yarn install`/`tsc`/`test` kunne ikkje køyrast lokalt (sandbox-restriksjon på `~/.yarnrc.yml`), så endringane er verifiserte ved lesing mot typar, DTO-ar og kallstader, samt syntaks-sjekk. CI er fasit — lint-feil som dukka opp undervegs er retta i eigne commits, og to av dei opphavlege rettingane (sjå arbeidsforhold og opptjening/tilrettelegging over) er korrigerte etter at ein etterfølgjande gjennomgang avdekte at dei introduserte regresjonar.



