### PR TITLE
TFP-6363: bruk GITHUB_TOKEN i stedet for READER_TOKEN

### DIFF
--- a/.github/workflows/build-deploy-branch.yml
+++ b/.github/workflows/build-deploy-branch.yml
@@ -32,7 +32,6 @@ jobs:
       # Alle apper bakar CDN-URL inn i assets (jf. build-<app>.yml).
       vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/${{ inputs.app }}/'
     secrets:
-      READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
 
   upload-to-CDN:

--- a/.github/workflows/build-fp-avdelingsleder.yml
+++ b/.github/workflows/build-fp-avdelingsleder.yml
@@ -32,7 +32,6 @@ jobs:
       # Må matche upload-to-CDN destination (teamforeldrepenger + /fp-avdelingsleder).
       vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/fp-avdelingsleder/'
     secrets:
-      READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
 
   upload-to-CDN:

--- a/.github/workflows/build-fp-frontend.yml
+++ b/.github/workflows/build-fp-frontend.yml
@@ -32,7 +32,6 @@ jobs:
       # Må matche upload-to-CDN destination (teamforeldrepenger + /fp-frontend).
       vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/fp-frontend/'
     secrets:
-      READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
 
   upload-to-CDN:

--- a/.github/workflows/build-fp-journalforing.yml
+++ b/.github/workflows/build-fp-journalforing.yml
@@ -32,7 +32,6 @@ jobs:
       # Må matche upload-to-CDN destination (teamforeldrepenger + /fp-journalforing).
       vite-cdn-url: 'https://cdn.nav.no/teamforeldrepenger/fp-journalforing/'
     secrets:
-      READER_TOKEN: ${{ secrets.READER_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN  }}
 
   upload-to-CDN:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,6 @@ jobs:
           ref: ${{ (inputs.branch != '' && inputs.branch) || '' }}
 
       - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
-        with:
-          npmAuthToken: ${{ secrets.READER_TOKEN }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build app
 on:
   workflow_call:
     secrets:
-      READER_TOKEN:
-        description: 'A token passed from the caller workflow'
-        required: true
       SENTRY_AUTH_TOKEN:
         description: 'A token passed from the caller workflow'
         required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
   build-and-test:
     name: Build and test
     permissions:
-      packages: write
+      packages: read
       id-token: write
     runs-on: ${{ (github.event.pull_request.user.login == 'dependabot[bot]' && 'ubuntu-latest') || inputs.runs-on }}
     env:

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -54,6 +54,5 @@ jobs:
       - name: Run knip
         uses: navikt/fp-gha-workflows/.github/actions/knip-it@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           package-manager: 'yarn'
           node-version: 26

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -48,12 +48,12 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      packages: read
       pull-requests: write
     steps:
       - name: Run knip
         uses: navikt/fp-gha-workflows/.github/actions/knip-it@main
         with:
-          npm-auth-token: ${{ secrets.READER_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           package-manager: 'yarn'
           node-version: 26

--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -5,12 +5,13 @@ jobs:
     name: Valider pull request
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 
       - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
-        with:
-          npmAuthToken: ${{ secrets.READER_TOKEN }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:


### PR DESCRIPTION
## Hva
Fjerner PAT/`READER_TOKEN` fra alle `setup-yarnrc`- og `knip-it`-kall i repoet og bruker kortlevd `GITHUB_TOKEN`.

### Endringer
- **build.yml**: dropp `npmAuthToken` (default `GITHUB_TOKEN`); stram `packages: write` → `packages: read`; fjern ubrukt `READER_TOKEN` fra `workflow_call.secrets`.
- **build-fp-frontend / build-fp-avdelingsleder / build-fp-journalforing / build-deploy-branch.yml**: slutt å sende `READER_TOKEN` inn til build.yml.
- **valider-pull-request.yml**:
  - `setup-yarnrc` uten token; `permissions: { contents: read, packages: read }` på valider-jobben.
  - `knip-it` uten `npm-auth-token`; `packages: read` lagt til på knip-jobben.

## Avhengigheter
- `setup-yarnrc`-default: navikt/fp-gha-workflows#476 (**merget**).
- `knip-it`-default: **navikt/fp-gha-workflows#477** – må merges før knip-steget virker uten token.

## Hvorfor packages: read holder i build.yml
Docker-imaget pushes til NAIS Google Artifact Registry via OIDC (`nais/login` → `id-token: write`), ikke GHCR, og ingen steg publiserer npm-pakker.

## Testet ✅
Verifisert i egen test-PR (nå lukket) med **yarn-cache deaktivert**: `GITHUB_TOKEN` med `packages: read` hentet både `@navikt/*` og cross-org `@nais/apm`. Ingen 401/403.

> `deploy-storybook.yml` sender fortsatt READER_TOKEN videre til en reusable workflow – egen migrering senere.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>