### PR TITLE
TFP-6363: dropp READER_TOKEN i deploy-storybook

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -17,5 +17,3 @@ jobs:
       package-manager: yarn
       cache: turbo
       node-version: 26
-    secrets:
-      READER_TOKEN: ${{ secrets.READER_TOKEN }}


### PR DESCRIPTION
Fjerner `READER_TOKEN`-videreformidlingen til den gjenbrukbare `deploy-storybook.yml`.

Trygt nå: navikt/fp-gha-workflows#479 gjør at workflowen faller tilbake på `GITHUB_TOKEN` (`secrets.READER_TOKEN || github.token`), og jobben har allerede `packages: read` (fra #7528). Dermed henter `GITHUB_TOKEN` `@navikt`/`@nais`-pakker uten PAT.