### PR TITLE
TFP-5653: filtrer avslåtte periodar frå dagsats-sjekk, endre varsel t…

### DIFF
--- a/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.spec.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.spec.tsx
@@ -4,7 +4,8 @@ import userEvent from '@testing-library/user-event';
 
 import * as stories from './TilkjentYtelseProsessIndex.stories';
 
-const { UtenAksjonspunkt, UtførtAksjonspunkt, MedPeriodeUtenDagsats } = composeStories(stories);
+const { UtenAksjonspunkt, UtførtAksjonspunkt, MedPeriodeUtenDagsats, MedAvslåttPeriodeUtenDagsats } =
+  composeStories(stories);
 
 describe('TilkjentYtelseProsessIndex', () => {
   it('skal se på tilkjent ytelse uten aksjonspunkt', async () => {
@@ -35,7 +36,7 @@ describe('TilkjentYtelseProsessIndex', () => {
     expect(screen.getByText('Dette er en begrunnelse saksbehandler tidligere har gjort.')).toBeInTheDocument();
   });
 
-  it('skal vise feilmelding når en periode har 0 i dagsats', async () => {
+  it('skal vise advarsel når en innvilget periode har 0 i dagsats', async () => {
     render(<MedPeriodeUtenDagsats />);
 
     expect(await screen.findByText('Tilkjent ytelse')).toBeInTheDocument();
@@ -45,5 +46,17 @@ describe('TilkjentYtelseProsessIndex', () => {
           'Dette kan føre til feil ved brevutsending. Kontroller beregningen før du fortsetter.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('skal ikke vise advarsel når periode med 0 i dagsats har alle andeler avslått', async () => {
+    render(<MedAvslåttPeriodeUtenDagsats />);
+
+    expect(await screen.findByText('Tilkjent ytelse')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Tilkjent ytelse inneholder en eller flere perioder med 0 kroner i dagsats. ' +
+          'Dette kan føre til feil ved brevutsending. Kontroller beregningen før du fortsetter.',
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.stories.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/TilkjentYtelseProsessIndex.stories.tsx
@@ -163,6 +163,40 @@ export const MedPeriodeUtenDagsats: Story = {
               uttak: {
                 stonadskontoType: 'FORELDREPENGER' satisfies StønadskontoType,
                 gradering: false,
+                periodeResultatType: 'INNVILGET',
+              },
+              aktivitetStatus: 'AT',
+              arbeidsforholdType: 'ARBEID',
+              arbeidsgiverReferanse: '',
+              refusjon: 0,
+              tilSøker: 0,
+              utbetalingsgrad: 0,
+              sisteUtbetalingsdato: '',
+              eksternArbeidsforholdId: '',
+            },
+          ],
+          fom: '2019-06-11',
+          tom: '2019-07-01',
+          dagsats: 0,
+        },
+      ],
+    } satisfies BeregningsresultatDagytelse,
+  },
+};
+
+export const MedAvslåttPeriodeUtenDagsats: Story = {
+  args: {
+    aksjonspunkterForPanel: [],
+    beregningresultat: {
+      perioder: [
+        ...(beregningresultat.perioder ?? []),
+        {
+          andeler: [
+            {
+              uttak: {
+                stonadskontoType: 'FORELDREPENGER' satisfies StønadskontoType,
+                gradering: false,
+                periodeResultatType: 'AVSLÅTT',
               },
               aktivitetStatus: 'AT',
               arbeidsforholdType: 'ARBEID',

--- a/packages/prosess/tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
@@ -8,6 +8,7 @@ import type {
   Aksjonspunkt,
   ArbeidsgiverOpplysningerPerId,
   BeregningsresultatDagytelse,
+  BeregningsresultatPeriode,
   FamilieHendelse,
   Feriepengegrunnlag,
   Personoversikt,
@@ -88,7 +89,7 @@ export const TilkjentYtelsePanel = ({
 const finnTilbaketrekkAksjonspunktBegrunnelse = (alleAksjonspunkter: Aksjonspunkt[]): string | undefined =>
   alleAksjonspunkter.find(ap => ap.definisjon === AksjonspunktKode.UTGÅTT_5090)?.begrunnelse ?? undefined;
 
-const erAlleAndelerAvslått = (periode: BeregningsresultatDagytelse['perioder'][0]): boolean =>
+const erAlleAndelerAvslått = (periode: BeregningsresultatPeriode): boolean =>
   (periode.andeler ?? []).length > 0 &&
   (periode.andeler ?? []).every(andel => andel.uttak.periodeResultatType === 'AVSLÅTT');
 

--- a/packages/prosess/tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
+++ b/packages/prosess/tilkjent-ytelse/src/components/TilkjentYtelsePanel.tsx
@@ -50,7 +50,7 @@ export const TilkjentYtelsePanel = ({
         <FormattedMessage id="TilkjentYtelse.Title" />
       </Heading>
       {harPeriodeMedNullIDagsats && (
-        <Alert size="small" variant="error">
+        <Alert size="small" variant="warning">
           <FormattedMessage id="TilkjentYtelse.NullIDagsats" />
         </Alert>
       )}
@@ -88,5 +88,9 @@ export const TilkjentYtelsePanel = ({
 const finnTilbaketrekkAksjonspunktBegrunnelse = (alleAksjonspunkter: Aksjonspunkt[]): string | undefined =>
   alleAksjonspunkter.find(ap => ap.definisjon === AksjonspunktKode.UTGÅTT_5090)?.begrunnelse ?? undefined;
 
+const erAlleAndelerAvslått = (periode: BeregningsresultatDagytelse['perioder'][0]): boolean =>
+  (periode.andeler ?? []).length > 0 &&
+  (periode.andeler ?? []).every(andel => andel.uttak.periodeResultatType === 'AVSLÅTT');
+
 const finnHarPeriodeMedNullIDagsats = (perioder: BeregningsresultatDagytelse['perioder']): boolean =>
-  (perioder ?? []).some(periode => periode.dagsats === 0);
+  (perioder ?? []).filter(periode => !erAlleAndelerAvslått(periode)).some(periode => periode.dagsats === 0);


### PR DESCRIPTION
…il advarsel

Periodar der alle andeler har periodeResultatType='AVSLÅTT' skal ikkje utløyse åtvaringsmeldinga om 0 i dagsats. Desse periodane er med vilje avslåtte og brevet vil ikkje feile på grunn av dei.

I tillegg er Alert-varianten endra frå 'error' (raud) til 'warning' (gul), sidan dette er ein åtvarsel til saksbehandlar og ikkje ein blokkerende feil.

https://jira.adeo.no/browse/TFP-5653