### PR TITLE
TFP-7117: valider ikkje tomt felt for Antall barn i Omsorg-panel

### DIFF
--- a/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
@@ -21,6 +21,10 @@ import { notEmpty } from '@navikt/fp-utils';
 const OMSORG_NAME_PREFIX = 'omsorg';
 const MAX_ANTALL_BARN = 10;
 
+// minValue/maxValue validerer sjølv tomme verdiar (tolkar '' som 0), så dei må vernast bak ei sjekk på om feltet har verdi
+const validateMinAntallBarn = (value?: number) => (value ? minValue(1)(value) : undefined);
+const validateMaxAntallBarn = (value?: number) => (value ? maxValue(10)(value) : undefined);
+
 type OmsorgOgAdopsjonFormValues = {
   [OMSORG_NAME_PREFIX]: {
     erEktefellesBarn?: boolean;
@@ -120,7 +124,7 @@ export const OmsorgOgAdopsjonPanel = ({
           readOnly={readOnly}
           htmlSize={8}
           parse={value => removeSpacesFromNumber(value)}
-          validate={[...(erAdopsjon ? [required] : []), hasValidInteger, minValue(1), maxValue(10)]}
+          validate={[...(erAdopsjon ? [required] : []), hasValidInteger, validateMinAntallBarn, validateMaxAntallBarn]}
           onChange={oppdaterAntallBarn}
         />
 

--- a/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
+++ b/packages/papirsoknad-ui-komponenter/src/omsorgOgAdopsjonPanel/components/OmsorgOgAdopsjonPanel.tsx
@@ -21,9 +21,12 @@ import { notEmpty } from '@navikt/fp-utils';
 const OMSORG_NAME_PREFIX = 'omsorg';
 const MAX_ANTALL_BARN = 10;
 
-// minValue/maxValue validerer sjølv tomme verdiar (tolkar '' som 0), så dei må vernast bak ei sjekk på om feltet har verdi
-const validateMinAntallBarn = (value?: number) => (value ? minValue(1)(value) : undefined);
-const validateMaxAntallBarn = (value?: number) => (value ? maxValue(10)(value) : undefined);
+// minValue/maxValue validerer sjølv tomme verdiar (tolkar '' som 0), så dei må vernast bak ei eksplisitt tomheit-sjekk.
+// NB: sjekken må ikkje bruke ein enkel truthy-test (`value ? ... : undefined`), då 0 er ein falsy, men gyldig utfylt verdi
+const erTom = (value?: number | string) => value === undefined || value === '';
+const validateMinAntallBarn = (value?: number | string) => (erTom(value) ? undefined : minValue(1)(value));
+const validateMaxAntallBarn = (value?: number | string) =>
+  erTom(value) ? undefined : maxValue(MAX_ANTALL_BARN)(value);
 
 type OmsorgOgAdopsjonFormValues = {
   [OMSORG_NAME_PREFIX]: {


### PR DESCRIPTION
minValue/maxValue frå @navikt/ft-form-validators hoppar ikkje over tomme verdiar (tolkar '' som 0), i motsetnad til hasValidInteger/required som bruker isEmpty. Guard-funksjonane som beskytta mot dette vart fjerna i konsolideringa av papirsøknad-typar (#7423), slik at feilmeldinga «Feltet må være større eller lik 1» vart vist sjølv når feltet var tomt.

Reinnfører guard-funksjonar som berre validerer min/maks når feltet faktisk har ein verdi.

https://jira.adeo.no/browse/TFP-7117