### PR TITLE
TFP-7024, Markere arbeidsforhold som inaktive i frontend.

### DIFF
--- a/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.stories.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/ArbeidOgInntektFaktaIndex.stories.tsx
@@ -1077,3 +1077,49 @@ export const SkalViseFødselsnummerForPrivatperson: Story = {
     },
   },
 };
+
+export const InaktivtArbeidsforholdIkkebestiltInntektsmelding: Story = {
+  args: {
+    arbeidOgInntekt: {
+      arbeidsforhold: [
+        {
+          ...defaultArbeidsforhold,
+          arbeidsgiverIdent: '910909090',
+          eksternArbeidsforholdId: 'ARB001-001',
+          fom: '2019-01-01',
+          internArbeidsforholdId: 'a1b2c3d4-0000-0000-0000-000000000001',
+          stillingsprosent: 100,
+          tom: '9999-12-31',
+          inaktivÅrsak: 'INAKTIVT_ARBEIDSFORHOLD',
+          permisjoner: [],
+        },
+      ],
+      inntektsmeldinger: [],
+      inntekter: [],
+      skjæringstidspunkt: '2021-11-10',
+    },
+  },
+};
+
+export const PermisjonArbeidsforholdIkkebestiltInntektsmelding: Story = {
+  args: {
+    arbeidOgInntekt: {
+      arbeidsforhold: [
+        {
+          ...defaultArbeidsforhold,
+          arbeidsgiverIdent: '910909090',
+          eksternArbeidsforholdId: 'ARB001-001',
+          fom: '2019-01-01',
+          internArbeidsforholdId: 'a1b2c3d4-0000-0000-0000-000000000001',
+          stillingsprosent: 100,
+          tom: '9999-12-31',
+          inaktivÅrsak: 'PERMISJON',
+          permisjoner: [],
+        },
+      ],
+      inntektsmeldinger: [],
+      inntekter: [],
+      skjæringstidspunkt: '2021-11-10',
+    },
+  },
+};

--- a/packages/fakta/arbeid-og-inntekt/src/components/ArbeidsforholdRad.tsx
+++ b/packages/fakta/arbeid-og-inntekt/src/components/ArbeidsforholdRad.tsx
@@ -56,16 +56,21 @@ export const ArbeidsforholdRad = ({
 }: Props) => {
   const intl = useIntl();
 
-  const { inntektsmeldingerForRad, arbeidsforholdForRad, arbeidsgiverNavn, avklaring, årsak } = radData;
+  const { inntektsmeldingerForRad, arbeidsforholdForRad, arbeidsgiverNavn, avklaring, årsak, inaktivÅrsak } = radData;
 
   const erManueltOpprettet = avklaring?.saksbehandlersVurdering === 'MANUELT_OPPRETTET_AV_SAKSBEHANDLER';
+  const erInaktivtEllerPermisjonsArbeidsforhold = inaktivÅrsak !== undefined;
   const harArbeidsforholdOgInntektsmelding =
     arbeidsforholdForRad.length > 0 && inntektsmeldingerForRad.length > 0 && !årsak;
   const manglerInntektsmelding = årsak === 'MANGLENDE_INNTEKTSMELDING';
   const manglerArbeidsforhold = årsak === 'INNTEKTSMELDING_UTEN_ARBEIDSFORHOLD';
   const harÅpentAksjonspunkt = !!årsak && !avklaring?.saksbehandlersVurdering;
   const harArbeidsforholdUtenInntektsmeldingMenIngenÅrsak =
-    arbeidsforholdForRad.length > 0 && inntektsmeldingerForRad.length === 0 && !årsak && !erManueltOpprettet;
+    arbeidsforholdForRad.length > 0 &&
+    inntektsmeldingerForRad.length === 0 &&
+    !årsak &&
+    !erManueltOpprettet &&
+    !erInaktivtEllerPermisjonsArbeidsforhold;
   const harKunInntektsmeldingOgIkkeÅrsak =
     arbeidsforholdForRad.length === 0 && inntektsmeldingerForRad.length > 0 && !årsak;
 

--- a/packages/fakta/arbeid-og-inntekt/src/types/arbeidsforholdOgInntekt.ts
+++ b/packages/fakta/arbeid-og-inntekt/src/types/arbeidsforholdOgInntekt.ts
@@ -1,6 +1,7 @@
 import type {
   Arbeidsforhold,
   ArbeidsforholdKomplettVurderingType,
+  InaktivArbeidsforholdÅrsak,
   Inntektsmelding,
   Inntektspost,
 } from '@navikt/fp-types';
@@ -32,6 +33,6 @@ export type ArbeidsforholdOgInntektRadData = {
   arbeidsforholdForRad: Arbeidsforhold[];
   inntektsposter: Inntektspost[];
   årsak?: string;
-  inaktivÅrsak?: 'INAKTIVT_ARBEIDSFORHOLD' | 'PERMISJON';
+  inaktivÅrsak?: InaktivArbeidsforholdÅrsak;
   avklaring?: Avklaring;
 } & AGOpplysninger;

--- a/packages/fakta/arbeid-og-inntekt/src/types/arbeidsforholdOgInntekt.ts
+++ b/packages/fakta/arbeid-og-inntekt/src/types/arbeidsforholdOgInntekt.ts
@@ -32,5 +32,6 @@ export type ArbeidsforholdOgInntektRadData = {
   arbeidsforholdForRad: Arbeidsforhold[];
   inntektsposter: Inntektspost[];
   årsak?: string;
+  inaktivÅrsak?: 'INAKTIVT_ARBEIDSFORHOLD' | 'PERMISJON';
   avklaring?: Avklaring;
 } & AGOpplysninger;

--- a/packages/fakta/arbeid-og-inntekt/src/utils/arbeidOgInntektTabellUtils.ts
+++ b/packages/fakta/arbeid-og-inntekt/src/utils/arbeidOgInntektTabellUtils.ts
@@ -42,6 +42,7 @@ export const byggTabellStruktur = (
       const ne: ArbeidsforholdOgInntektRadData = {
         ...arbeidsgiverOpplysninger,
         årsak: af.årsak ?? inntektsmeldingerForRad[0]?.årsak ?? undefined,
+        inaktivÅrsak: arbeidsforholdForRad.find(a => a.inaktivÅrsak)?.inaktivÅrsak,
         avklaring: lagAvklaringFraArbeidsforhold(af, arbeidsgiverOpplysninger.arbeidsgiverNavn),
         arbeidsforholdForRad,
         inntektsmeldingerForRad,

--- a/packages/types/src/fpsak.gen.ts
+++ b/packages/types/src/fpsak.gen.ts
@@ -2519,6 +2519,8 @@ export type foreldrepenger_domene_arbeidsforhold_impl_AksjonspunktÅrsak =
   | 'ENDRING_I_ARBEIDSFORHOLDS_ID'
   | 'PERMISJON_UTEN_SLUTTDATO';
 
+export type foreldrepenger_domene_arbeidsforhold_impl_InaktivArbeidsforholdÅrsak = 'INAKTIVT_ARBEIDSFORHOLD' | 'PERMISJON';
+
 export type foreldrepenger_domene_iay_modell_kodeverk_InntektsmeldingInnsendingsårsak = 'NY' | 'ENDRING';
 
 export type foreldrepenger_domene_iay_modell_kodeverk_NaturalYtelseType =
@@ -2554,6 +2556,7 @@ export type foreldrepenger_domene_arbeidInntektsmelding_dto_ArbeidsforholdDto = 
   begrunnelse?: string;
   eksternArbeidsforholdId?: string;
   fom: string;
+  inaktivÅrsak?: foreldrepenger_domene_arbeidsforhold_impl_InaktivArbeidsforholdÅrsak;
   internArbeidsforholdId?: string;
   permisjonOgMangel?: foreldrepenger_domene_arbeidInntektsmelding_dto_PermisjonOgMangelDto;
   permisjoner: Array<foreldrepenger_domene_arbeidInntektsmelding_dto_PermisjonDto>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,6 +19,7 @@ export type {
   foreldrepenger_domene_arbeidInntektsmelding_dto_ArbeidOgInntektsmeldingDto as ArbeidOgInntektsmelding,
   foreldrepenger_behandlingslager_virksomhet_ArbeidType as ArbeidType,
   foreldrepenger_domene_arbeidInntektsmelding_dto_ArbeidsforholdDto as Arbeidsforhold,
+  foreldrepenger_domene_arbeidsforhold_impl_InaktivArbeidsforholdÅrsak as InaktivArbeidsforholdÅrsak,
   tjenester_behandling_svp_SvpArbeidsforholdDto as SvpArbeidsforholdDto,
   tjenester_behandling_svp_BekreftTilrettelegging as BekreftTilrettelegging,
   tjenester_behandling_svp_SvpTilretteleggingDatoDto as SvpTilretteleggingDatoDto,


### PR DESCRIPTION
- under panelet (arbeid og inntekt) skal vi vise i hvorfor en inntektsmelding ikke har blitt bestilt