### PR TITLE
refactor: fjern fire ts-expect-error med reelle typefikser

### DIFF
--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -143,7 +143,7 @@ const PAPIRSØKNAD_AP_KODER = [
 type PapirsøknadApKode = (typeof PAPIRSØKNAD_AP_KODER)[number];
 
 const erPapirsøknadApKode = (kode: Aksjonspunkt['definisjon']): kode is PapirsøknadApKode =>
-  PAPIRSØKNAD_AP_KODER.some(papirsøknadKode => papirsøknadKode === kode);
+  (PAPIRSØKNAD_AP_KODER as readonly Aksjonspunkt['definisjon'][]).includes(kode);
 
 const getAktivPapirsøknadApKode = (aksjonspunkter: Aksjonspunkt[]): PapirsøknadApKode => {
   const ap = aksjonspunkter.map(a => a.definisjon).find(erPapirsøknadApKode);

--- a/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
+++ b/apps/fp-frontend/src/behandling/papirsoknad/BehandlingPapirsoknadIndex.tsx
@@ -133,26 +133,23 @@ const useLagrePapirsøknad = (
   return { lagrePapirsøknad, lagreUfullstendigPapirsøknad };
 };
 
-const getAktivPapirsøknadApKode = (
-  aksjonspunkter: Aksjonspunkt[],
-):
-  | AksjonspunktKode.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD
-  | AksjonspunktKode.REGISTRER_PAPIRSØKNAD_FORELDREPENGER
-  | AksjonspunktKode.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER
-  | AksjonspunktKode.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER => {
-  const ap = aksjonspunkter
-    .map(a => a.definisjon)
-    .find(
-      kode =>
-        kode === AksjonspunktKode.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD ||
-        kode === AksjonspunktKode.REGISTRER_PAPIRSØKNAD_FORELDREPENGER ||
-        kode === AksjonspunktKode.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER ||
-        kode === AksjonspunktKode.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER,
-    );
+const PAPIRSØKNAD_AP_KODER = [
+  AksjonspunktKode.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD,
+  AksjonspunktKode.REGISTRER_PAPIRSØKNAD_FORELDREPENGER,
+  AksjonspunktKode.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER,
+  AksjonspunktKode.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER,
+] as const;
+
+type PapirsøknadApKode = (typeof PAPIRSØKNAD_AP_KODER)[number];
+
+const erPapirsøknadApKode = (kode: Aksjonspunkt['definisjon']): kode is PapirsøknadApKode =>
+  PAPIRSØKNAD_AP_KODER.some(papirsøknadKode => papirsøknadKode === kode);
+
+const getAktivPapirsøknadApKode = (aksjonspunkter: Aksjonspunkt[]): PapirsøknadApKode => {
+  const ap = aksjonspunkter.map(a => a.definisjon).find(erPapirsøknadApKode);
 
   if (!ap) {
     throw new Error('Fant ikke aktivt aksjonspunkt for papirsøknad');
   }
-  // @ts-expect-error Blir fiksa når AksjonspunktKode reflekterar backend-typar
   return ap;
 };

--- a/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
+++ b/packages/fakta/uttak/src/UttakFaktaIndex.spec.tsx
@@ -15,6 +15,12 @@ const {
   VisPanelDerAksjonspunktErLøstOgBehandlingAvsluttet,
 } = composeStories(stories);
 
+// RhfNumericField gir prosentverdiar som tekst på runtime, medan DTO-typen seier number.
+// Testen dokumenterer den faktiske runtime-forma til lagra data.
+type PeriodeMedProsentSomTekst = Omit<KontrollerFaktaPeriodeMedApMarkering, 'samtidigUttaksprosent'> & {
+  samtidigUttaksprosent?: string;
+};
+
 describe('UttakFaktaIndex', () => {
   it('skal vise tabellrader som ikke kan ekspanderes når det ikke er aksjonspunkt', async () => {
     render(<VisUttaksperiodeUtenAksjonspunkt />);
@@ -68,7 +74,6 @@ describe('UttakFaktaIndex', () => {
             tom: '2022-12-01',
             originalFom: '2022-11-12',
             periodeKilde: 'SAKSBEHANDLER',
-            // @ts-expect-error -- typene i formet er inkonsekvente
             samtidigUttaksprosent: '10',
             uttakPeriodeType: 'MØDREKVOTE',
             aksjonspunktType: undefined,
@@ -76,7 +81,7 @@ describe('UttakFaktaIndex', () => {
             arbeidstidsprosent: undefined,
             flerbarnsdager: false,
           },
-        ] satisfies KontrollerFaktaPeriodeMedApMarkering[],
+        ] satisfies PeriodeMedProsentSomTekst[],
       },
     ]);
   });

--- a/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/fulltUttak/RenderPermisjonPeriodeFieldArray.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/permisjonFp/components/fulltUttak/RenderPermisjonPeriodeFieldArray.tsx
@@ -8,7 +8,7 @@ import { hasValidDate, hasValidDecimal, maxValue, minValue, required } from '@na
 import { ISO_DATE_FORMAT, removeSpacesFromNumber } from '@navikt/ft-utils';
 import dayjs from 'dayjs';
 
-import type { AlleKodeverk, UttakPeriodeType } from '@navikt/fp-types';
+import type { AlleKodeverk, PermisjonPeriodeDto, UttakPeriodeType } from '@navikt/fp-types';
 
 import { FieldArrayRow } from '../../../felles/FieldArrayRow';
 import { PERMISJON_PERIODE_FIELD_ARRAY_NAME, TIDSROM_PERMISJON_FORM_NAME_PREFIX } from '../../constants';
@@ -21,6 +21,12 @@ const getPrefix = (index: number) => `${FA_PREFIX}.${index}` as const;
 
 const minValue0 = minValue(0);
 const maxValue100 = maxValue(100);
+
+const TOM_PERMISJONSPERIODE = {
+  periodeType: '' as unknown as UttakPeriodeType,
+  periodeFom: '',
+  periodeTom: '',
+} satisfies PermisjonPeriodeDto;
 
 interface Props {
   readOnly: boolean;
@@ -54,8 +60,7 @@ export const RenderPermisjonPeriodeFieldArray = ({ søkerErMor, readOnly, alleKo
 
   useEffect(() => {
     if (fields.length === 0) {
-      // @ts-expect-error Fiks
-      append({});
+      append(TOM_PERMISJONSPERIODE);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- legg berre til ein tom rad ved montering; fields.length skal ikkje trigge effekten på nytt
   }, []);
@@ -65,11 +70,7 @@ export const RenderPermisjonPeriodeFieldArray = ({ søkerErMor, readOnly, alleKo
       readOnly={readOnly}
       fields={fields}
       addButtonText={intl.formatMessage({ id: 'Registrering.Permisjon.nyPeriode' })}
-      emptyTemplate={{
-        periodeType: '' as unknown as UttakPeriodeType,
-        periodeFom: '',
-        periodeTom: '',
-      }}
+      emptyTemplate={TOM_PERMISJONSPERIODE}
       append={append}
       remove={remove}
     >

--- a/packages/sak/dekorator/src/components/FeilmeldingsdetaljerModal.tsx
+++ b/packages/sak/dekorator/src/components/FeilmeldingsdetaljerModal.tsx
@@ -6,6 +6,19 @@ import { capitalizeFirstLetter } from '@navikt/ft-utils';
 
 import type { Feilmelding } from '../typer/feilmeldingTsType';
 
+type Detalj = NonNullable<Feilmelding['tilleggsInfo']>[string];
+
+// Detaljane kan vera nøsta objekt eller lister. Desse blir serialisert i staden for å renderast rekursivt.
+const formaterDetalj = (detalj: Detalj | undefined): string => {
+  if (detalj === undefined) {
+    return '';
+  }
+  if (typeof detalj === 'object') {
+    return JSON.stringify(detalj);
+  }
+  return String(detalj);
+};
+
 interface Props {
   skalViseModal: boolean;
   lukkModal: () => void;
@@ -40,8 +53,7 @@ export const FeilmeldingsdetaljerModal = ({ skalViseModal, lukkModal, feilmeldin
                   <div key={edKey}>
                     <Detail>{`${capitalizeFirstLetter(edKey)}:`}</Detail>
                     <div>
-                      {/* @ts-expect-error Fiks. Dette vil kreve at vi lager en rekursiv rendering av objectet */}
-                      <BodyShort size="small">{feilmeldingsdetaljer[edKey]}</BodyShort>
+                      <BodyShort size="small">{formaterDetalj(feilmeldingsdetaljer[edKey])}</BodyShort>
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
- BehandlingPapirsoknadIndex: erstatt undertrykking med type-predicate som snevrer backend-unionen Aksjonspunkt['definisjon'] til papirsøknad-kodene
- FeilmeldingsdetaljerModal: håndter at JSONValue kan vera objekt/array ved å serialisera nøsta verdiar i staden for å senda dei til BodyShort
- RenderPermisjonPeriodeFieldArray: del TOM_PERMISJONSPERIODE mellom append og emptyTemplate slik at påkravde felt er med
- UttakFaktaIndex.spec: type forventninga eksplisitt der RhfNumericField gir samtidigUttaksprosent som tekst medan DTO-typen seier number