### PR TITLE
TFP-6388: valider mot startdato istedenfor første uttaksdato i fakta …

### DIFF
--- a/packages/fakta/uttak/i18n/nb_NO.json
+++ b/packages/fakta/uttak/i18n/nb_NO.json
@@ -35,7 +35,7 @@
   "UttakFaktaDetailForm.SamtidigUttaksprosent": "Samtidig uttaksprosent",
   "UttakFaktaDetailForm.Arbeidsgiver": "Arbeidsgiver",
   "UttakFaktaDetailForm.Opphold": "Opphold",
-  "UttakFaktaDetailForm.ErIkkeLikForsteUttaksdato": "En av periodene må ha dato lik første uttaksdato ({dato})",
+  "UttakFaktaDetailForm.ErIkkeLikForsteUttaksdato": "En av periodene må ha dato lik startdato ({dato})",
   "UttakFaktaDetailForm.ErFørFørsteUttaktsdato": "En periode kan ikke starte før første uttaksdato ({dato})",
   "UttakFaktaDetailForm.ErFørFødselsdato": "En periode kan ikke starte før fødselsdato ({dato})",
   "UttakFaktaDetailForm.TomForFom": "Dato kan ikke være før fra",

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -2,6 +2,7 @@ import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { harPeriodeMedStartdato } from './components/UttakFaktaForm';
 import type { KontrollerFaktaPeriodeMedApMarkering } from './typer/kontrollerFaktaPeriodeMedApMarkering';
 import * as stories from './UttakFaktaIndex.stories';
 
@@ -16,6 +17,16 @@ const {
 } = composeStories(stories);
 
 describe('UttakFaktaIndex', () => {
+  it('skal validere mot startdato og ikke automatisk generert periode for tapte dager', () => {
+    const perioder = [
+      { fom: '2024-10-28', tom: '2024-12-31' },
+      { fom: '2025-01-01', tom: '2025-01-31' },
+    ] as KontrollerFaktaPeriodeMedApMarkering[];
+
+    expect(harPeriodeMedStartdato(perioder, '2025-01-01')).toBe(true);
+    expect(harPeriodeMedStartdato(perioder, '2025-02-01')).toBe(false);
+  });
+
   it('skal vise tabellrader som ikke kan ekspanderes når det ikke er aksjonspunkt', async () => {
     render(<VisUttaksperiodeUtenAksjonspunkt />);
 

--- a/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
+++ b/packages/fakta/uttak/src/components/UttakFaktaForm.tsx
@@ -78,6 +78,11 @@ const leggTilAksjonspunktMarkering = (
 const periodeSkalVurderesIftFørsteDato = (periode: FaktaUttakPeriode): boolean =>
   !(periode.utsettelseÅrsak ?? periode.oppholdÅrsak);
 
+export const harPeriodeMedStartdato = (
+  uttakPerioder: KontrollerFaktaPeriodeMedApMarkering[],
+  startdato: string,
+): boolean => uttakPerioder.some(periode => dayjs(periode.fom).isSame(startdato));
+
 const valider = (
   uttakPerioder: KontrollerFaktaPeriodeMedApMarkering[],
   erMor: boolean,
@@ -107,6 +112,7 @@ const validerPerioder = (
   erMor: boolean,
   aksjonspunkter: Aksjonspunkt[],
   førsteUttaksdato: string,
+  startDatoForPermisjon: string,
   intl: IntlShape,
 ): string | null => {
   const periodeMap = uttakPerioder.map(({ fom, tom }) => [fom, tom]);
@@ -119,13 +125,14 @@ const validerPerioder = (
     fagsak.familiehendelse?.hendelseType === 'FODSL' ? fagsak.familiehendelse.hendelseDato : undefined;
   const brukFødselsdato = erMor && !!fødselsdato && dayjs(fødselsdato).isBefore(førsteUttaksdato);
   const tidligsteDato = brukFødselsdato ? fødselsdato : førsteUttaksdato;
+  const startdatoForValidering = startDatoForPermisjon || førsteUttaksdato;
 
-  if (uttakPerioder.every(up => !dayjs(up.fom).isSame(førsteUttaksdato))) {
+  if (!harPeriodeMedStartdato(uttakPerioder, startdatoForValidering)) {
     return intl.formatMessage(
       {
         id: 'UttakFaktaDetailForm.ErIkkeLikForsteUttaksdato',
       },
-      { dato: dateFormat(førsteUttaksdato) },
+      { dato: dateFormat(startdatoForValidering) },
     );
   }
 
@@ -216,6 +223,7 @@ export const UttakFaktaForm = ({
       erMor,
       aksjonspunkterForPanel,
       ytelsefordeling.førsteUttaksdato,
+      ytelsefordeling.startDatoForPermisjon,
       intl,
     );
   }


### PR DESCRIPTION
…om uttak

Valideringen "En av periodene må ha dato lik startdato" sjekket tidligere mot ytelsefordeling.førsteUttaksdato, som kan være en systemgenerert periode for å telle tapte dager (f.eks. 28.10.24 ved STP i januar). Dette ga en feilaktig valideringsfeil når saksbehandler rettet perioder i fakta om uttak.

Validerer nå mot startDatoForPermisjon, med fallback til førsteUttaksdato dersom startdato mangler.

https://jira.adeo.no/browse/TFP-6388