### PR TITLE
TFP-5653: vis feilmelding når tilkjent ytelse har periode med 0 i dag…

### DIFF
--- a/packages/prosess/tilkjent-ytelse/i18n/nb_NO.json
+++ b/packages/prosess/tilkjent-ytelse/i18n/nb_NO.json
@@ -1,5 +1,6 @@
 {
   "TilkjentYtelse.Title": "Tilkjent ytelse",
+  "TilkjentYtelse.NullIDagsats": "Tilkjent ytelse inneholder en eller flere perioder med 0 kroner i dagsats. Dette kan føre til feil ved brevutsending. Kontroller beregningen før du fortsetter.",
   "TilkjentYtelse.VurderTilbaketrekk.Beskrivelse": "Saksbehandler har vurdert om ytelsen skal endres fra direkte utbetaling til refusjon til arbeidsgiver, og tilbakekreves fra bruker, eller om det er en sak mellom arbeidstaker og arbeidsgiver.",
   "TilkjentYtelse.Stonadinfo.Stonadsdager": "Stønadsdager",
   "TilkjentYtelse.PeriodeData.Detaljer": "Detaljer for valgt periode",

--- a/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.spec.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import * as stories from './TilkjentYtelseProsessIndex.stories';
 
-const { UtenAksjonspunkt, UtførtAksjonspunkt } = composeStories(stories);
+const { UtenAksjonspunkt, UtførtAksjonspunkt, MedPeriodeUtenDagsats } = composeStories(stories);
 
 describe('TilkjentYtelseProsessIndex', () => {
   it('skal se på tilkjent ytelse uten aksjonspunkt', async () => {
@@ -33,5 +33,17 @@ describe('TilkjentYtelseProsessIndex', () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText('Dette er en begrunnelse saksbehandler tidligere har gjort.')).toBeInTheDocument();
+  });
+
+  it('skal vise feilmelding når en periode har 0 i dagsats', async () => {
+    render(<MedPeriodeUtenDagsats />);
+
+    expect(await screen.findByText('Tilkjent ytelse')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Tilkjent ytelse inneholder en eller flere perioder med 0 kroner i dagsats. ' +
+          'Dette kan føre til feil ved brevutsending. Kontroller beregningen før du fortsetter.',
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.stories.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.stories.tsx
@@ -150,3 +150,35 @@ export const MedBarnFodtLengeForForstePeriode: Story = {
     } satisfies FamilieHendelse,
   },
 };
+
+export const MedPeriodeUtenDagsats: Story = {
+  args: {
+    aksjonspunkterForPanel: [],
+    beregningresultat: {
+      perioder: [
+        ...beregningresultat.perioder!,
+        {
+          andeler: [
+            {
+              uttak: {
+                stonadskontoType: 'FORELDREPENGER' satisfies StønadskontoType,
+                gradering: false,
+              },
+              aktivitetStatus: 'AT',
+              arbeidsforholdType: 'ARBEID',
+              arbeidsgiverReferanse: '',
+              refusjon: 0,
+              tilSøker: 0,
+              utbetalingsgrad: 0,
+              sisteUtbetalingsdato: '',
+              eksternArbeidsforholdId: '',
+            },
+          ],
+          fom: '2019-06-11',
+          tom: '2019-07-01',
+          dagsats: 0,
+        },
+      ],
+    } satisfies BeregningsresultatDagytelse,
+  },
+};

--- a/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.stories.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.stories.tsx
@@ -156,7 +156,7 @@ export const MedPeriodeUtenDagsats: Story = {
     aksjonspunkterForPanel: [],
     beregningresultat: {
       perioder: [
-        ...beregningresultat.perioder!,
+        ...(beregningresultat.perioder ?? []),
         {
           andeler: [
             {

--- a/packages/prosess/tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { BodyShort, Heading, HStack, Label, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading, HStack, Label, VStack } from '@navikt/ds-react';
 import { EditedIcon } from '@navikt/ft-ui-komponenter';
 
 import { AksjonspunktKode } from '@navikt/fp-kodeverk';
@@ -42,11 +42,18 @@ export const TilkjentYtelsePanel = ({
 
   const søknadMottattDato = søknad.søknadsfrist.gjeldendeMottattDato ?? søknad.mottattDato;
 
+  const harPeriodeMedNullIDagsats = finnHarPeriodeMedNullIDagsats(beregningresultat.perioder);
+
   return (
     <VStack gap="space-16">
       <Heading size="small" level="2">
         <FormattedMessage id="TilkjentYtelse.Title" />
       </Heading>
+      {harPeriodeMedNullIDagsats && (
+        <Alert size="small" variant="error">
+          <FormattedMessage id="TilkjentYtelse.NullIDagsats" />
+        </Alert>
+      )}
       <TilkjentYtelse
         beregningsresultatPeriode={beregningresultat.perioder}
         søknadsdato={søknadMottattDato}
@@ -80,3 +87,6 @@ export const TilkjentYtelsePanel = ({
 
 const finnTilbaketrekkAksjonspunktBegrunnelse = (alleAksjonspunkter: Aksjonspunkt[]): string | undefined =>
   alleAksjonspunkter.find(ap => ap.definisjon === AksjonspunktKode.UTGÅTT_5090)?.begrunnelse ?? undefined;
+
+const finnHarPeriodeMedNullIDagsats = (perioder: BeregningsresultatDagytelse['perioder']): boolean =>
+  (perioder ?? []).some(periode => periode.dagsats === 0);


### PR DESCRIPTION
…sats

Perioder med 0 i dagsats ble tidligere filtrert bort i tidslinjen uten at saksbehandler fikk noen indikasjon på at noe var galt. Dette kan føre til at brevet feiler ved vedtak. Legger til et synlig varsel i tilkjent ytelse-panelet når dette forekommer, slik at saksbehandler kan kontrollere beregningen før behandlingen går videre.

https://jira.adeo.no/browse/TFP-5653