### PR TITLE
TFP-5836: gi respons når bruker ikke har saker i Infotrygd

### DIFF
--- a/packages/utbetalingsdata-is15/i18n/nb_NO.json
+++ b/packages/utbetalingsdata-is15/i18n/nb_NO.json
@@ -3,7 +3,7 @@
   "UtbetalingsdataPanel.Sok": "Fødselsnummer",
   "UtbetalingsdataPanel.UgyldigFnr": "Oppgitt fødselsnummer er ikke gyldig",
   "UtbetalingsdataPanel.Resultat": "Søkeresultat:",
-  "UtbetalingsdataPanel.IngenSakerFunnet": "Søkeresultat: Ingen saker funnet",
+  "UtbetalingsdataPanel.IngenSakerFunnet": "Bruker har ingen saker som gjelder foreldrepenger, svangerskapspenger eller engangsstønad i Infotrygd",
   "UtbetalingsdataPanel.Saker": "Saker",
   "UtbetalingsdataPanel.Utbetalinger": "Utbetalinger",
 

--- a/packages/utbetalingsdata-is15/src/UtbetalingsdataIs15Index.spec.tsx
+++ b/packages/utbetalingsdata-is15/src/UtbetalingsdataIs15Index.spec.tsx
@@ -56,6 +56,10 @@ describe('UtbetalingsdataIs15Index', () => {
 
     await userEvent.click(screen.getAllByRole('button')[1]!);
 
-    expect(await screen.findByText('Søkeresultat: Ingen saker funnet')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Bruker har ingen saker som gjelder foreldrepenger, svangerskapspenger eller engangsstønad i Infotrygd',
+      ),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Søket mot Infotrygd ga ingen respons hvis bruker ikke hadde saker i Infotrygd. Endrer meldingen som vises ved tomt søkeresultat til å tydelig informere om at bruker ikke har saker som gjelder foreldrepenger, svangerskapspenger eller engangsstønad i Infotrygd.

https://jira.adeo.no/browse/TFP-5836