### PR TITLE
TFP-6363: test setup-yarnrc med GITHUB_TOKEN

### DIFF
--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -5,12 +5,13 @@ jobs:
     name: Valider pull request
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 
-      - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
-        with:
-          npmAuthToken: ${{ secrets.READER_TOKEN }}
+      - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@sirimykland/setup-yarnrc-github-token
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 26
-          cache: 'yarn'
+          # cache bevisst deaktivert i denne test-branchen: enableGlobalCache=false gjør at
+          # GHA restaurerer .yarn/cache (keyet på uendret yarn.lock), så pakkene aldri hentes
+          # autentisert. Vi vil teste at GITHUB_TOKEN faktisk kan laste ned pakkene (inkl. @nais/apm).
 
       - name: Use turbo cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache@v6.1.0


### PR DESCRIPTION
**Test-PR** for å verifisere endringen i navikt/fp-gha-workflows-branchen `sirimykland/setup-yarnrc-github-token`.

## Hva testes
`setup-yarnrc`-actionen defaulter nå `npmAuthToken` til `GITHUB_TOKEN`. Denne PR-en:
- Peker `valider-pull-request.yml` til test-branchen av actionen
- Dropper `npmAuthToken: ${{ secrets.READER_TOKEN }}` helt
- Legger til `permissions: { packages: read }` på jobben

## Formål
Verifisere om kortlevd `GITHUB_TOKEN` (med `packages: read`) kan hente `@navikt/*`- og `@nais/*`-pakker fra GitHub Package Registry, slik at vi kan skrive oss bort fra PAT/READER_TOKEN.

⚠️ Ikke ment å merges som den er – `uses:` peker på en feature-branch. `build.yml` bruker fortsatt READER_TOKEN og trigges ikke av denne PR-en.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>