### PR TITLE
fix: forenkle utledNøkkel til arbeidsgiverIdent + internArbeidsforholdId

### DIFF
--- a/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
+++ b/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
@@ -45,13 +45,13 @@ export const PersonArbeidsforholdTable = ({
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {alleArbeidsforhold.map((arbeidsforhold, index) => {
+        {alleArbeidsforhold.map(arbeidsforhold => {
           const stillingsprosent =
             arbeidsforhold.stillingsprosent !== undefined ? `${arbeidsforhold.stillingsprosent.toFixed(2)} %` : '-';
           const mottattDato = inntektsmeldinger.find(im => erMatch(arbeidsforhold, im))?.mottattDato;
           return (
             <Table.ExpandableRow
-              key={utledNøkkel(arbeidsforhold, index)}
+              key={utledNøkkel(arbeidsforhold)}
               content={
                 arbeidsforhold.saksbehandlersVurdering ? (
                   <ArbeidsforholdDetail valgtArbeidsforhold={arbeidsforhold} />
@@ -128,12 +128,5 @@ const utledNavn = (
   return formaterArbeidsgiver(arbeidsgiverOpplysninger, eksternId ?? undefined);
 };
 
-const utledNøkkel = (arbeidsforhold: Arbeidsforhold, index: number): string =>
-  [
-    arbeidsforhold.arbeidsgiverIdent,
-    arbeidsforhold.internArbeidsforholdId ?? '',
-    arbeidsforhold.eksternArbeidsforholdId ?? '',
-    arbeidsforhold.fom,
-    arbeidsforhold.tom,
-    `${index}`,
-  ].join('-');
+const utledNøkkel = (arbeidsforhold: Arbeidsforhold): string =>
+  `${arbeidsforhold.arbeidsgiverIdent}-${arbeidsforhold.internArbeidsforholdId}`;

--- a/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
+++ b/packages/fakta/arbeidsforhold/src/components/PersonArbeidsforholdTable.tsx
@@ -51,7 +51,7 @@ export const PersonArbeidsforholdTable = ({
           const mottattDato = inntektsmeldinger.find(im => erMatch(arbeidsforhold, im))?.mottattDato;
           return (
             <Table.ExpandableRow
-              key={utledNøkkel(arbeidsforhold)}
+              key={`${arbeidsforhold.arbeidsgiverIdent}-${arbeidsforhold.internArbeidsforholdId}`}
               content={
                 arbeidsforhold.saksbehandlersVurdering ? (
                   <ArbeidsforholdDetail valgtArbeidsforhold={arbeidsforhold} />
@@ -127,6 +127,3 @@ const utledNavn = (
 
   return formaterArbeidsgiver(arbeidsgiverOpplysninger, eksternId ?? undefined);
 };
-
-const utledNøkkel = (arbeidsforhold: Arbeidsforhold): string =>
-  `${arbeidsforhold.arbeidsgiverIdent}-${arbeidsforhold.internArbeidsforholdId}`;


### PR DESCRIPTION
internArbeidsforholdId er ein uuid vi set når arbeidsforholdet finst i aareg (eksternArbeidsforholdId), som gjeld 99,99 % av arbeidsforhold. Kombinasjonen arbeidsgiverIdent + internArbeidsforholdId er difor unik nok som React-key, utan behov for eksternArbeidsforholdId, fom, tom eller array-index som tiebreaker.