### PR TITLE
TFP-6594: valider at tilretteleggingsperiode ikke starter etter neste…

### DIFF
--- a/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
+++ b/packages/papirsoknad-ui-komponenter/i18n/nb_NO.json
@@ -147,6 +147,7 @@
   "BehovForTilrettteleggingFieldArray.LeggTilTilretteleggingsbehov": "Legg til tilretteleggingsbehov",
   "BehovForTilrettteleggingFieldArray.BehovForTilrettelegging": "Behov for tilrettelegging",
   "BehovForTilrettteleggingFieldArray.FraDato": "Fra dato",
+  "BehovForTilrettteleggingFieldArray.FraDatoMaaVaereFoerNeste": "Fra dato må være før neste tilretteleggingsperiode",
   "BehovForTilrettteleggingFieldArray.Stillingsprosent": "Stillingsprosent",
   "BehovForTilrettteleggingFieldArray.KanGjennomfores": "a) kan gjennomføres slik at arbeidstakeren kan fortsette med samme stilling fra og med",
   "BehovForTilrettteleggingFieldArray.RedusertArbeid": "b) kan gjennomføres slik at arbeidstakeren kan fortsette med redusert arbeidstid fra og med",

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.spec.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/BehovForTilretteleggingPanel.spec.tsx
@@ -159,6 +159,40 @@ describe('BehovForTilretteleggingPanel', () => {
     });
   });
 
+  it('skal ikke tillate fra dato etter til og med dato i neste tilretteleggingsperiode', async () => {
+    const lagre = vi.fn();
+
+    await Default.run({
+      parameters: {
+        submitCallback: lagre,
+      },
+    });
+
+    await userEvent.click(screen.getAllByText('Ja')[2]!);
+
+    const arbeidstaker = within(
+      screen.getByText('Søkes det om svangerskapspenger som arbeidstaker?').closest('fieldset') as HTMLElement,
+    );
+
+    await userEvent.type(arbeidstaker.getByLabelText('Arbeidsgivers orgnr/fnr'), '000000000');
+    await userEvent.type(
+      arbeidstaker.getByLabelText('Jordmor/lege oppgir at tilrettelegging er nødvendig fra og med'),
+      '01.01.2024',
+    );
+    await userEvent.selectOptions(arbeidstaker.getByLabelText('Behov for tilrettelegging'), 'HEL_TILRETTELEGGING');
+    await userEvent.type(arbeidstaker.getByLabelText('Fra dato'), '10.01.2024');
+    await userEvent.type(arbeidstaker.getByLabelText('Stillingsprosent'), '100');
+    await userEvent.click(screen.getByText('Legg til tilretteleggingsbehov'));
+    await userEvent.selectOptions(arbeidstaker.getAllByLabelText('Behov for tilrettelegging')[1]!, 'DELVIS_TILRETTELEGGING');
+    await userEvent.type(arbeidstaker.getAllByLabelText('Fra dato')[1]!, '05.01.2024');
+    await userEvent.type(arbeidstaker.getAllByLabelText('Stillingsprosent')[1]!, '100');
+
+    await userEvent.click(screen.getByText('Lagreknapp (Kun for test)'));
+
+    expect(await screen.findByText('Fra dato må være før neste tilretteleggingsperiode')).toBeInTheDocument();
+    expect(lagre).not.toHaveBeenCalled();
+  });
+
   it(
     'skal slette alle arbeidsgivere og gi beskje om at den trenger minst et element i arbeidsgiiverlisten',
     { timeout: 30000 },

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
-import { useIntl } from 'react-intl';
+import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook-form';
+import { type IntlShape, useIntl } from 'react-intl';
 
 import { Box } from '@navikt/ds-react';
 import { RhfDatepicker, RhfFieldArray, RhfSelect, RhfTextField } from '@navikt/ft-form-hooks';
@@ -22,12 +22,37 @@ const defaultTilrettelegging: Tilrettelegging = {
   stillingsprosent: undefined,
 };
 
+type TilretteleggingerFieldName =
+  | 'tilretteleggingArbeidsforhold.tilretteleggingFrilans.tilrettelegginger'
+  | 'tilretteleggingArbeidsforhold.tilretteleggingSelvstendigNaringsdrivende.tilrettelegginger'
+  | `tilretteleggingArbeidsforhold.tilretteleggingForArbeidsgiver.${number}.tilrettelegginger`;
+
+// Perioden mangler eit eige til og med-felt, så til og med-dato for ein periode er alltid
+// neste periodes fra dato minus éin dag. Denne validerer at fra dato ikkje er etter den avleia til og med-datoen.
+// Datoane vert henta lazy via getValues ved kvar validering, sidan komponenten ikkje nødvendigvis
+// vert re-rendra når naboraden si fra dato vert endra.
+const validerFraDatoErFørNestePeriode =
+  (intl: IntlShape, getValues: UseFormGetValues<FormValues>, name: TilretteleggingerFieldName, index: number) =>
+  (): string | null => {
+    const dato = getValues(`${name}.${index}.dato`);
+    const nesteDato = getValues(`${name}.${index + 1}.dato`);
+
+    if (!dato || !nesteDato) {
+      return null;
+    }
+
+    const erEtterNestePeriode = dateBeforeOrEqual(dayjs(nesteDato).subtract(1, 'day').format(ISO_DATE_FORMAT))(
+      dato,
+    );
+
+    return erEtterNestePeriode
+      ? intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDatoMaaVaereFoerNeste' })
+      : null;
+  };
+
 interface Props {
   readOnly: boolean;
-  name:
-    | 'tilretteleggingArbeidsforhold.tilretteleggingFrilans.tilrettelegginger'
-    | 'tilretteleggingArbeidsforhold.tilretteleggingSelvstendigNaringsdrivende.tilrettelegginger'
-    | `tilretteleggingArbeidsforhold.tilretteleggingForArbeidsgiver.${number}.tilrettelegginger`;
+  name: TilretteleggingerFieldName;
 }
 
 export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => {
@@ -92,25 +117,7 @@ export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => 
               control={control}
               readOnly={readOnly}
               label={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDato' })}
-              validate={[
-                required,
-                () => {
-                  const dato = getValues(`${name}.${index}.dato`);
-                  const nesteDato = getValues(`${name}.${index + 1}.dato`);
-
-                  if (!dato || !nesteDato) {
-                    return null;
-                  }
-
-                  const datoEtterNeste = dateBeforeOrEqual(
-                    dayjs(nesteDato).subtract(1, 'day').format(ISO_DATE_FORMAT),
-                  )(dato);
-
-                  return datoEtterNeste
-                    ? intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDatoMaaVaereFoerNeste' })
-                    : null;
-                },
-              ]}
+              validate={[required, validerFraDatoErFørNestePeriode(intl, getValues, name, index)]}
               onChange={() => (isSubmitted ? trigger() : undefined)}
             />
 

--- a/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/tilretteleggingSvp/components/BehovForTilretteleggingFieldArray.tsx
@@ -4,8 +4,9 @@ import { useIntl } from 'react-intl';
 
 import { Box } from '@navikt/ds-react';
 import { RhfDatepicker, RhfFieldArray, RhfSelect, RhfTextField } from '@navikt/ft-form-hooks';
-import { hasValidDecimal, maxValue, minValue, required } from '@navikt/ft-form-validators';
-import { removeSpacesFromNumber } from '@navikt/ft-utils';
+import { dateBeforeOrEqual, hasValidDecimal, maxValue, minValue, required } from '@navikt/ft-form-validators';
+import { ISO_DATE_FORMAT, removeSpacesFromNumber } from '@navikt/ft-utils';
+import dayjs from 'dayjs';
 
 import type { SvpTilretteleggingType } from '@navikt/fp-types';
 
@@ -32,7 +33,12 @@ interface Props {
 export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => {
   const intl = useIntl();
 
-  const { control } = useFormContext<FormValues>();
+  const {
+    control,
+    getValues,
+    trigger,
+    formState: { isSubmitted },
+  } = useFormContext<FormValues>();
 
   const { fields, remove, append } = useFieldArray({
     control,
@@ -86,7 +92,26 @@ export const BehovForTilretteleggingFieldArray = ({ readOnly, name }: Props) => 
               control={control}
               readOnly={readOnly}
               label={intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDato' })}
-              validate={[required]}
+              validate={[
+                required,
+                () => {
+                  const dato = getValues(`${name}.${index}.dato`);
+                  const nesteDato = getValues(`${name}.${index + 1}.dato`);
+
+                  if (!dato || !nesteDato) {
+                    return null;
+                  }
+
+                  const datoEtterNeste = dateBeforeOrEqual(
+                    dayjs(nesteDato).subtract(1, 'day').format(ISO_DATE_FORMAT),
+                  )(dato);
+
+                  return datoEtterNeste
+                    ? intl.formatMessage({ id: 'BehovForTilrettteleggingFieldArray.FraDatoMaaVaereFoerNeste' })
+                    : null;
+                },
+              ]}
+              onChange={() => (isSubmitted ? trigger() : undefined)}
             />
 
             <RhfTextField


### PR DESCRIPTION
… periode

Det var mulig å legge inn en tilretteleggingsperiode med fra dato etter til og med dato (implisitt neste periodes fra dato minus én dag) i papirsøknad for svangerskapspenger. Legger til validering i BehovForTilretteleggingFieldArray som sammenligner fra dato mot neste rads fra dato for alle grupper (selvstendig næringsdrivende, frilans og arbeidsgiver).

https://jira.adeo.no/browse/TFP-6594