### PR TITLE
TFP-6363: gi packages:read i deploy-storybook-jobben

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -11,6 +11,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
+      packages: read
     uses: navikt/fp-gha-workflows/.github/workflows/deploy-storybook.yml@main
     with:
       package-manager: yarn


### PR DESCRIPTION
## Hva
Legger til `packages: read` i deploy-storybook-jobbens permissions.

## Hvorfor
Forbereder at den gjenbrukbare `deploy-storybook.yml` skal kunne bruke `GITHUB_TOKEN` (navikt/fp-gha-workflows#479). En gjenbrukbar workflow kan ikke få mer enn kalleren gir, så kalleren må gi `packages: read` for at `GITHUB_TOKEN`-fallbacken skal kunne hente `@navikt`/`@nais`-pakker.

`READER_TOKEN` sendes fortsatt inn, så atferden er uendret. **Denne må merges før fp-gha-workflows#479.**